### PR TITLE
Add basic QC hold workflow

### DIFF
--- a/api/receiving/qc_pending.php
+++ b/api/receiving/qc_pending.php
@@ -1,0 +1,28 @@
+<?php
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+require_once BASE_PATH . '/bootstrap.php';
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Unauthorized']);
+    exit;
+}
+
+$config = require BASE_PATH . '/config/config.php';
+$dbFactory = $config['connection_factory'];
+$db = $dbFactory();
+require_once BASE_PATH . '/models/ReceivingSession.php';
+
+try {
+    $model = new ReceivingSession($db);
+    $count = $model->countPendingQualityItems();
+    echo json_encode(['success' => true, 'pending' => $count]);
+} catch (Exception $e) {
+    error_log('QC pending API error: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Server error']);
+}

--- a/database/migrations/2025_07_02_120928_create_complete_wms_schema.php
+++ b/database/migrations/2025_07_02_120928_create_complete_wms_schema.php
@@ -76,7 +76,7 @@ class CreateCompleteWmsSchemaMigration {
                     id INT PRIMARY KEY AUTO_INCREMENT,
                     location_code VARCHAR(50) UNIQUE NOT NULL,
                     zone VARCHAR(50) NOT NULL,
-                    type ENUM('warehouse', 'zone', 'rack', 'shelf', 'bin') DEFAULT 'bin',
+                    type ENUM('warehouse', 'zone', 'rack', 'shelf', 'bin', 'qc_hold', 'quarantine', 'pending_approval') DEFAULT 'bin',
                     levels INT DEFAULT 3,
                     parent_location_id INT NULL,
                     capacity INT DEFAULT 0,

--- a/database/migrations/2025_07_14_143433_create_receiving_tables_migration.php
+++ b/database/migrations/2025_07_14_143433_create_receiving_tables_migration.php
@@ -53,6 +53,7 @@ class CreateReceivingTablesMigration {
                 batch_number VARCHAR(100),
                 expiry_date DATE,
                 location_id INT,
+                approval_status ENUM('approved', 'pending', 'rejected') DEFAULT 'approved',
                 notes TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/index.php
+++ b/index.php
@@ -44,6 +44,7 @@ $users = new Users($db);
 $location = new Location($db);
 $inventory = new Inventory($db);
 $orders = new Order($db);
+$receivingSession = new ReceivingSession($db);
 
 // Get Dashboard Data
 try {
@@ -56,6 +57,7 @@ try {
     $activeOrders = $orders->countActiveOrders();
     $pendingOrders = $orders->countPendingOrders();
     $completedOrdersToday = $orders->countCompletedToday();
+    $pendingQualityItems = $receivingSession->countPendingQualityItems();
     
     // Calculate warehouse occupation percentage
     $warehouseOccupationPercent = $totalLocations > 0 ? round(($occupiedLocations / $totalLocations) * 100, 1) : 0;
@@ -79,6 +81,7 @@ try {
     $warehouseOccupationPercent = 0;
     $recentOrders = $criticalStockAlerts = [];
     $todayStats = ['orders_created' => 0, 'orders_completed' => 0, 'items_moved' => 0];
+    $pendingQualityItems = 0;
 }
 ?>
 
@@ -184,6 +187,17 @@ try {
                             <div class="detail-item">
                                 <span class="detail-label">Finalizate azi:</span>
                                 <span class="detail-value text-success"><?= number_format($todayStats['orders_completed']) ?></span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- QC Pending -->
+                    <div class="metric-card warning">
+                        <div class="metric-header">
+                            <span class="material-symbols-outlined">fact_check</span>
+                            <div class="metric-values">
+                                <div class="metric-primary"><?= number_format($pendingQualityItems) ?></div>
+                                <div class="metric-label">QC în Așteptare</div>
                             </div>
                         </div>
                     </div>

--- a/models/ReceivingSession.php
+++ b/models/ReceivingSession.php
@@ -353,4 +353,20 @@ class ReceivingSession {
         $stmt->execute($params);
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }
+
+    /**
+     * Count items that require quality approval
+     * @return int Pending approval count
+     */
+    public function countPendingQualityItems(): int {
+        $sql = "SELECT COUNT(*) FROM receiving_items WHERE approval_status = 'pending'";
+        try {
+            $stmt = $this->db->prepare($sql);
+            $stmt->execute();
+            return (int) $stmt->fetchColumn();
+        } catch (PDOException $e) {
+            error_log('Error counting pending quality items: ' . $e->getMessage());
+            return 0;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- expand location types to include QC areas
- track approval_status when receiving items
- count pending QC items for dashboard metrics
- expose qc_pending API endpoint
- show pending QC metric on dashboard