### PR TITLE
Add quick PO search for receiving

### DIFF
--- a/api/receiving/quick_search_purchase_orders.php
+++ b/api/receiving/quick_search_purchase_orders.php
@@ -1,0 +1,57 @@
+<?php
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+require_once BASE_PATH . '/bootstrap.php';
+
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Unauthorized']);
+    exit;
+}
+
+$config = require BASE_PATH . '/config/config.php';
+$dbFactory = $config['connection_factory'];
+$db = $dbFactory();
+
+$search = trim($_GET['q'] ?? '');
+if ($search === '') {
+    echo json_encode(['success' => true, 'orders' => []]);
+    exit;
+}
+
+try {
+    $stmt = $db->prepare("
+        SELECT po.id, po.order_number, s.supplier_name, po.status,
+               po.total_amount, po.currency
+        FROM purchase_orders po
+        JOIN sellers s ON po.seller_id = s.id
+        WHERE po.order_number LIKE :search
+          AND po.status IN ('sent','confirmed','partial_delivery','delivered')
+        ORDER BY po.created_at DESC
+        LIMIT 10
+    ");
+    $stmt->execute([':search' => '%' . $search . '%']);
+    $orders = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $formatted = array_map(function($po) {
+        return [
+            'id' => (int)$po['id'],
+            'order_number' => $po['order_number'],
+            'supplier_name' => $po['supplier_name'],
+            'status' => $po['status'],
+            'total_amount' => number_format((float)$po['total_amount'], 2),
+            'currency' => $po['currency']
+        ];
+    }, $orders);
+
+    echo json_encode(['success' => true, 'orders' => $formatted]);
+
+} catch (Exception $e) {
+    error_log('Quick search PO error: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Server error']);
+}

--- a/api/receiving/start_session.php
+++ b/api/receiving/start_session.php
@@ -55,9 +55,9 @@ try {
     $supplierDocNumber = trim($input['supplier_doc_number'] ?? '');
     $docType = trim($input['doc_type'] ?? '');
     $docDate = trim($input['doc_date'] ?? '');
-    
-    if (!$purchaseOrderId || !$supplierDocNumber || !$docType) {
-        throw new Exception('Purchase order ID, supplier document number and type are required');
+
+    if (!$purchaseOrderId) {
+        throw new Exception('Purchase order ID is required');
     }
     
     // Validate purchase order exists
@@ -70,9 +70,17 @@ try {
     ");
     $stmt->execute([':po_id' => $purchaseOrderId]);
     $purchaseOrder = $stmt->fetch(PDO::FETCH_ASSOC);
-    
+
     if (!$purchaseOrder) {
         throw new Exception('Purchase order not found');
+    }
+
+    // Use defaults when supplier document info is missing
+    if (!$supplierDocNumber) {
+        $supplierDocNumber = 'PO-' . $purchaseOrder['order_number'];
+    }
+    if (!$docType) {
+        $docType = 'delivery_note';
     }
     
     // Check if there's already an active session for this PO

--- a/scripts/warehouse-js/warehouse_receiving.js
+++ b/scripts/warehouse-js/warehouse_receiving.js
@@ -28,16 +28,10 @@ class WarehouseReceiving {
     }
 
     bindEvents() {
-        // Document form submission
-        const documentForm = document.getElementById('document-form');
-        if (documentForm) {
-            documentForm.addEventListener('submit', (e) => this.handleDocumentSubmit(e));
-        }
-
-        // Purchase order selection
-        const selectPOBtn = document.getElementById('select-po-btn');
-        if (selectPOBtn) {
-            selectPOBtn.addEventListener('click', () => this.selectPurchaseOrder());
+        // Search purchase order by number
+        const poSearchInput = document.getElementById('po-search-input');
+        if (poSearchInput) {
+            poSearchInput.addEventListener('input', (e) => this.quickSearchPO(e.target.value));
         }
 
         // Complete receiving
@@ -88,63 +82,31 @@ class WarehouseReceiving {
         }
     }
 
-    async handleDocumentSubmit(event) {
-        event.preventDefault();
-        
-        const formData = new FormData(event.target);
-        const supplierDocNumber = formData.get('supplier_doc_number');
-        const docType = formData.get('doc_type');
-        const docDate = formData.get('doc_date');
-        
-        if (!supplierDocNumber || !docType) {
-            this.showError('Completează numărul documentului și tipul acestuia');
+    async quickSearchPO(query) {
+        if (!query) {
+            const container = document.getElementById('po-search-results');
+            if (container) container.innerHTML = '';
             return;
         }
 
-        this.showLoading(true);
-        
         try {
-            // Search for matching purchase orders
-            const response = await fetch(`${this.config.apiBase}/receiving/search_purchase_orders.php`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-Token': this.config.csrfToken
-                },
-                body: JSON.stringify({
-                    supplier_doc_number: supplierDocNumber,
-                    doc_type: docType,
-                    doc_date: docDate
-                })
-            });
-
+            const response = await fetch(`${this.config.apiBase}/receiving/quick_search_purchase_orders.php?q=${encodeURIComponent(query)}`);
             const result = await response.json();
-            
-            if (!response.ok) {
-                throw new Error(result.message || 'Eroare la căutarea comenzilor');
-            }
 
-            if (result.purchase_orders && result.purchase_orders.length > 0) {
-                this.displayPurchaseOrders(result.purchase_orders);
-                this.showStep(2);
-            } else {
-                this.showError('Nu s-au găsit comenzi de achiziție asociate cu acest document');
+            if (response.ok && result.orders) {
+                this.displayPurchaseOrders(result.orders, 'po-search-results');
             }
-            
         } catch (error) {
-            console.error('Error searching purchase orders:', error);
-            this.showError('Eroare la căutarea comenzilor: ' + error.message);
-        } finally {
-            this.showLoading(false);
+            console.error('Quick search error:', error);
         }
     }
 
-    displayPurchaseOrders(purchaseOrders) {
-        const container = document.getElementById('purchase-orders-list');
+    displayPurchaseOrders(purchaseOrders, containerId = 'purchase-orders-list') {
+        const container = document.getElementById(containerId);
         if (!container) return;
 
         container.innerHTML = purchaseOrders.map(po => `
-            <div class="purchase-order-item" data-po-id="${po.id}" onclick="receivingSystem.selectPO(${po.id})">
+            <div class="purchase-order-item" data-po-id="${po.id}" onclick="receivingSystem.startReceivingFromSearch(${po.id})">
                 <div class="po-header">
                     <div class="po-number">${this.escapeHtml(po.order_number)}</div>
                     <div class="po-status status-${po.status}">
@@ -173,36 +135,10 @@ class WarehouseReceiving {
         `).join('');
     }
 
-    selectPO(poId) {
-        // Remove previous selection
-        document.querySelectorAll('.purchase-order-item').forEach(item => {
-            item.classList.remove('selected');
-        });
-        
-        // Add selection to clicked item
-        const selectedItem = document.querySelector(`[data-po-id="${poId}"]`);
-        if (selectedItem) {
-            selectedItem.classList.add('selected');
-            this.selectedPurchaseOrder = poId;
-            
-            // Enable continue button
-            const selectBtn = document.getElementById('select-po-btn');
-            if (selectBtn) {
-                selectBtn.disabled = false;
-            }
-        }
-    }
-
-    async selectPurchaseOrder() {
-        if (!this.selectedPurchaseOrder) {
-            this.showError('Selectează o comandă de achiziție');
-            return;
-        }
-
+    async startReceivingFromSearch(poId) {
         this.showLoading(true);
-        
+
         try {
-            // Start receiving session
             const response = await fetch(`${this.config.apiBase}/receiving/start_session.php`, {
                 method: 'POST',
                 headers: {
@@ -210,17 +146,13 @@ class WarehouseReceiving {
                     'X-CSRF-Token': this.config.csrfToken
                 },
                 body: JSON.stringify({
-                    purchase_order_id: this.selectedPurchaseOrder,
-                    supplier_doc_number: document.getElementById('supplier-doc-number').value,
-                    doc_type: document.getElementById('doc-type').value,
-                    doc_date: document.getElementById('doc-date').value
+                    purchase_order_id: poId
                 })
             });
 
             const result = await response.json();
-            
+
             if (!response.ok) {
-                // Check if it's an existing session error
                 if (result.error_type === 'existing_session') {
                     this.handleExistingSession(result.existing_session);
                     return;
@@ -232,7 +164,7 @@ class WarehouseReceiving {
             this.loadReceivingItems();
             this.updateReceivingSummary();
             this.showStep(3);
-            
+
         } catch (error) {
             console.error('Error starting receiving session:', error);
             this.showError('Eroare la începerea recepției: ' + error.message);
@@ -670,14 +602,14 @@ class WarehouseReceiving {
         this.selectedPurchaseOrder = null;
         this.receivingItems = [];
         
-        // Reset forms
-        const documentForm = document.getElementById('document-form');
-        if (documentForm) {
-            documentForm.reset();
+        const searchInput = document.getElementById('po-search-input');
+        if (searchInput) {
+            searchInput.value = '';
         }
-        
-        // Reset UI
-        document.getElementById('select-po-btn').disabled = true;
+        const results = document.getElementById('po-search-results');
+        if (results) {
+            results.innerHTML = '';
+        }
         
         this.showStep(1);
     }

--- a/warehouse_receiving.php
+++ b/warehouse_receiving.php
@@ -169,87 +169,25 @@ $currentPage = 'warehouse_receiving';
                     </div>
                 <?php endif; ?>
 
-                <!-- Step 1: Document Entry -->
+                <!-- Step 1: Order Search -->
                 <div id="step-1" class="step-section active">
                     <div class="step-header">
                         <h2 class="step-title">
-                            <span class="material-symbols-outlined">receipt</span>
-                            Introdu Documentul Furnizorului
+                            <span class="material-symbols-outlined">search</span>
+                            Caută Comanda
                         </h2>
-                        <p class="step-subtitle">Începe cu numărul facturii sau avizului de livrare</p>
+                        <p class="step-subtitle">Scrie numărul comenzii de achiziție</p>
                     </div>
-                    
+
                     <div class="step-content">
-                        <form id="document-form" class="document-form">
-                            <div class="form-group">
-                                <label for="supplier-doc-number" class="form-label">
-                                    Numărul Documentului *
-                                </label>
-                                <input type="text" 
-                                       id="supplier-doc-number" 
-                                       name="supplier_doc_number" 
-                                       class="form-input" 
-                                       placeholder="ex: FAC-2024-001, AV-123456"
-                                       required>
-                            </div>
-                            
-                            <div class="form-group">
-                                <label for="doc-type" class="form-label">
-                                    Tipul Documentului *
-                                </label>
-                                <select id="doc-type" name="doc_type" class="form-select" required>
-                                    <option value="">Selectează tipul</option>
-                                    <option value="invoice">Factură</option>
-                                    <option value="delivery_note">Aviz de livrare</option>
-                                    <option value="packing_slip">Bon de transport</option>
-                                </select>
-                            </div>
-                            
-                            <div class="form-group">
-                                <label for="doc-date" class="form-label">
-                                    Data Documentului
-                                </label>
-                                <input type="date" 
-                                       id="doc-date" 
-                                       name="doc_date" 
-                                       class="form-input">
-                            </div>
-                            
-                            <button type="submit" class="btn btn-primary">
-                                <span class="material-symbols-outlined">search</span>
-                                Caută Comenzi Asociate
-                            </button>
-                        </form>
+                        <div class="form-group">
+                            <label for="po-search-input" class="form-label">Număr Comandă</label>
+                            <input type="text" id="po-search-input" class="form-input" placeholder="ex: PO-2024-001">
+                        </div>
+                        <div id="po-search-results" class="purchase-orders-list"></div>
                     </div>
                 </div>
 
-                <!-- Step 2: Purchase Order Selection -->
-                <div id="step-2" class="step-section">
-                    <div class="step-header">
-                        <h2 class="step-title">
-                            <span class="material-symbols-outlined">shopping_cart</span>
-                            Selectează Comanda de Achiziție
-                        </h2>
-                        <p class="step-subtitle">Alege comanda corespunzătoare pentru această livrare</p>
-                    </div>
-                    
-                    <div class="step-content">
-                        <div id="purchase-orders-list" class="purchase-orders-list">
-                            <!-- Purchase orders will be populated here -->
-                        </div>
-                        
-                        <div class="step-actions">
-                            <button type="button" class="btn btn-secondary" onclick="goToPreviousStep()">
-                                <span class="material-symbols-outlined">arrow_back</span>
-                                Înapoi
-                            </button>
-                            <button type="button" class="btn btn-primary" id="select-po-btn" disabled>
-                                <span class="material-symbols-outlined">arrow_forward</span>
-                                Continuă cu Comanda
-                            </button>
-                        </div>
-                    </div>
-                </div>
 
                 <!-- Step 3: Item Receiving -->
                 <div id="step-3" class="step-section">


### PR DESCRIPTION
## Summary
- implement `quick_search_purchase_orders.php` endpoint
- allow starting receiving session without document details
- simplify receiving interface to search by purchase order number
- update warehouse receiving JS for live PO search and session start