### PR TITLE
Fix update transaction in locations

### DIFF
--- a/locations.php
+++ b/locations.php
@@ -355,7 +355,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             throw new Exception($subdivisionResult['message']);
                         }
                         
-                        $db->commit();
+                        if ($db->inTransaction()) {
+                            $db->commit();
+                        }
         
                         echo json_encode([
                             'success' => true,


### PR DESCRIPTION
## Summary
- avoid committing transactions when none are active during location update

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688c8ac2ca3c8329ae046916ac242711