### PR TITLE
Fix level mapping when adding stock

### DIFF
--- a/api/subdivision_info.php
+++ b/api/subdivision_info.php
@@ -26,16 +26,13 @@ if ($locationId <= 0 || $levelNumber <= 0) {
 }
 
 require_once BASE_PATH . '/models/LocationSubdivision.php';
+require_once BASE_PATH . '/models/LocationLevelSettings.php';
 
 $subModel = new LocationSubdivision($db);
 
-// Determine shelf level name from number
-$levelName = match($levelNumber) {
-    1 => 'bottom',
-    2 => 'middle',
-    3 => 'top',
-    default => 'middle'
-};
+// Determine shelf level name from number using dynamic settings
+$lls = new LocationLevelSettings($db);
+$levelName = $lls->getLevelNameByNumber($locationId, $levelNumber) ?? 'middle';
 
 try {
     $query = "SELECT ls.*, p.name AS product_name,

--- a/models/Inventory.php
+++ b/models/Inventory.php
@@ -198,12 +198,16 @@ class Inventory {
         $batchNumber = $data['batch_number'] ?? null;
         $lotNumber   = $data['lot_number']   ?? null;
         $expiryDate  = $data['expiry_date']  ?? null;
-        $shelfLevel  = $data['shelf_level']  ?? 'middle';
+        $shelfLevel  = $data['shelf_level']  ?? null;
         $subdivision = $data['subdivision_number'] ?? null;
 
-        // Validate shelf level
-        $validLevels = ['top', 'middle', 'bottom'];
-        if (!in_array($shelfLevel, $validLevels)) {
+        // Resolve numeric level to custom level name if needed
+        if (is_numeric($shelfLevel)) {
+            require_once __DIR__ . '/LocationLevelSettings.php';
+            $lls = new LocationLevelSettings($this->conn);
+            $name = $lls->getLevelNameByNumber((int)$data['location_id'], (int)$shelfLevel);
+            $shelfLevel = $name ?: 'middle';
+        } elseif ($shelfLevel === null) {
             $shelfLevel = 'middle';
         }
 

--- a/models/LocationLevelSettings.php
+++ b/models/LocationLevelSettings.php
@@ -57,7 +57,7 @@ class LocationLevelSettings {
      * @return array|null
      */
     public function getLevelSetting(int $locationId, int $levelNumber): ?array {
-        $query = "SELECT * FROM {$this->table} 
+        $query = "SELECT * FROM {$this->table}
                   WHERE location_id = :location_id AND level_number = :level_number";
         
         try {
@@ -75,6 +75,25 @@ class LocationLevelSettings {
             return $result ?: null;
         } catch (PDOException $e) {
             error_log("Error getting level setting: " . $e->getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Fetch the custom level name for a location level
+     *
+     * @param int $locationId
+     * @param int $levelNumber
+     * @return string|null
+     */
+    public function getLevelNameByNumber(int $locationId, int $levelNumber): ?string {
+        try {
+            $stmt = $this->conn->prepare("SELECT level_name FROM {$this->table} WHERE location_id = :loc AND level_number = :lvl LIMIT 1");
+            $stmt->execute([':loc' => $locationId, ':lvl' => $levelNumber]);
+            $name = $stmt->fetchColumn();
+            return $name !== false ? $name : null;
+        } catch (PDOException $e) {
+            error_log("Error fetching level name: " . $e->getMessage());
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- support fetching level names from `location_level_settings`
- use dynamic level names when adding stock
- ensure subdivision API resolves levels dynamically

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688b12d2c9a88320a233d1a49b0e4742