### PR TITLE
Enable remote printer URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ CARGUS_API_URL=https://urgentcargus.azure-api.net/api/
 
 # API key used for verifying incoming webhooks
 WMS_API_KEY=wms_webhook_2025_secure!
+
+# Print server configuration
+PRINT_SERVER_URL=http://86.124.196.102:3000/print_server.php
+DEFAULT_PRINTER=godex

--- a/config/config.php
+++ b/config/config.php
@@ -101,9 +101,13 @@ return [
 
     // call this to get your PDO instance:
     'connection_factory' => $connectionFactory,
-    
+
+    // Print server configuration
+    'print_server_url' => getenv('PRINT_SERVER_URL') ?: 'http://86.124.196.102:3000/print_server.php',
+    'default_printer'  => getenv('DEFAULT_PRINTER') ?: 'godex',
+
     // Cargus API credentials (set via environment variables or directly here)
-    
+
     'cargus' => [
         'username' => getenv('CARGUS_USER') ?: '',
         'password' => getenv('CARGUS_PASS') ?: '',


### PR DESCRIPTION
## Summary
- add PRINT_SERVER_URL and DEFAULT_PRINTER env vars
- use remote print server in label print API
- simplify production receipt printing
- send network_identifier from client

## Testing
- `composer test` *(fails: HealthEndpointTest::testHealthEndpoint)*

------
https://chatgpt.com/codex/tasks/task_e_687dea8b06e88320a924b5e5d9b21b73