### PR TITLE
Add ActivityLog logging utility

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -64,4 +64,31 @@ function loadPageAsset($page, $type) {
     
     return '';
 }
-?>
+
+// ----------------------------------------------------------------------
+// Activity Log setup
+// ----------------------------------------------------------------------
+
+if (!isset($GLOBALS['config'])) {
+    $GLOBALS['config'] = require __DIR__ . '/config/config.php';
+}
+$config = $GLOBALS['config'];
+
+require_once __DIR__ . '/models/ActivityLog.php';
+
+try {
+    $dbFactory = $config['connection_factory'];
+    $logDb = $dbFactory();
+    $GLOBALS['activityLog'] = new ActivityLog($logDb);
+} catch (Exception $e) {
+    $GLOBALS['activityLog'] = null;
+    error_log('Activity log init failed: ' . $e->getMessage());
+}
+
+function logActivity($userId, $action, $resourceType, $resourceId, $description, $oldValues = null, $newValues = null) {
+    $logger = $GLOBALS['activityLog'] ?? null;
+    if ($logger instanceof ActivityLog) {
+        return $logger->log($userId, $action, $resourceType, $resourceId, $description, $oldValues, $newValues);
+    }
+    return false;
+}?>

--- a/models/ActivityLog.php
+++ b/models/ActivityLog.php
@@ -1,0 +1,59 @@
+<?php
+class ActivityLog {
+    private PDO $conn;
+    private string $table = 'activity_log';
+
+    public function __construct(PDO $db) {
+        $this->conn = $db;
+    }
+
+    /**
+     * Write an activity log entry.
+     */
+    public function log(
+        int $userId,
+        string $action,
+        string $resourceType,
+        int|string $resourceId,
+        string $description,
+        $oldValues = null,
+        $newValues = null
+    ): bool {
+        $query = "INSERT INTO {$this->table}
+                  (user_id, action, resource_type, resource_id, description, old_values, new_values, created_at)
+                  VALUES (:user_id, :action, :resource_type, :resource_id, :description, :old_values, :new_values, NOW())";
+
+        try {
+            $stmt = $this->conn->prepare($query);
+            $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
+            $stmt->bindValue(':action', $action);
+            $stmt->bindValue(':resource_type', $resourceType);
+            $stmt->bindValue(':resource_id', $resourceId);
+            $stmt->bindValue(':description', $description);
+            $stmt->bindValue(':old_values', $oldValues !== null ? json_encode($oldValues) : null);
+            $stmt->bindValue(':new_values', $newValues !== null ? json_encode($newValues) : null);
+            return $stmt->execute();
+        } catch (PDOException $e) {
+            error_log('ActivityLog error: ' . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Retrieve activity log entries.
+     */
+    public function getAll(int $limit = 50, int $offset = 0): array {
+        $query = "SELECT * FROM {$this->table} ORDER BY created_at DESC LIMIT :limit OFFSET :offset";
+        try {
+            $stmt = $this->conn->prepare($query);
+            $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+            $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+            $stmt->execute();
+            return $stmt->fetchAll(PDO::FETCH_ASSOC);
+        } catch (PDOException $e) {
+            error_log('ActivityLog getAll error: ' . $e->getMessage());
+            return [];
+        }
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- add `models/ActivityLog.php` with methods for writing and fetching logs
- wire up activity logging in `bootstrap.php`
- expose a helper `logActivity()` for easy use

## Testing
- `php -l models/ActivityLog.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e42a2b93883208b671a068a678ab0