### PR TITLE
Use product unit data for weight and parcel sizing

### DIFF
--- a/models/Order.php
+++ b/models/Order.php
@@ -378,7 +378,7 @@ class Order
                 p.name as product_name,
                 p.code as product_code,
                 p.category as product_category,
-                COALESCE(pu.weight_per_unit, ut.default_weight_per_unit, 0.5) as weight_per_unit,
+                pu.weight_per_unit,
                 COALESCE(pu.volume_per_unit, 0) as volume_per_unit,
                 ut.unit_name,
                 ut.packaging_type,


### PR DESCRIPTION
## Summary
- look up product weights and dimensions directly from `product_units`
- pack parcels using real size and max stack height limits
- generate AWB parcel codes with per‑parcel measurements

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688dfa1e5a7083208f1cdfd40a613993