### PR TITLE
Enable VAT selection for purchase orders

### DIFF
--- a/database/migrations/2025_07_21_150000_add_tax_rate_to_purchase_orders.php
+++ b/database/migrations/2025_07_21_150000_add_tax_rate_to_purchase_orders.php
@@ -1,0 +1,12 @@
+<?php
+class AddTaxRateToPurchaseOrdersMigration {
+    public function up(PDO $pdo) {
+        echo "\u{1F4B0} Adding tax_rate column to purchase_orders...\n";
+        $pdo->exec("ALTER TABLE purchase_orders ADD COLUMN tax_rate DECIMAL(5,2) DEFAULT 19 AFTER pdf_path");
+    }
+    public function down(PDO $pdo) {
+        echo "\u{1F5D1}\uFE0F  Removing tax_rate column from purchase_orders...\n";
+        $pdo->exec("ALTER TABLE purchase_orders DROP COLUMN tax_rate");
+    }
+}
+return new AddTaxRateToPurchaseOrdersMigration();

--- a/models/PurchaseOrder.php
+++ b/models/PurchaseOrder.php
@@ -134,11 +134,11 @@ class PurchaseOrder {
             $query = "INSERT INTO {$this->table} (
                 order_number, seller_id, total_amount, currency, custom_message,
                 email_subject, status, expected_delivery_date, email_recipient,
-                notes, pdf_path, created_by
+                notes, pdf_path, tax_rate, created_by
             ) VALUES (
                 :order_number, :seller_id, :total_amount, :currency, :custom_message,
                 :email_subject, :status, :expected_delivery_date, :email_recipient,
-                :notes, :pdf_path, :created_by
+                :notes, :pdf_path, :tax_rate, :created_by
             )";
             
             $stmt = $this->conn->prepare($query);
@@ -153,6 +153,7 @@ class PurchaseOrder {
             $stmt->bindValue(':email_recipient', $orderData['email_recipient'] ?? null);
             $stmt->bindValue(':notes', $orderData['notes'] ?? null);
             $stmt->bindValue(':pdf_path', $orderData['pdf_path'] ?? null);
+            $stmt->bindValue(':tax_rate', $orderData['tax_rate'] ?? 19);
             $stmt->bindValue(':created_by', $_SESSION['user_id'], PDO::PARAM_INT);
             
             if (!$stmt->execute()) {

--- a/purchase_orders.php
+++ b/purchase_orders.php
@@ -117,6 +117,16 @@ function generatePurchaseOrderPdf(array $orderInfo, array $items): ?string {
         $pdf->Cell(140, 8, 'TOTAL:', 1, 0, 'R');
         $pdf->Cell(30, 8, number_format($grandTotal, 2) . ' RON', 1, 1, 'R');
 
+        // VAT
+        $vatRate = isset($orderInfo['tax_rate']) ? floatval($orderInfo['tax_rate']) : 19;
+        $vatAmount = $grandTotal * ($vatRate / 100);
+        $pdf->SetFont('Arial', '', 10);
+        $pdf->Cell(140, 8, 'TVA (' . $vatRate . '%):', 1, 0, 'R');
+        $pdf->Cell(30, 8, number_format($vatAmount, 2) . ' RON', 1, 1, 'R');
+        $pdf->SetFont('Arial', 'B', 10);
+        $pdf->Cell(140, 8, 'TOTAL CU TVA:', 1, 0, 'R');
+        $pdf->Cell(30, 8, number_format($grandTotal + $vatAmount, 2) . ' RON', 1, 1, 'R');
+
         // Try multiple writable locations
         $fileName = 'po_' . $orderInfo['order_number'] . '_' . time() . '.pdf';
         $writableLocations = [
@@ -242,6 +252,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $customMessage = trim($_POST['custom_message'] ?? '');
                 $emailSubject = trim($_POST['email_subject'] ?? '');
                 $expectedDeliveryDate = $_POST['expected_delivery_date'] ?? null;
+                $taxRate = floatval($_POST['tax_rate'] ?? 19);
                 $items = $_POST['items'] ?? [];
                 
                 if ($sellerId <= 0) {
@@ -340,6 +351,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'email_subject' => $emailSubject,
                     'expected_delivery_date' => $expectedDeliveryDate,
                     'email_recipient' => $emailRecipient,
+                    'tax_rate' => $taxRate,
                     'items' => $processedItems
                 ];
                 
@@ -733,6 +745,17 @@ require_once __DIR__ . '/includes/header.php';
                             <div class="form-group">
                                 <label for="expected_delivery_date" class="form-label">Data Livrării Estimate</label>
                                 <input type="date" name="expected_delivery_date" id="expected_delivery_date" class="form-control">
+                            </div>
+                        </div>
+
+                        <!-- TVA Rate -->
+                        <div class="row">
+                            <div class="form-group">
+                                <label for="tax_rate" class="form-label">TVA</label>
+                                <select name="tax_rate" id="tax_rate" class="form-control">
+                                    <option value="19" selected>19% TVA</option>
+                                    <option value="0">0% TVA</option>
+                                </select>
                             </div>
                         </div>
 


### PR DESCRIPTION
## Summary
- add migration for purchase order `tax_rate`
- support tax rate on order creation
- display VAT in purchase order PDF
- provide TVA selection in UI