### PR TITLE
Add per-level capacity and dedicated product

### DIFF
--- a/database/migrations/2025_09_02_000000_add_product_assignment_to_location_level_settings.php
+++ b/database/migrations/2025_09_02_000000_add_product_assignment_to_location_level_settings.php
@@ -1,0 +1,15 @@
+<?php
+class AddProductAssignmentToLocationLevelSettingsMigration {
+    public function up(PDO $pdo) {
+        $pdo->exec("ALTER TABLE location_level_settings
+            ADD COLUMN dedicated_product_id INT DEFAULT NULL AFTER items_capacity,
+            ADD COLUMN allow_other_products BOOLEAN DEFAULT TRUE AFTER dedicated_product_id,
+            ADD INDEX idx_dedicated_product_id (dedicated_product_id)");
+    }
+    public function down(PDO $pdo) {
+        $pdo->exec("ALTER TABLE location_level_settings
+            DROP COLUMN allow_other_products,
+            DROP COLUMN dedicated_product_id");
+    }
+}
+return new AddProductAssignmentToLocationLevelSettingsMigration();

--- a/models/Location.php
+++ b/models/Location.php
@@ -1436,6 +1436,8 @@ class Location {
             'height_mm' => 300,
             'max_weight_kg' => 50,
             'items_capacity' => null,
+            'dedicated_product_id' => null,
+            'allow_other_products' => true,
             'enable_auto_repartition' => false,
             'repartition_trigger_threshold' => 80,
             'priority_order' => $totalLevels - $levelNumber + 1

--- a/models/LocationLevelSettings.php
+++ b/models/LocationLevelSettings.php
@@ -89,12 +89,14 @@ class LocationLevelSettings {
         $query = "INSERT INTO {$this->table} 
                   (location_id, level_number, level_name, storage_policy, allowed_product_types,
                    max_different_products, length_mm, depth_mm, height_mm, max_weight_kg, items_capacity,
+                   dedicated_product_id, allow_other_products,
                    volume_min_liters, volume_max_liters, weight_min_kg, weight_max_kg,
                    enable_auto_repartition, repartition_trigger_threshold, priority_order,
                    requires_special_handling, temperature_controlled, notes)
-                  VALUES 
+                  VALUES
                   (:location_id, :level_number, :level_name, :storage_policy, :allowed_product_types,
                    :max_different_products, :length_mm, :depth_mm, :height_mm, :max_weight_kg, :items_capacity,
+                   :dedicated_product_id, :allow_other_products,
                    :volume_min_liters, :volume_max_liters, :weight_min_kg, :weight_max_kg,
                    :enable_auto_repartition, :repartition_trigger_threshold, :priority_order,
                    :requires_special_handling, :temperature_controlled, :notes)
@@ -108,6 +110,8 @@ class LocationLevelSettings {
                   height_mm = VALUES(height_mm),
                   max_weight_kg = VALUES(max_weight_kg),
                   items_capacity = VALUES(items_capacity),
+                  dedicated_product_id = VALUES(dedicated_product_id),
+                  allow_other_products = VALUES(allow_other_products),
                   volume_min_liters = VALUES(volume_min_liters),
                   volume_max_liters = VALUES(volume_max_liters),
                   weight_min_kg = VALUES(weight_min_kg),
@@ -135,6 +139,8 @@ class LocationLevelSettings {
                 ':height_mm' => $settings['height_mm'] ?? 0,
                 ':max_weight_kg' => $settings['max_weight_kg'] ?? 0,
                 ':items_capacity' => $settings['items_capacity'] ?? null,
+                ':dedicated_product_id' => $settings['dedicated_product_id'] ?? null,
+                ':allow_other_products' => $settings['allow_other_products'] ?? true,
                 ':volume_min_liters' => $settings['volume_min_liters'] ?? null,
                 ':volume_max_liters' => $settings['volume_max_liters'] ?? null,
                 ':weight_min_kg' => $settings['weight_min_kg'] ?? null,
@@ -347,6 +353,8 @@ class LocationLevelSettings {
                 'height_mm' => 300,
                 'max_weight_kg' => 50,
                 'items_capacity' => null,
+                'dedicated_product_id' => null,
+                'allow_other_products' => true,
                 'enable_auto_repartition' => false,
                 'repartition_trigger_threshold' => 80,
                 'priority_order' => $totalLevels - $level + 1 // Bottom = highest priority

--- a/scripts/locations.js
+++ b/scripts/locations.js
@@ -194,6 +194,8 @@ document.getElementById('locationForm').addEventListener('submit', function(even
                 height_mm: parseInt(document.getElementById(`level_${lvl}_height`)?.value) || 0,
                 max_weight_kg: parseFloat(document.getElementById(`level_${lvl}_weight`)?.value) || 0,
                 items_capacity: parseInt(document.getElementById(`level_${lvl}_capacity`)?.value) || null,
+                dedicated_product_id: document.getElementById(`level_${lvl}_dedicated_product`)?.value || null,
+                allow_other_products: document.getElementById(`level_${lvl}_allow_others`)?.checked ?? true,
                 volume_min_liters: parseFloat(document.querySelector(`input[name="level_${lvl}_volume_min"]`)?.value) || null,
                 volume_max_liters: parseFloat(document.querySelector(`input[name="level_${lvl}_volume_max"]`)?.value) || null,
                 enable_auto_repartition: document.getElementById(`level_${lvl}_auto_repartition`)?.checked || false,
@@ -1054,6 +1056,16 @@ function createLevelSettingsDiv(levelNumber) {
                         <input type="number" name="level_${levelNumber}_capacity" id="level_${levelNumber}_capacity"
                                class="form-control" min="0">
                     </div>
+                    <div class="form-group">
+                        <label class="form-label">Produs dedicat</label>
+                        <select name="level_${levelNumber}_dedicated_product" id="level_${levelNumber}_dedicated_product" class="form-control">
+                            ${generateInternalProductOptions()}
+                        </select>
+                        <div class="form-check" style="margin-top:0.5rem;">
+                            <input type="checkbox" id="level_${levelNumber}_allow_others" name="level_${levelNumber}_allow_others" checked>
+                            <label for="level_${levelNumber}_allow_others" class="form-label">Permite alte produse</label>
+                        </div>
+                    </div>
                 </div>
                 
                 <div class="settings-section">
@@ -1180,6 +1192,23 @@ function distributeItemCapacity() {
             input.value = perLevel;
         }
     }
+}
+
+function generateInternalProductOptions() {
+    if (typeof window.allProducts !== 'undefined') {
+        let options = '<option value="">-- Produs intern --</option>';
+        window.allProducts.forEach(p => {
+            options += `<option value="${p.product_id}">${escapeHtml(p.name)} (${escapeHtml(p.sku)})</option>`;
+        });
+        return options;
+    }
+    return '<option value="">-- Produs intern --</option>';
+}
+
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
 }
 
 /**
@@ -1371,6 +1400,12 @@ function populateLevelSettings(levelSettings) {
 
         const capacityInput = document.getElementById(`level_${level}_capacity`);
         if (capacityInput) capacityInput.value = setting.items_capacity || '';
+
+        const productSelect = document.getElementById(`level_${level}_dedicated_product`);
+        if (productSelect) productSelect.value = setting.dedicated_product_id || '';
+
+        const allowOthersCheckbox = document.getElementById(`level_${level}_allow_others`);
+        if (allowOthersCheckbox) allowOthersCheckbox.checked = setting.allow_other_products !== false;
         
         // Restrictions
         const volumeMinInput = document.querySelector(`input[name="level_${level}_volume_min"]`);
@@ -1642,6 +1677,9 @@ document.getElementById('locationForm')?.addEventListener('submit', function(eve
                 storage_policy: document.querySelector(`input[name="level_${level}_storage_policy"]:checked`)?.value || 'multiple_products',
                 height_mm: parseInt(document.getElementById(`level_${level}_height`)?.value) || 0,
                 max_weight_kg: parseFloat(document.getElementById(`level_${level}_weight`)?.value) || 0,
+                items_capacity: parseInt(document.getElementById(`level_${level}_capacity`)?.value) || null,
+                dedicated_product_id: document.getElementById(`level_${level}_dedicated_product`)?.value || null,
+                allow_other_products: document.getElementById(`level_${level}_allow_others`)?.checked ?? true,
                 volume_min_liters: parseFloat(document.querySelector(`input[name="level_${level}_volume_min"]`)?.value) || null,
                 volume_max_liters: parseFloat(document.querySelector(`input[name="level_${level}_volume_max"]`)?.value) || null,
                 enable_auto_repartition: document.getElementById(`level_${level}_auto_repartition`)?.checked || false,
@@ -1669,6 +1707,7 @@ window.selectStoragePolicy = selectStoragePolicy;
 window.distributeLevelHeights = distributeLevelHeights;
 window.distributeWeightCapacity = distributeWeightCapacity;
 window.distributeItemCapacity = distributeItemCapacity;
+window.generateInternalProductOptions = generateInternalProductOptions;
 
 // QR CODES
 window.updateLocationQr = updateLocationQr;


### PR DESCRIPTION
## Summary
- add migration to store dedicated_product_id and allow_other_products
- support new fields in LocationLevelSettings model and Location model
- fetch products in locations page and expose to JS
- update level settings UI to set items per level and dedicated product

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688863f2a0cc8320a78a2d93da08d8b9