### PR TITLE
Enable Cargus AWB generation

### DIFF
--- a/api/.htaccess
+++ b/api/.htaccess
@@ -9,4 +9,4 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 
 # Route everything else to index.php for API routing
-RewriteRule ^(.*)$ index.php [QSA,L]
+RewriteRule ^(.*)$ index.php?endpoint=$1 [QSA,L]

--- a/api/index.php
+++ b/api/index.php
@@ -378,31 +378,38 @@ class ProductionWMSAPI {
     }
     
     private function generateAWB($orderId) {
-        // This would integrate with the Cargus API
-        // For now, just update the order with AWB placeholder
         $order = $this->orderModel->getOrderById($orderId);
         
         if (!$order) {
             throw new Exception('Order not found', 404);
         }
-        
+
+        if (strtolower($order['status']) !== 'picked') {
+            throw new Exception('AWB can only be generated for picked orders', 400);
+        }
+
         if (empty($order['recipient_county_id'])) {
             throw new Exception('Order missing AWB data', 400);
         }
-        
-        // TODO: Implement Cargus API integration here
-        $awbBarcode = 'AWB' . time() . rand(1000, 9999);
-        
+
+        require_once BASE_PATH . '/models/CargusService.php';
+        $cargus = new CargusService();
+        $result = $cargus->generateAWB($order);
+
+        if (!$result['success']) {
+            throw new Exception('Cargus API error: ' . $result['error'], 500);
+        }
+
         $this->orderModel->updateAWBInfo($orderId, [
-            'awb_barcode' => $awbBarcode,
+            'awb_barcode' => $result['barcode'],
             'awb_created_at' => date('Y-m-d H:i:s'),
-            'cargus_order_id' => 'CRG' . $orderId . time()
+            'cargus_order_id' => $result['parcelCodes'][0] ?? ''
         ]);
-        
+
         $this->sendResponse([
             'success' => true,
             'order_id' => $orderId,
-            'awb_barcode' => $awbBarcode,
+            'awb_barcode' => $result['barcode'],
             'message' => 'AWB generated successfully'
         ]);
     }

--- a/config/config.php
+++ b/config/config.php
@@ -73,4 +73,11 @@ return [
     
     // call this to get your PDO instance:
     'connection_factory' => $connectionFactory,
+
+    // Cargus API credentials (set via environment variables or directly here)
+    'cargus' => [
+        'username' => getenv('CARGUS_USER') ?: '',
+        'password' => getenv('CARGUS_PASS') ?: '',
+        'api_url'  => getenv('CARGUS_API_URL') ?: 'https://urgentcargus.azure-api.net/api/'
+    ],
 ];

--- a/orders.php
+++ b/orders.php
@@ -418,6 +418,7 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                                 <select name="status" id="status" class="form-control">
                                     <option value="Pending">Pending</option>
                                     <option value="Processing">Processing</option>
+                                    <option value="Picked">Picked</option>
                                     <option value="Shipped">Shipped</option>
                                     <option value="Delivered">Delivered</option>
                                     <option value="Cancelled">Cancelled</option>
@@ -506,6 +507,7 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                             <select name="status" id="updateStatus" class="form-control" required>
                                 <option value="Pending">Pending</option>
                                 <option value="Processing">Processing</option>
+                                <option value="Picked">Picked</option>
                                 <option value="Shipped">Shipped</option>
                                 <option value="Delivered">Delivered</option>
                                 <option value="Cancelled">Cancelled</option>


### PR DESCRIPTION
## Summary
- add Cargus API credentials to config
- fix CargusService initialization and add HTTP helper
- store lowercase status in orders and allow updating AWB info
- integrate real AWB creation in API
- show `Picked` in order status dropdown
- fix API routing via .htaccess and respect configured API URL

## Testing
- `php -l models/CargusService.php` (fails: `php: command not found`)


------
https://chatgpt.com/codex/tasks/task_e_686cdec2dc0483209effadb13e774cab