### PR TITLE
Add invoice printing to orders and picking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node_modules/
 database/backups/*.sql
 vendor/
 \.phpunit.result.cache
+storage/invoice_pdfs/

--- a/api/invoices/print_invoice.php
+++ b/api/invoices/print_invoice.php
@@ -1,0 +1,104 @@
+<?php
+// File: api/invoices/print_invoice.php
+// Generates a simple PDF invoice for an order and sends it to a network printer
+
+ob_start();
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/config/config.php';
+
+function respond($data, int $code = 200) {
+    ob_end_clean();
+    http_response_code($code);
+    echo json_encode($data);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    respond(['status' => 'error', 'message' => 'Method not allowed'], 405);
+}
+
+$orderId = $_POST['order_id'] ?? '';
+if (empty($orderId)) {
+    respond(['status' => 'error', 'message' => 'Missing order_id'], 400);
+}
+
+try {
+    $config = require BASE_PATH . '/config/config.php';
+    if (!isset($config['connection_factory']) || !is_callable($config['connection_factory'])) {
+        respond(['status' => 'error', 'message' => 'Database configuration error'], 500);
+    }
+    $db = $config['connection_factory']();
+
+    require_once BASE_PATH . '/models/Order.php';
+    require_once BASE_PATH . '/lib/fpdf.php';
+
+    $orderModel = new Order($db);
+    $order = $orderModel->getOrderById((int)$orderId);
+    if (!$order) {
+        respond(['status' => 'error', 'message' => 'Order not found'], 404);
+    }
+
+    $storageDir = BASE_PATH . '/storage/invoice_pdfs';
+    if (!is_dir($storageDir)) {
+        @mkdir($storageDir, 0777, true);
+    }
+
+    // Generate PDF invoice
+    $fileName = 'inv_' . $order['order_number'] . '_' . time() . '.pdf';
+    $filePath = $storageDir . '/' . $fileName;
+
+    $pdf = new FPDF();
+    $pdf->AddPage();
+    $pdf->SetFont('Arial', 'B', 16);
+    $pdf->Cell(0, 10, 'FACTURA', 0, 1, 'C');
+
+    $pdf->SetFont('Arial', '', 12);
+    $pdf->Cell(0, 8, 'Comanda: ' . $order['order_number'], 0, 1);
+    $pdf->Cell(0, 8, 'Client: ' . $order['customer_name'], 0, 1);
+    $pdf->Cell(0, 8, 'Data: ' . date('d.m.Y H:i', strtotime($order['order_date'])), 0, 1);
+    $pdf->Ln(8);
+
+    $pdf->SetFont('Arial', 'B', 10);
+    $pdf->Cell(80, 8, 'Produs', 1, 0, 'C');
+    $pdf->Cell(30, 8, 'Cantitate', 1, 0, 'C');
+    $pdf->Cell(30, 8, 'Pret', 1, 0, 'C');
+    $pdf->Cell(30, 8, 'Total', 1, 1, 'C');
+
+    $pdf->SetFont('Arial', '', 9);
+    $total = 0;
+    foreach ($order['items'] as $item) {
+        $name = $item['product_name'] ?? '';
+        if (strlen($name) > 35) {
+            $name = substr($name, 0, 32) . '...';
+        }
+        $qty = (float)($item['quantity'] ?? 0);
+        $price = (float)($item['unit_price'] ?? 0);
+        $lineTotal = $qty * $price;
+        $total += $lineTotal;
+        $pdf->Cell(80, 8, $name, 1);
+        $pdf->Cell(30, 8, number_format($qty, 2), 1, 0, 'R');
+        $pdf->Cell(30, 8, number_format($price, 2), 1, 0, 'R');
+        $pdf->Cell(30, 8, number_format($lineTotal, 2), 1, 1, 'R');
+    }
+
+    $pdf->SetFont('Arial', 'B', 10);
+    $pdf->Cell(140, 8, 'TOTAL:', 1, 0, 'R');
+    $pdf->Cell(30, 8, number_format($total, 2) . ' RON', 1, 1, 'R');
+
+    $pdf->Output('F', $filePath);
+
+    // Send to printer via lpr
+    $printer = 'Brother_MFC_L2712DN';
+    $cmd = 'lpr -P ' . escapeshellarg($printer) . ' ' . escapeshellarg($filePath);
+    $printOutput = shell_exec($cmd . ' 2>&1');
+
+    respond(['status' => 'success', 'message' => 'Invoice sent to printer', 'debug' => $printOutput]);
+
+} catch (Exception $e) {
+    respond(['status' => 'error', 'message' => $e->getMessage()], 500);
+}

--- a/mobile_picker.php
+++ b/mobile_picker.php
@@ -23,6 +23,9 @@ $hasOrderFromUrl = !empty($orderNumber);
                 <div class="order-number">#<span id="current-order-number"><?= $orderNumber ?></span></div>
                 <div class="customer-name" id="customer-name">Loading...</div>
             </div>
+            <button id="print-invoice-btn" class="btn btn-secondary btn-sm <?= !$hasOrderFromUrl ? 'hidden' : '' ?>" title="Printează Factura">
+                <span class="material-symbols-outlined">print</span>
+            </button>
         </div>
     </div>
 

--- a/orders.php
+++ b/orders.php
@@ -310,6 +310,9 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                                                                 <span class="material-symbols-outlined">local_shipping</span>
                                                             </button>
                                                         <?php endif; ?>
+                                                        <button class="btn btn-sm btn-outline-info" onclick="printInvoice(<?= $order['id'] ?>)" title="Printează Factura">
+                                                            <span class="material-symbols-outlined">print</span>
+                                                        </button>
                                                         <button class="btn btn-sm btn-outline-danger"
                                                                 onclick="openDeleteModal(<?= $order['id'] ?>, '<?= htmlspecialchars(addslashes($order['order_number'])) ?>')"
                                                                 title="Șterge">

--- a/scripts/orders.js
+++ b/scripts/orders.js
@@ -340,6 +340,40 @@ function printAWB(barcode) {
 }
 
 /**
+ * Send request to generate and print the invoice for a specific order.
+ * @param {number} orderId Order ID
+ */
+function printInvoice(orderId) {
+    if (!confirm(`Trimite factura la imprimantă pentru comanda #${orderId}?`)) {
+        return;
+    }
+
+    const formData = new FormData();
+    formData.append('order_id', orderId);
+
+    fetch('api/invoices/print_invoice.php', {
+        method: 'POST',
+        body: formData
+    })
+        .then(resp => resp.text())
+        .then(text => {
+            try {
+                const data = JSON.parse(text);
+                if (data.status === 'success') {
+                    alert('Factura a fost trimisă la imprimantă.');
+                } else {
+                    alert(data.message || 'Eroare la imprimare.');
+                }
+            } catch (e) {
+                alert('Eroare la imprimare: ' + e.message);
+            }
+        })
+        .catch(err => {
+            alert('Eroare la imprimare: ' + err.message);
+        });
+}
+
+/**
  * Dynamically adds a new product row to the "Create Order" form.
  */
 function addOrderItem() {

--- a/scripts/warehouse-js/mobile_picker.js
+++ b/scripts/warehouse-js/mobile_picker.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
         orderInfo: document.getElementById('order-info'),
         currentOrderNumber: document.getElementById('current-order-number'),
         customerName: document.getElementById('customer-name'),
+        printInvoiceBtn: document.getElementById('print-invoice-btn'),
         
         // Progress
         progressSection: document.getElementById('progress-section'),
@@ -133,6 +134,8 @@ document.addEventListener('DOMContentLoaded', () => {
         elements.qtyIncrease?.addEventListener('click', () => adjustQuantity(1));
         elements.confirmQuantityBtn?.addEventListener('click', confirmPick);
         elements.backToProduct?.addEventListener('click', () => showStep('product'));
+
+        elements.printInvoiceBtn?.addEventListener('click', printInvoice);
         
         // Scanner
         elements.closeScanner?.addEventListener('click', closeScanner);
@@ -208,13 +211,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function updateOrderDisplay() {
         if (!currentOrder) return;
-        
+
         if (elements.currentOrderNumber) {
             elements.currentOrderNumber.textContent = currentOrder.order_number;
         }
-        
+
         if (elements.customerName) {
             elements.customerName.textContent = currentOrder.customer_name || 'Client necunoscut';
+        }
+
+        if (elements.printInvoiceBtn) {
+            elements.printInvoiceBtn.classList.remove('hidden');
         }
     }
 
@@ -596,6 +603,31 @@ document.addEventListener('DOMContentLoaded', () => {
         elements.completionSection?.classList.remove('hidden');
     }
 
+    async function printInvoice() {
+        if (!currentOrder) return;
+        try {
+            showLoading(true);
+            const formData = new FormData();
+            formData.append('order_id', currentOrder.id);
+            const response = await fetch(`${API_BASE}/invoices/print_invoice.php`, {
+                method: 'POST',
+                body: formData
+            });
+            const text = await response.text();
+            const data = JSON.parse(text);
+            if (data.status === 'success') {
+                showMessage('Factura a fost trimisă la imprimantă.', 'success');
+            } else {
+                throw new Error(data.message || 'Eroare la imprimare');
+            }
+        } catch (err) {
+            console.error('Print invoice error:', err);
+            showMessage(`Eroare la imprimare: ${err.message}`, 'error');
+        } finally {
+            showLoading(false);
+        }
+    }
+
     // Utility Functions
     function showLoading(show = true) {
         if (elements.loadingOverlay) {
@@ -638,6 +670,7 @@ document.addEventListener('DOMContentLoaded', () => {
         orderItems: () => orderItems,
         refreshItems: () => {
             if (currentOrder) loadOrderItems(currentOrder.id);
-        }
+        },
+        printInvoice
     };
 });


### PR DESCRIPTION
## Summary
- add new API endpoint for generating invoice PDF and printing
- add print invoice button to admin orders table
- show invoice print button on mobile picking page
- implement JS helpers for printing in admin and warehouse interfaces
- ignore generated invoice PDFs