### PR TITLE
Fix receiving summary update

### DIFF
--- a/scripts/warehouse-js/warehouse_receiving.js
+++ b/scripts/warehouse-js/warehouse_receiving.js
@@ -248,6 +248,7 @@ class WarehouseReceiving {
             if (response.ok) {
                 this.receivingItems = result.items || [];
                 this.displayReceivingItems();
+                this.updateReceivingSummary();
             }
             
         } catch (error) {
@@ -298,9 +299,32 @@ class WarehouseReceiving {
 
     getLocationOptions() {
         const locations = this.config.locations || [];
-        return locations.map(loc => 
+        return locations.map(loc =>
             `<option value="${loc.location_code}">${loc.location_code} (${loc.zone})</option>`
         ).join('');
+    }
+
+    updateReceivingSummary() {
+        if (!this.currentReceivingSession) return;
+
+        const poNumberEl = document.getElementById('current-po-number');
+        const supplierEl = document.getElementById('current-supplier');
+        const receivedEl = document.getElementById('items-received');
+        const expectedEl = document.getElementById('items-expected');
+
+        if (poNumberEl) {
+            poNumberEl.textContent = this.currentReceivingSession.po_number || '-';
+        }
+
+        if (supplierEl) {
+            supplierEl.textContent = this.currentReceivingSession.supplier_name || '-';
+        }
+
+        const receivedCount = this.receivingItems.filter(item => item.status === 'received').length;
+        const expectedCount = this.receivingItems.length || this.currentReceivingSession.total_items_expected || 0;
+
+        if (receivedEl) receivedEl.textContent = receivedCount;
+        if (expectedEl) expectedEl.textContent = expectedCount;
     }
 
     async receiveItem(itemId) {


### PR DESCRIPTION
## Summary
- update loadReceivingItems to refresh summary after items load
- implement `updateReceivingSummary` to populate order and progress data

## Testing
- `npm test` *(fails: Database connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687a1691ef4083209556014356069ba9