### PR TITLE
Add printers management

### DIFF
--- a/api/printers.php
+++ b/api/printers.php
@@ -1,0 +1,136 @@
+<?php
+header('Content-Type: application/json');
+header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+session_start();
+if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
+    http_response_code(403);
+    echo json_encode(['error' => 'Access denied']);
+    exit;
+}
+
+$config = require BASE_PATH . '/config/config.php';
+$db = $config['connection_factory']();
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+try {
+    switch ($method) {
+        case 'GET':
+            handleGet($db);
+            break;
+        case 'POST':
+            handlePost($db);
+            break;
+        case 'PUT':
+            handlePut($db);
+            break;
+        case 'DELETE':
+            handleDelete($db);
+            break;
+        default:
+            http_response_code(405);
+            echo json_encode(['error' => 'Method not allowed']);
+    }
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Internal server error: ' . $e->getMessage()]);
+}
+
+function handleGet(PDO $db) {
+    $stmt = $db->query("SELECT id, name, network_address FROM printers ORDER BY name ASC");
+    $printers = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $formatted = array_map(function ($row) {
+        return [
+            'id' => (int)$row['id'],
+            'name' => $row['name'],
+            'network_address' => $row['network_address'],
+        ];
+    }, $printers);
+
+    echo json_encode($formatted);
+}
+
+function handlePost(PDO $db) {
+    $input = json_decode(file_get_contents('php://input'), true);
+    if (!$input || empty($input['name']) || empty($input['network_address'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid input']);
+        return;
+    }
+
+    $stmt = $db->prepare('INSERT INTO printers (name, network_address) VALUES (?, ?)');
+    $result = $stmt->execute([$input['name'], $input['network_address']]);
+
+    if ($result) {
+        echo json_encode(['success' => true, 'id' => $db->lastInsertId()]);
+    } else {
+        http_response_code(500);
+        echo json_encode(['error' => 'Failed to create printer']);
+    }
+}
+
+function handlePut(PDO $db) {
+    $input = json_decode(file_get_contents('php://input'), true);
+    if (!$input || !isset($input['id'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Missing printer ID']);
+        return;
+    }
+
+    $fields = [];
+    $values = [];
+
+    if (isset($input['name'])) {
+        $fields[] = 'name = ?';
+        $values[] = $input['name'];
+    }
+    if (isset($input['network_address'])) {
+        $fields[] = 'network_address = ?';
+        $values[] = $input['network_address'];
+    }
+
+    if (empty($fields)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'No data to update']);
+        return;
+    }
+
+    $values[] = $input['id'];
+    $stmt = $db->prepare('UPDATE printers SET ' . implode(', ', $fields) . ' WHERE id = ?');
+    $result = $stmt->execute($values);
+
+    if ($result) {
+        echo json_encode(['success' => true]);
+    } else {
+        http_response_code(500);
+        echo json_encode(['error' => 'Failed to update printer']);
+    }
+}
+
+function handleDelete(PDO $db) {
+    $id = $_GET['id'] ?? null;
+    if (!$id) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Missing printer ID']);
+        return;
+    }
+
+    $stmt = $db->prepare('DELETE FROM printers WHERE id = ?');
+    $result = $stmt->execute([$id]);
+
+    if ($result) {
+        echo json_encode(['success' => true]);
+    } else {
+        http_response_code(500);
+        echo json_encode(['error' => 'Failed to delete printer']);
+    }
+}
+?>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -27,7 +27,8 @@ $pageSpecificJS = [
     'orders' => 'orders.js',
     'sellers' => 'sellers.js',
     'purchase_orders' => 'purchase_orders.js',
-    'product-units' => 'product-units.js'
+    'product-units' => 'product-units.js',
+    'printers' => 'printers.js'
 ];
 
 // Check if a specific script is defined for the current page in our array.

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -146,11 +146,21 @@ if (isset($_SESSION['username'])) {
 
         <!-- SmartBill Sync -->
         <li class="sidebar__item">
-            <a href="<?= getNavUrl('smartbill-sync.php') ?>" 
+            <a href="<?= getNavUrl('smartbill-sync.php') ?>"
                class="sidebar__link <?= getActiveClass('smartbill-sync.php') ?>"
                data-tooltip="SmartBill Sync">
                 <span class="material-symbols-outlined">sync</span>
                 <span class="link-text">SmartBill Sync</span>
+            </a>
+        </li>
+
+        <!-- Printers -->
+        <li class="sidebar__item">
+            <a href="<?= getNavUrl('printers.php') ?>"
+               class="sidebar__link <?= getActiveClass('printers.php') ?>"
+               data-tooltip="Imprimante">
+                <span class="material-symbols-outlined">print</span>
+                <span class="link-text">Imprimante</span>
             </a>
         </li>
         

--- a/printers.php
+++ b/printers.php
@@ -1,0 +1,120 @@
+<?php
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', __DIR__);
+}
+require_once BASE_PATH . '/bootstrap.php';
+$config = require BASE_PATH . '/config/config.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
+    header('Location: ' . getNavUrl('login.php'));
+    exit;
+}
+
+$pageTitle = 'Administrare Imprimante';
+$currentPage = 'printers';
+?>
+<!DOCTYPE html>
+<html lang="ro" data-theme="dark">
+<head>
+    <?php require_once BASE_PATH . '/includes/header.php'; ?>
+</head>
+<body>
+<div class="app">
+    <?php require_once BASE_PATH . '/includes/navbar.php'; ?>
+    <main class="main-content">
+        <div class="page-container">
+            <div class="page-header">
+                <div class="page-header-content">
+                    <h1 class="page-title">
+                        <span class="material-symbols-outlined">print</span>
+                        Administrare Imprimante
+                    </h1>
+                    <div class="header-actions">
+                        <button class="btn btn-primary" id="addPrinterBtn">
+                            <span class="material-symbols-outlined">add</span>
+                            Adaugă Imprimantă
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="table-responsive">
+                <table class="table" id="printersTable">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Nume</th>
+                            <th>Adresă Rețea</th>
+                            <th>Acțiuni</th>
+                        </tr>
+                    </thead>
+                    <tbody id="printersBody">
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </main>
+</div>
+
+<div class="modal" id="printerModal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title" id="printerModalTitle">Imprimantă</h3>
+                <button class="modal-close" onclick="closePrinterModal()">
+                    <span class="material-symbols-outlined">close</span>
+                </button>
+            </div>
+            <form id="printerForm">
+                <div class="modal-body">
+                    <input type="hidden" id="printerId" name="id">
+                    <div class="form-group">
+                        <label for="printerName" class="form-label">Nume</label>
+                        <input type="text" id="printerName" name="name" class="form-control" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="printerAddress" class="form-label">Adresă Rețea</label>
+                        <input type="text" id="printerAddress" name="network_address" class="form-control" required>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" onclick="closePrinterModal()">Anulează</button>
+                    <button type="submit" class="btn btn-primary">Salvează</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<div class="modal" id="deletePrinterModal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title">Șterge Imprimantă</h3>
+                <button class="modal-close" onclick="closeDeleteModal()">
+                    <span class="material-symbols-outlined">close</span>
+                </button>
+            </div>
+            <form id="deletePrinterForm">
+                <div class="modal-body">
+                    <p>Sunteți sigur că doriți să ștergeți imprimanta <strong id="deletePrinterName"></strong>?</p>
+                    <input type="hidden" id="deletePrinterId" name="id">
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" onclick="closeDeleteModal()">Anulează</button>
+                    <button type="submit" class="btn btn-danger">Șterge</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<?php require_once __DIR__ . '/includes/footer.php'; ?>

--- a/scripts/printers.js
+++ b/scripts/printers.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const baseUrl = window.APP_CONFIG?.baseUrl || '';
+const printersApi = `${baseUrl}/api/printers.php`;
+
+const PrinterApp = {
+    init() {
+        this.cache();
+        this.bindEvents();
+        this.loadPrinters();
+    },
+
+    cache() {
+        this.tableBody = document.getElementById('printersBody');
+        this.addBtn = document.getElementById('addPrinterBtn');
+        this.modal = document.getElementById('printerModal');
+        this.modalTitle = document.getElementById('printerModalTitle');
+        this.form = document.getElementById('printerForm');
+        this.idInput = document.getElementById('printerId');
+        this.nameInput = document.getElementById('printerName');
+        this.addressInput = document.getElementById('printerAddress');
+        this.deleteModal = document.getElementById('deletePrinterModal');
+        this.deleteForm = document.getElementById('deletePrinterForm');
+        this.deleteId = document.getElementById('deletePrinterId');
+        this.deleteName = document.getElementById('deletePrinterName');
+    },
+
+    bindEvents() {
+        if (this.addBtn) {
+            this.addBtn.addEventListener('click', () => this.open());
+        }
+        if (this.form) {
+            this.form.addEventListener('submit', e => {
+                e.preventDefault();
+                this.save();
+            });
+        }
+        if (this.deleteForm) {
+            this.deleteForm.addEventListener('submit', e => {
+                e.preventDefault();
+                this.remove();
+            });
+        }
+    },
+
+    async loadPrinters() {
+        try {
+            const res = await fetch(printersApi);
+            const data = await res.json();
+            this.render(data);
+        } catch (err) {
+            console.error('Failed to load printers', err);
+        }
+    },
+
+    render(printers) {
+        this.tableBody.innerHTML = '';
+        printers.forEach(p => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>${p.id}</td>
+                <td>${p.name}</td>
+                <td>${p.network_address}</td>
+                <td>
+                    <button class="btn btn-sm btn-primary" data-id="${p.id}" data-name="${p.name}" data-address="${p.network_address}">Editează</button>
+                    <button class="btn btn-sm btn-danger" data-del="${p.id}" data-name="${p.name}">Șterge</button>
+                </td>`;
+            tr.querySelector('[data-id]')?.addEventListener('click', () => {
+                this.open(tr.querySelector('[data-id]').dataset);
+            });
+            tr.querySelector('[data-del]')?.addEventListener('click', () => {
+                this.confirmDelete(tr.querySelector('[data-del]').dataset);
+            });
+            this.tableBody.appendChild(tr);
+        });
+    },
+
+    open(data = {}) {
+        this.idInput.value = data.id || '';
+        this.nameInput.value = data.name || '';
+        this.addressInput.value = data.address || '';
+        this.modalTitle.textContent = data.id ? 'Editează Imprimantă' : 'Adaugă Imprimantă';
+        this.modal.classList.add('show');
+    },
+
+    close() {
+        this.modal.classList.remove('show');
+        this.form.reset();
+        this.idInput.value = '';
+    },
+
+    async save() {
+        const payload = {
+            name: this.nameInput.value.trim(),
+            network_address: this.addressInput.value.trim()
+        };
+        const id = this.idInput.value;
+        if (id) payload.id = parseInt(id, 10);
+
+        const res = await fetch(printersApi + (id ? '' : ''), {
+            method: id ? 'PUT' : 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+        if (res.ok) {
+            this.close();
+            this.loadPrinters();
+        } else {
+            console.error('Save failed');
+        }
+    },
+
+    confirmDelete(data) {
+        this.deleteId.value = data.del;
+        this.deleteName.textContent = data.name;
+        this.deleteModal.classList.add('show');
+    },
+
+    closeDelete() {
+        this.deleteModal.classList.remove('show');
+        this.deleteForm.reset();
+    },
+
+    async remove() {
+        const id = this.deleteId.value;
+        const res = await fetch(`${printersApi}?id=${id}`, { method: 'DELETE' });
+        if (res.ok) {
+            this.closeDelete();
+            this.loadPrinters();
+        } else {
+            console.error('Delete failed');
+        }
+    }
+};
+
+document.addEventListener('DOMContentLoaded', () => PrinterApp.init());
+
+function closePrinterModal() {
+    PrinterApp.close();
+}
+function closeDeleteModal() {
+    PrinterApp.closeDelete();
+}


### PR DESCRIPTION
## Summary
- create admin page for managing printers
- implement CRUD API for printers
- support AJAX operations with printers.js
- link to printers page in navbar
- load printers.js through footer

## Testing
- `php test_api.php`
- `php -l printers.php`
- `php -l api/printers.php`
- `php -l scripts/printers.js`

------
https://chatgpt.com/codex/tasks/task_e_6874d20734388320a608b3b791a88325