### PR TITLE
Add barrel dimension presets and fix hazardous insert

### DIFF
--- a/api/barrel_dimensions.php
+++ b/api/barrel_dimensions.php
@@ -1,0 +1,81 @@
+<?php
+header('Content-Type: application/json');
+header('Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__));
+}
+require_once BASE_PATH . '/bootstrap.php';
+
+session_start();
+if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
+    http_response_code(403);
+    echo json_encode(['error' => 'Access denied']);
+    exit;
+}
+
+$config = require BASE_PATH . '/config/config.php';
+$db = $config['connection_factory']();
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+try {
+    switch ($method) {
+        case 'GET':
+            handleGet($db);
+            break;
+        case 'POST':
+            handlePost($db);
+            break;
+        case 'DELETE':
+            handleDelete($db);
+            break;
+        default:
+            http_response_code(405);
+            echo json_encode(['error' => 'Method not allowed']);
+    }
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Internal server error: ' . $e->getMessage()]);
+}
+
+function handleGet($db) {
+    $stmt = $db->query("SELECT id, label, length_cm, width_cm, height_cm FROM barrel_dimensions ORDER BY id ASC");
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode(['data' => $rows]);
+}
+
+function handlePost($db) {
+    $input = json_decode(file_get_contents('php://input'), true);
+    if (!$input || !isset($input['label'], $input['length_cm'], $input['width_cm'], $input['height_cm'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid input']);
+        return;
+    }
+    $stmt = $db->prepare("INSERT INTO barrel_dimensions (label, length_cm, width_cm, height_cm) VALUES (?, ?, ?, ?)");
+    $ok = $stmt->execute([
+        $input['label'],
+        $input['length_cm'],
+        $input['width_cm'],
+        $input['height_cm']
+    ]);
+    if ($ok) {
+        echo json_encode(['success' => true, 'id' => $db->lastInsertId()]);
+    } else {
+        http_response_code(500);
+        echo json_encode(['error' => 'Failed to add dimension']);
+    }
+}
+
+function handleDelete($db) {
+    $id = $_GET['id'] ?? null;
+    if (!$id) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Missing id']);
+        return;
+    }
+    $stmt = $db->prepare("DELETE FROM barrel_dimensions WHERE id = ?");
+    $ok = $stmt->execute([$id]);
+    echo json_encode(['success' => (bool)$ok]);
+}

--- a/api/product_units.php
+++ b/api/product_units.php
@@ -180,11 +180,11 @@ function handlePost($db) {
         $input['dimensions_width'] ?? null,
         $input['dimensions_height'] ?? null,
         $input['max_stack_height'] ?? 1,
-        isset($input['fragile']) ? (bool)$input['fragile'] : false,
-        isset($input['hazardous']) ? (bool)$input['hazardous'] : false,
-        isset($input['temperature_controlled']) ? (bool)$input['temperature_controlled'] : false,
+        !empty($input['fragile']) ? 1 : 0,
+        !empty($input['hazardous']) ? 1 : 0,
+        !empty($input['temperature_controlled']) ? 1 : 0,
         $input['packaging_cost'] ?? 0.00,
-        isset($input['active']) ? (bool)$input['active'] : true
+        isset($input['active']) ? (!empty($input['active']) ? 1 : 0) : 1
     ]);
     
     if ($result) {
@@ -228,7 +228,7 @@ function handlePut($db) {
             $updateFields[] = "$field = ?";
             
             if (in_array($field, ['fragile', 'hazardous', 'temperature_controlled', 'active'])) {
-                $updateValues[] = (bool)$input[$field];
+                $updateValues[] = !empty($input[$field]) ? 1 : 0;
             } else {
                 $updateValues[] = $input[$field];
             }

--- a/database/migrations/2025_08_30_000001_create_barrel_dimensions_table.php
+++ b/database/migrations/2025_08_30_000001_create_barrel_dimensions_table.php
@@ -1,0 +1,23 @@
+<?php
+class CreateBarrelDimensionsTableMigration {
+    public function up(PDO $pdo) {
+        echo "Creating barrel_dimensions table...\n";
+        $pdo->exec("CREATE TABLE barrel_dimensions (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            label VARCHAR(50) NOT NULL,
+            length_cm DECIMAL(6,2) NOT NULL,
+            width_cm DECIMAL(6,2) NOT NULL,
+            height_cm DECIMAL(6,2) NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
+        echo "barrel_dimensions table created!\n";
+    }
+
+    public function down(PDO $pdo) {
+        echo "Dropping barrel_dimensions table...\n";
+        $pdo->exec("DROP TABLE IF EXISTS barrel_dimensions;");
+        echo "barrel_dimensions table dropped!\n";
+    }
+}
+return new CreateBarrelDimensionsTableMigration();

--- a/product-units.php
+++ b/product-units.php
@@ -636,12 +636,18 @@ $currentPage = 'product-units';
                     </div>
                     <div class="form-group">
                         <label for="volumePerUnit">Volum per Unitate (L)</label>
-                        <input type="number" 
-                               id="volumePerUnit" 
-                               name="volume_per_unit" 
-                               step="0.001" 
-                               min="0" 
+                    <input type="number"
+                               id="volumePerUnit"
+                               name="volume_per_unit"
+                               step="0.001"
+                               min="0"
                                placeholder="0.000">
+                    </div>
+                    <div class="form-group">
+                        <label for="barrelDimensionSelect">Dimensiune Standard Bidon</label>
+                        <select id="barrelDimensionSelect">
+                            <option value="">Selectează...</option>
+                        </select>
                     </div>
                     <div class="form-group">
                         <label for="dimensionsLength">Lungime (cm)</label>


### PR DESCRIPTION
## Summary
- rename dimensions tab label
- allow adding standard barrel dimensions
- expose barrel_dimensions API
- support selecting preset barrel dimensions when adding product units
- fix hazardous boolean insert
- migrate new `barrel_dimensions` table