### PR TITLE
Fix bulk status handling and stock transfer

### DIFF
--- a/inventory.php
+++ b/inventory.php
@@ -95,12 +95,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $fromLocationId = intval($_POST['from_location_id'] ?? 0);
             $newLocationId  = intval($_POST['new_location_id'] ?? 0);
             $moveQuantity   = intval($_POST['move_quantity'] ?? 0);
+            $inventoryId    = intval($_POST['inventory_id'] ?? 0) ?: null;
 
             if ($productId <= 0 || $fromLocationId <= 0 || $newLocationId <= 0 || $moveQuantity <= 0) {
                 $message = 'Toate câmpurile sunt obligatorii pentru mutarea stocului.';
                 $messageType = 'error';
             } else {
-                if ($inventoryModel->moveStock($productId, $fromLocationId, $newLocationId, $moveQuantity)) {
+                if ($inventoryModel->moveStock($productId, $fromLocationId, $newLocationId, $moveQuantity, $inventoryId)) {
                     $message = 'Stocul a fost mutat cu succes.';
                     $messageType = 'success';
                 } else {

--- a/models/Product.php
+++ b/models/Product.php
@@ -794,6 +794,42 @@ class Product {
     }
 
     /**
+     * Update product status
+     * @param int $productId Product ID
+     * @param string $status New status (active/inactive/discontinued)
+     * @return bool Success status
+     */
+    public function updateStatus(int $productId, string $status): bool {
+        $query = "UPDATE {$this->table} SET status = :status, updated_at = NOW() WHERE product_id = :id";
+
+        try {
+            $old = $this->findById($productId);
+            $stmt = $this->conn->prepare($query);
+            $stmt->bindValue(':id', $productId, PDO::PARAM_INT);
+            $stmt->bindValue(':status', $status);
+            $result = $stmt->execute();
+
+            if ($result) {
+                $userId = $_SESSION['user_id'] ?? 0;
+                logActivity(
+                    $userId,
+                    'update',
+                    'product',
+                    $productId,
+                    'Status updated',
+                    ['status' => $old['status'] ?? null],
+                    ['status' => $status]
+                );
+            }
+
+            return $result;
+        } catch (PDOException $e) {
+            error_log("Error updating product status: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
      * Delete a product
      * @param int $productId Product ID
      * @return bool Success status

--- a/products.php
+++ b/products.php
@@ -147,29 +147,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                     break;
                                     
                                 case 'activate':
-                                    // Use quantity > 0 as "active" status
                                     error_log("Attempting to activate product ID: $productId");
-                                    $product = $productModel->findById($productId);
-                                    if ($product) {
-                                        // If quantity is 0, set it to 1 to "activate"
-                                        $newQuantity = max(1, $product['quantity']);
-                                        if ($productModel->updateProduct($productId, ['quantity' => $newQuantity])) {
-                                            $successCount++;
-                                            error_log("Successfully activated product ID: $productId");
-                                        } else {
-                                            $errorCount++;
-                                            error_log("Failed to activate product ID: $productId");
-                                        }
+                                    if ($productModel->updateStatus($productId, 'active')) {
+                                        $successCount++;
+                                        error_log("Successfully activated product ID: $productId");
                                     } else {
                                         $errorCount++;
-                                        error_log("Product not found for activation: $productId");
+                                        error_log("Failed to activate product ID: $productId");
                                     }
                                     break;
-                                    
+
                                 case 'deactivate':
-                                    // Set quantity to 0 to "deactivate"
                                     error_log("Attempting to deactivate product ID: $productId");
-                                    if ($productModel->updateProduct($productId, ['quantity' => 0])) {
+                                    if ($productModel->updateStatus($productId, 'inactive')) {
                                         $successCount++;
                                         error_log("Successfully deactivated product ID: $productId");
                                     } else {


### PR DESCRIPTION
## Summary
- adjust bulk product activation/deactivation to use the product status field
- add `updateStatus` method to `Product` model
- extend `moveStock` to optionally operate on a specific inventory record
- pass inventory id when moving stock