### PR TITLE
Add README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# Product WMS
+
+This repository contains a warehouse management system. Below are the basic steps for setting up a development environment and running the project.
+
+## Requirements
+
+- **PHP** 8 or higher
+- **MySQL** server
+- **Node.js** with **npm**
+
+## Configuration
+
+1. Copy the example environment file and edit it:
+   ```bash
+   cp .env.example .env
+   ```
+2. Open `.env` and fill in the required values. At minimum set:
+   - `DB_HOST` – database host
+   - `DB_NAME` – database name
+   - `CARGUS_USER`, `CARGUS_PASS`, `CARGUS_SUBSCRIPTION_KEY`, `CARGUS_API_URL`
+   - `WMS_API_KEY`
+
+   Cargus credentials must be valid in order to generate AWBs.
+
+## Installing dependencies
+
+Install Node dependencies and build the front‑end assets:
+
+```bash
+npm install
+
+# For development
+npm run dev
+
+# For production builds
+npm run build
+```
+
+## Database migrations
+
+Run pending migrations using the migration CLI:
+
+```bash
+php migrate.php migrate
+```
+
+## Running automated tests
+
+A simple test script is provided to verify the API endpoints:
+
+```bash
+php test_api.php
+```
+
+This performs a few requests against the configured API and prints the results.


### PR DESCRIPTION
## Summary
- add quickstart README with environment setup, migrations, and test script guidance

## Testing
- `php -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686e5e0458c48320916c79a3d7f92abe