### PR TITLE
Add search bar for pending products

### DIFF
--- a/product-units.php
+++ b/product-units.php
@@ -792,6 +792,9 @@ $currentPage = 'product-units';
                 </button>
             </div>
             <div class="modal-body">
+                <div class="stock-search-bar">
+                    <input type="text" id="pendingSearch" class="stock-search-input" placeholder="Caută produs...">
+                </div>
                 <table class="data-table">
                     <thead>
                         <tr>
@@ -803,6 +806,7 @@ $currentPage = 'product-units';
                     <tbody id="pendingProductsList">
                     </tbody>
                 </table>
+                <div id="pendingPagination" class="pagination-wrapper"></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add search input in pending products modal
- filter pending product list by search term with pagination
- reset search when opening or closing modal

## Testing
- `composer test`
- `node --check scripts/product-units.js`


------
https://chatgpt.com/codex/tasks/task_e_688b3a6048b8832093ca46d1acfcb9d3