### PR TITLE
Update warehouse hub layout

### DIFF
--- a/styles/warehouse-css/warehouse_hub.css
+++ b/styles/warehouse-css/warehouse_hub.css
@@ -135,9 +135,9 @@ body {
 /* ===== OPERATIONS GRID ===== */
 .operations-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: var(--grid-gap);
-    max-width: 1000px;
+    max-width: 600px;
     margin: 0 auto;
 }
 
@@ -146,13 +146,17 @@ body {
     background-color: var(--dark-gray);
     border: 2px solid rgba(255, 255, 255, 0.1);
     border-radius: var(--border-radius);
-    padding: 2rem;
+    padding: 1.5rem 1rem;
     text-align: center;
     cursor: pointer;
     transition: all 0.3s ease;
     box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
     position: relative;
     overflow: hidden;
+    height: 170px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
 }
 
 .operation-card::before {
@@ -177,8 +181,8 @@ body {
 
 /* ===== OPERATION CARD CONTENT ===== */
 .operation-icon {
-    font-size: 3.5rem;
-    margin-bottom: 1.5rem;
+    font-size: 3rem;
+    margin-bottom: 0.5rem;
     color: var(--white);
     display: block;
     transition: transform 0.3s ease;
@@ -189,18 +193,14 @@ body {
 }
 
 .operation-title {
-    font-size: 1.5rem;
+    font-size: 1.2rem;
     font-weight: 600;
     color: var(--white);
-    margin-bottom: 1rem;
+    margin-bottom: 0.5rem;
 }
 
 .operation-description {
-    color: var(--light-gray);
-    font-size: 0.95rem;
-    line-height: 1.6;
-    margin-bottom: 2rem;
-    min-height: 60px;
+    display: none;
 }
 
 /* ===== OPERATION STATS ===== */
@@ -355,9 +355,7 @@ body {
     }
 
     .operation-description {
-        font-size: 0.9rem;
-        margin-bottom: 1.5rem;
-        min-height: auto;
+        display: none;
     }
 
     .stat-number {

--- a/warehouse_hub.php
+++ b/warehouse_hub.php
@@ -34,9 +34,6 @@ if (!isset($_SESSION['user_id'])) {
                 <div class="status-indicator" id="picking-status"></div>
                 <span class="material-symbols-outlined operation-icon">shopping_cart</span>
                 <h2 class="operation-title">Picking Comenzi</h2>
-                <p class="operation-description">
-                    Scanează comenzile, localizează produsele și finalizează task-urile de picking cu ghidare pas cu pas.
-                </p>
                 <div class="operation-stats">
                     <div class="stat-item">
                         <span class="stat-number" id="pending-picks">-</span>
@@ -54,9 +51,6 @@ if (!isset($_SESSION['user_id'])) {
                 <div class="status-indicator" id="receiving-status"></div>
                 <span class="material-symbols-outlined operation-icon">inventory_2</span>
                 <h2 class="operation-title">Recepție Marfă</h2>
-                <p class="operation-description">
-                    Procesează livrările primite, verifică produsele și actualizează stocurile cu localizare precisă.
-                </p>
                 <div class="operation-stats">
                     <div class="stat-item">
                         <span class="stat-number" id="pending-receipts">-</span>
@@ -70,13 +64,10 @@ if (!isset($_SESSION['user_id'])) {
             </div>
 
             <!-- Inventory -->
-            <!-- <div class="operation-card inventory-card" data-operation="inventory">
+            <div class="operation-card inventory-card" data-operation="inventory">
                 <div class="status-indicator" id="inventory-status"></div>
                 <span class="material-symbols-outlined operation-icon">inventory</span>
                 <h2 class="operation-title">Căutare Stoc</h2>
-                <p class="operation-description">
-                    Căutări rapide în inventar, verificări de stoc și localizări pentru managementul eficient al depozitului.
-                </p>
                 <div class="operation-stats">
                     <div class="stat-item">
                         <span class="stat-number" id="total-products">-</span>
@@ -87,16 +78,13 @@ if (!isset($_SESSION['user_id'])) {
                         <span class="stat-label">Stoc scăzut</span>
                     </div>
                 </div>
-            </div> -->
+            </div>
 
             <!-- Cycle Count -->
-            <!-- <div class="operation-card cycle-count-card" data-operation="cycle-count">
+            <div class="operation-card cycle-count-card" data-operation="cycle-count">
                 <div class="status-indicator" id="cycle-count-status"></div>
                 <span class="material-symbols-outlined operation-icon">fact_check</span>
                 <h2 class="operation-title">Inventariere Ciclică</h2>
-                <p class="operation-description">
-                    Efectuează inventarieri sistematice pentru menținerea preciziei stocurilor și identificarea discrepanțelor.
-                </p>
                 <div class="operation-stats">
                     <div class="stat-item">
                         <span class="stat-number" id="scheduled-counts">-</span>
@@ -107,7 +95,7 @@ if (!isset($_SESSION['user_id'])) {
                         <span class="stat-label">Diferențe</span>
                     </div>
                 </div>
-            </div> -->
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- simplify layout of warehouse_hub with compact operation cards
- tweak warehouse_hub.css for smaller tiles without descriptions

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688b4f63dcd4832098ee81e0859c1c9e