### PR TITLE
Use dynamic level names

### DIFF
--- a/models/AutoRepartitionService.php
+++ b/models/AutoRepartitionService.php
@@ -186,7 +186,7 @@ class AutoRepartitionService {
      * @return array
      */
     private function analyzeLevelInventory(int $locationId, array $levelSettings): array {
-        $shelfLevel = $this->getLevelName($levelSettings['level_number']);
+        $shelfLevel = $this->levelSettings->getLevelNameByNumber($locationId, $levelSettings['level_number']) ?? ('Level ' . $levelSettings['level_number']);
         
         $query = "SELECT 
                     i.product_id,
@@ -435,8 +435,8 @@ class AutoRepartitionService {
         try {
             $this->conn->beginTransaction();
             
-            $fromShelfLevel = $this->getLevelName($move['from_level']);
-            $toShelfLevel = $this->getLevelName($move['to_level']);
+            $fromShelfLevel = $this->levelSettings->getLevelNameByNumber($move['location_id'] ?? 0, $move['from_level']) ?? ('Level ' . $move['from_level']);
+            $toShelfLevel = $this->levelSettings->getLevelNameByNumber($move['location_id'] ?? 0, $move['to_level']) ?? ('Level ' . $move['to_level']);
             
             // Update the inventory record
             $updateQuery = "UPDATE inventory 
@@ -530,17 +530,4 @@ class AutoRepartitionService {
         // Could also log to a dedicated repartition_log table if needed
     }
     
-    /**
-     * Convert level number to shelf level name
-     * @param int $levelNumber
-     * @return string
-     */
-    private function getLevelName(int $levelNumber): string {
-        return match($levelNumber) {
-            1 => 'bottom',
-            2 => 'middle',
-            3 => 'top',
-            default => 'middle'
-        };
-    }
 }

--- a/models/Inventory.php
+++ b/models/Inventory.php
@@ -201,7 +201,7 @@ class Inventory {
         $shelfLevel  = $data['shelf_level']  ?? null;
         $subdivision = $data['subdivision_number'] ?? null;
 
-        // Resolve numeric level to custom level name if needed
+        // Resolve numeric level using settings table when provided
         if (is_numeric($shelfLevel)) {
             require_once __DIR__ . '/LocationLevelSettings.php';
             $lls = new LocationLevelSettings($this->conn);

--- a/models/Location.php
+++ b/models/Location.php
@@ -504,7 +504,7 @@ class Location {
      * @return array
      */
     private function getLevelOccupancyData(int $locationId, int $levelNumber): array {
-        $levelName = $this->getLevelName($levelNumber);
+        $levelName = $this->levelSettings->getLevelNameByNumber($locationId, $levelNumber) ?? ('Level ' . $levelNumber);
         
         $query = "SELECT 
                     COALESCE(SUM(i.quantity), 0) as items,
@@ -1508,14 +1508,7 @@ class Location {
      * @param int $levelNumber
      * @return string
      */
-    private function getLevelName(int $levelNumber): string {
-        return match($levelNumber) {
-            1 => 'bottom',
-            2 => 'middle',
-            3 => 'top',
-            default => 'middle'
-        };
-    }
+
 
     /**
      * Enhance location occupancy calculations

--- a/models/LocationLevelSettings.php
+++ b/models/LocationLevelSettings.php
@@ -232,7 +232,7 @@ class LocationLevelSettings {
                                  AND product_id != :product_id LIMIT 1";
                 
                 $existingStmt = $this->conn->prepare($existingQuery);
-                $shelfLevel = $this->getLevelName($levelNumber);
+                $shelfLevel = $this->getLevelNameByNumber($locationId, $levelNumber) ?? ('Level ' . $levelNumber);
                 $existingStmt->execute([
                     ':location_id' => $locationId,
                     ':shelf_level' => $shelfLevel,
@@ -315,7 +315,7 @@ class LocationLevelSettings {
      * @return float
      */
     private function getLevelOccupancy(int $locationId, int $levelNumber): float {
-        $shelfLevel = $this->getLevelName($levelNumber);
+        $shelfLevel = $this->getLevelNameByNumber($locationId, $levelNumber) ?? ('Level ' . $levelNumber);
         
         $query = "SELECT
                     COALESCE(lls.items_capacity, l.capacity / l.levels) as level_capacity,
@@ -347,19 +347,7 @@ class LocationLevelSettings {
         }
     }
     
-    /**
-     * Convert level number to shelf level name
-     * @param int $levelNumber
-     * @return string
-     */
-    private function getLevelName(int $levelNumber): string {
-        return match($levelNumber) {
-            1 => 'bottom',
-            2 => 'middle', 
-            3 => 'top',
-            default => 'middle'
-        };
-    }
+
     
     /**
      * Create default level settings for a new location


### PR DESCRIPTION
## Summary
- fetch shelf level names from location level settings
- remove hardcoded three-level mapping

## Testing
- `composer install`
- `vendor/bin/phpunit --colors=always`


------
https://chatgpt.com/codex/tasks/task_e_688b273f57c483208376839c1e338dcb