### PR TITLE
Enable AJAX submission for locations

### DIFF
--- a/scripts/locations.js
+++ b/scripts/locations.js
@@ -1658,6 +1658,7 @@ function enhanceFormSubmission() {
     if (!form) return;
 
     form.addEventListener('submit', function(event) {
+        event.preventDefault();
         console.log('Form submission started. Created levels:', createdLevels.length);
 
         // Validate form fields across tabs
@@ -1722,6 +1723,27 @@ function enhanceFormSubmission() {
         }
         
         console.log('Form submission data prepared');
+
+        const formData = new FormData(form);
+        formData.append('ajax', '1');
+
+        fetch('locations.php', {
+            method: 'POST',
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            body: formData
+        })
+        .then(resp => resp.json())
+        .then(data => {
+            if (data.success) {
+                window.location.reload();
+            } else {
+                alert(data.message || 'Eroare la salvarea locației');
+            }
+        })
+        .catch(err => {
+            console.error('AJAX submit failed', err);
+            alert('Eroare la salvarea locației');
+        });
     });
 }
 


### PR DESCRIPTION
## Summary
- add helper to send JSON responses from PHP
- send JSON after create and update actions in `locations.php`
- convert `locationForm` to submit via `fetch`

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688c8ed56f648329851ab8bfe4bc1f37