### PR TITLE
Add shelf_level column to inventory

### DIFF
--- a/api/qc_management.php
+++ b/api/qc_management.php
@@ -353,12 +353,13 @@ function approveItems($db, $input) {
                 } else {
                     // Create new inventory record
                     $stmt = $db->prepare("
-                        INSERT INTO inventory (product_id, location_id, quantity, batch_number, expiry_date, received_at)
-                        VALUES (:product_id, :location_id, :quantity, :batch_number, :expiry_date, NOW())
+                        INSERT INTO inventory (product_id, location_id, shelf_level, quantity, batch_number, expiry_date, received_at)
+                        VALUES (:product_id, :location_id, :shelf_level, :quantity, :batch_number, :expiry_date, NOW())
                     ");
                     $stmt->execute([
                         ':product_id' => $productId,
                         ':location_id' => $targetLocationId,
+                        ':shelf_level' => 'middle',
                         ':quantity' => $item['received_quantity'],
                         ':batch_number' => $item['batch_number'],
                         ':expiry_date' => $item['expiry_date']

--- a/api/receiving/receive_item.php
+++ b/api/receiving/receive_item.php
@@ -268,16 +268,17 @@ try {
             // Create new inventory record
             $stmt = $db->prepare("
                 INSERT INTO inventory (
-                    product_id, location_id, quantity, batch_number, 
+                    product_id, location_id, shelf_level, quantity, batch_number,
                     expiry_date, received_at
                 ) VALUES (
-                    :product_id, :location_id, :quantity, :batch_number,
+                    :product_id, :location_id, :shelf_level, :quantity, :batch_number,
                     :expiry_date, NOW()
                 )
             ");
             $stmt->execute([
                 ':product_id' => $orderItem['main_product_id'],
                 ':location_id' => $location['id'],
+                ':shelf_level' => 'middle',
                 ':quantity' => $receivedQuantity,
                 ':batch_number' => $batchNumber ?: null,
                 ':expiry_date' => $expiryDate ?: null

--- a/database/migrations/2025_07_18_110000_add_shelf_level_to_inventory.php
+++ b/database/migrations/2025_07_18_110000_add_shelf_level_to_inventory.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Migration: Add shelf_level column to inventory table
+ */
+class AddShelfLevelToInventory {
+    public function up(PDO $pdo): void {
+        $pdo->exec("ALTER TABLE inventory ADD COLUMN shelf_level ENUM('top','middle','bottom') NOT NULL DEFAULT 'middle' AFTER location_id");
+        // Optional index for shelf_level queries
+        $pdo->exec("CREATE INDEX IF NOT EXISTS idx_shelf_level ON inventory (shelf_level)");
+    }
+
+    public function down(PDO $pdo): void {
+        // Drop index if exists - MySQL syntax may vary but safe
+        try { $pdo->exec('DROP INDEX idx_shelf_level ON inventory'); } catch (Exception $e) {}
+        $pdo->exec("ALTER TABLE inventory DROP COLUMN shelf_level");
+    }
+}
+return new AddShelfLevelToInventory();

--- a/models/Inventory.php
+++ b/models/Inventory.php
@@ -191,6 +191,13 @@ class Inventory {
         $batchNumber = $data['batch_number'] ?? null;
         $lotNumber   = $data['lot_number']   ?? null;
         $expiryDate  = $data['expiry_date']  ?? null;
+        $shelfLevel  = $data['shelf_level']  ?? 'middle';
+
+        // Validate shelf level
+        $validLevels = ['top', 'middle', 'bottom'];
+        if (!in_array($shelfLevel, $validLevels)) {
+            $shelfLevel = 'middle';
+        }
 
         // Handle empty strings as null for date fields
         if (empty($expiryDate)) {
@@ -203,13 +210,14 @@ class Inventory {
             }
 
             // Insert inventory record
-            $query = "INSERT INTO {$this->inventoryTable} 
-                      (product_id, location_id, quantity, batch_number, lot_number, expiry_date, received_at) 
-                      VALUES (:product_id, :location_id, :quantity, :batch_number, :lot_number, :expiry_date, :received_at)";
+            $query = "INSERT INTO {$this->inventoryTable}
+                      (product_id, location_id, shelf_level, quantity, batch_number, lot_number, expiry_date, received_at)
+                      VALUES (:product_id, :location_id, :shelf_level, :quantity, :batch_number, :lot_number, :expiry_date, :received_at)";
 
             $stmt = $this->conn->prepare($query);
             $stmt->bindParam(':product_id', $data['product_id'], PDO::PARAM_INT);
             $stmt->bindParam(':location_id', $data['location_id'], PDO::PARAM_INT);
+            $stmt->bindParam(':shelf_level', $shelfLevel, PDO::PARAM_STR);
             $stmt->bindParam(':quantity', $data['quantity'], PDO::PARAM_INT);
             $stmt->bindParam(':batch_number', $batchNumber, PDO::PARAM_STR);
             $stmt->bindParam(':lot_number', $lotNumber, PDO::PARAM_STR);

--- a/models/MultiWarehouseSmartBillService.php
+++ b/models/MultiWarehouseSmartBillService.php
@@ -222,13 +222,14 @@ class MultiWarehouseSmartBillService extends SmartBillService {
             $locationId = $this->getOrCreateWarehouseLocation($warehouse);
             
             $query = "INSERT INTO inventory (
-                        product_id, 
-                        location_id, 
-                        quantity, 
+                        product_id,
+                        location_id,
+                        shelf_level,
+                        quantity,
                         received_at,
                         batch_number
-                    ) VALUES (?, ?, ?, NOW(), ?)
-                    ON DUPLICATE KEY UPDATE 
+                    ) VALUES (?, ?, 'middle', ?, NOW(), ?)
+                    ON DUPLICATE KEY UPDATE
                         quantity = VALUES(quantity),
                         received_at = NOW()";
             

--- a/models/SmartBillService.php
+++ b/models/SmartBillService.php
@@ -360,13 +360,14 @@ class SmartBillService {
             $locationId = $this->getOrCreateWarehouseLocation($warehouse);
             
             $query = "INSERT INTO inventory (
-                        product_id, 
-                        location_id, 
-                        quantity, 
+                        product_id,
+                        location_id,
+                        shelf_level,
+                        quantity,
                         received_at,
                         batch_number
-                    ) VALUES (?, ?, ?, NOW(), ?)
-                    ON DUPLICATE KEY UPDATE 
+                    ) VALUES (?, ?, 'middle', ?, NOW(), ?)
+                    ON DUPLICATE KEY UPDATE
                         quantity = VALUES(quantity),
                         received_at = NOW()";
             


### PR DESCRIPTION
## Summary
- add migration for new `shelf_level` column
- support shelf level when adding stock
- insert default shelf level in receiving and QC flows
- ensure SmartBill services set shelf level

## Testing
- `composer install`
- `composer test` *(fails: HealthEndpointTest::testHealthEndpoint)*

------
https://chatgpt.com/codex/tasks/task_e_687d3b9b34648320a8e5468b1616553b