### PR TITLE
Add Picked status and AWB button

### DIFF
--- a/api/picking/confirm_pick.php
+++ b/api/picking/confirm_pick.php
@@ -169,7 +169,7 @@ try {
     if ($isOrderComplete) {
         $updateOrderQuery = "
             UPDATE orders 
-            SET status = 'Completed',
+            SET status = 'Picked',
                 updated_at = NOW()
             WHERE id = :order_id
         ";

--- a/api/warehouse/update_order_status.php
+++ b/api/warehouse/update_order_status.php
@@ -67,6 +67,9 @@ try {
         case 'processing':
             $dbStatus = 'Processing';
             break;
+        case 'picked':
+            $dbStatus = 'Picked';
+            break;
         case 'completed':
             $dbStatus = 'Completed';
             break;

--- a/database/migrations/2025_07_04_100000_add_picked_status_to_orders.php
+++ b/database/migrations/2025_07_04_100000_add_picked_status_to_orders.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Migration: add_picked_status_to_orders
+ * Created: 2025-07-04 10:00:00
+ * Purpose: Allow new 'Picked' status in orders table ENUM
+ */
+
+class AddPickedStatusToOrdersMigration {
+    public function up(PDO $pdo) {
+        $pdo->exec("ALTER TABLE orders MODIFY status ENUM('pending','processing','picked','completed','cancelled','shipped') DEFAULT 'pending'");
+    }
+
+    public function down(PDO $pdo) {
+        $pdo->exec("ALTER TABLE orders MODIFY status ENUM('pending','processing','completed','cancelled','shipped') DEFAULT 'pending'");
+    }
+}
+
+return new AddPickedStatusToOrdersMigration();

--- a/models/Order.php
+++ b/models/Order.php
@@ -113,11 +113,11 @@ class Order {
             $result = $stmt->fetchAll(PDO::FETCH_COLUMN);
             
             // Add common statuses if not present
-            $commonStatuses = ['Pending', 'Processing', 'Shipped', 'Delivered', 'Cancelled'];
+            $commonStatuses = ['Pending', 'Processing', 'Picked', 'Shipped', 'Delivered', 'Cancelled'];
             return array_unique(array_merge($result, $commonStatuses));
         } catch (PDOException $e) {
             error_log("Error getting statuses: " . $e->getMessage());
-            return ['Pending', 'Processing', 'Shipped', 'Delivered', 'Cancelled'];
+            return ['Pending', 'Processing', 'Picked', 'Shipped', 'Delivered', 'Cancelled'];
         }
     }
     

--- a/orders.php
+++ b/orders.php
@@ -285,17 +285,27 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                                                 </td>
                                                 <td>
                                                     <div class="btn-group">
-                                                        <button class="btn btn-sm btn-outline-primary" 
+                                                        <button class="btn btn-sm btn-outline-primary"
                                                                 onclick="viewOrderDetails(<?= $order['id'] ?>)"
                                                                 title="Vezi detalii">
                                                             <span class="material-symbols-outlined">visibility</span>
                                                         </button>
-                                                        <button class="btn btn-sm btn-outline-secondary" 
+                                                        <button class="btn btn-sm btn-outline-secondary"
                                                                 onclick="openStatusModal(<?= $order['id'] ?>, '<?= htmlspecialchars($order['status']) ?>')"
                                                                 title="Schimbă status">
                                                             <span class="material-symbols-outlined">edit</span>
                                                         </button>
-                                                        <button class="btn btn-sm btn-outline-danger" 
+                                                        <?php $awbDisabled = strtolower($order['status']) !== 'picked'; ?>
+                                                        <?php if (!empty($order['awb_barcode'])): ?>
+                                                            <button class="btn btn-sm btn-outline-success" onclick="printAWB('<?= htmlspecialchars($order['awb_barcode']) ?>')" title="Printează AWB">
+                                                                <span class="material-symbols-outlined">local_shipping</span>
+                                                            </button>
+                                                        <?php else: ?>
+                                                            <button class="btn btn-sm btn-outline-warning" onclick="generateAWB(<?= $order['id'] ?>)" title="Generează AWB" <?= $awbDisabled ? 'disabled' : '' ?>>
+                                                                <span class="material-symbols-outlined">local_shipping</span>
+                                                            </button>
+                                                        <?php endif; ?>
+                                                        <button class="btn btn-sm btn-outline-danger"
                                                                 onclick="openDeleteModal(<?= $order['id'] ?>, '<?= htmlspecialchars(addslashes($order['order_number'])) ?>')"
                                                                 title="Șterge">
                                                             <span class="material-symbols-outlined">delete</span>

--- a/scripts/mobile_picker.js
+++ b/scripts/mobile_picker.js
@@ -212,7 +212,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 updateOrderStatus(trimmedOrderId, 'picking');
                 showLocationScanPrompt(result.data);
             } else if (result.status === 'complete') {
-                updateOrderStatus(trimmedOrderId, 'completed');
+                updateOrderStatus(trimmedOrderId, 'picked');
                 showCompletionScreen(result.message);
             } else {
                 throw new Error(result.message || 'API returned an unknown error.');

--- a/scripts/orders.js
+++ b/scripts/orders.js
@@ -177,7 +177,7 @@ function generateAWB(orderId) {
 
     console.log(`Generating AWB for order ${orderId}...`);
 
-    fetch(`/api/orders/${orderId}/generate-awb`, {
+    fetch(`/api/orders/${orderId}/awb`, {
             method: 'POST'
         })
         .then(response => response.json())

--- a/scripts/warehouse_orders.js
+++ b/scripts/warehouse_orders.js
@@ -180,7 +180,7 @@ function updateStats() {
     document.getElementById('total-orders').textContent = allOrders.length;
     document.getElementById('pending-orders').textContent = allOrders.filter(o => o.status === 'pending').length;
     document.getElementById('in-progress-orders').textContent = allOrders.filter(o => o.status === 'assigned').length;
-    document.getElementById('completed-orders').textContent = allOrders.filter(o => o.status === 'completed').length;
+    document.getElementById('completed-orders').textContent = allOrders.filter(o => o.status === 'picked').length;
 }
 
 /**
@@ -501,6 +501,7 @@ function getStatusLabel(status) {
         'pending': 'În Așteptare',
         'processing': 'În Procesare',
         'assigned': 'Asignat',
+        'picked': 'Colectat',
         'completed': 'Finalizat',
         'shipped': 'Expediat',
         'cancelled': 'Anulat'

--- a/styles/orders.css
+++ b/styles/orders.css
@@ -209,6 +209,12 @@
     border: 1px solid rgba(13, 202, 240, 0.2);
 }
 
+.status-picked {
+    background-color: rgba(13, 202, 240, 0.1);
+    color: #0dcaf0;
+    border: 1px solid rgba(13, 202, 240, 0.2);
+}
+
 .status-shipped {
     background-color: rgba(25, 135, 84, 0.1);
     color: #198754;

--- a/styles/warehouse_orders.css
+++ b/styles/warehouse_orders.css
@@ -256,6 +256,12 @@
     border: 1px solid #0dcaf0;
 }
 
+.status-picked {
+    background-color: rgba(13, 202, 240, 0.2);
+    color: #0dcaf0;
+    border: 1px solid #0dcaf0;
+}
+
 .status-completed {
     background-color: rgba(25, 135, 84, 0.2);
     color: #198754;


### PR DESCRIPTION
## Summary
- allow new `Picked` status in orders table
- expose `Picked` in order model status lists
- update status handling and UI to recognize `Picked`
- show Generate AWB button in Orders page, enabled when order status is `Picked`
- fix AWB endpoint path in orders script
- add matching styles
- add migration to update orders table enum

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686cd4cd08c48320977d73a28df92484