### PR TITLE
Include postal code and address text when importing orders

### DIFF
--- a/api/awb/generate_awb.php
+++ b/api/awb/generate_awb.php
@@ -81,8 +81,8 @@ try {
             $manualFields = [
                 'recipient_name', 'recipient_contact_person', 'recipient_phone', 'recipient_email',
                 'recipient_county_id', 'recipient_locality_id', 'recipient_county_name', 'recipient_locality_name',
-                'shipping_address', 'total_weight', 'declared_value', 'parcels_count', 'envelopes_count',
-                'package_content', 'cash_repayment', 'bank_repayment', 'saturday_delivery', 
+                'shipping_address', 'address_text', 'recipient_postal', 'total_weight', 'declared_value', 'parcels_count', 'envelopes_count',
+                'package_content', 'cash_repayment', 'bank_repayment', 'saturday_delivery',
                 'morning_delivery', 'open_package', 'observations', 'recipient_reference1', 'recipient_reference2'
             ];
             
@@ -186,9 +186,14 @@ try {
                 $requirements[] = 'Shipping address required';
                 $canGenerate = false;
             }
-            
+
             if (empty($order['recipient_phone'])) {
                 $requirements[] = 'Recipient phone required';
+                $canGenerate = false;
+            }
+
+            if (empty($order['recipient_postal'])) {
+                $requirements[] = 'Recipient postal code required';
                 $canGenerate = false;
             }
             

--- a/database/migrations/2025_09_10_000000_add_address_text_and_postal_to_orders.php
+++ b/database/migrations/2025_09_10_000000_add_address_text_and_postal_to_orders.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Migration: add_address_text_and_postal_to_orders
+ * Created: 2025-09-10
+ * Purpose: Add postal code and address text columns to orders table
+ */
+
+class AddAddressTextAndPostalToOrdersMigration {
+    /**
+     * Run the migration
+     */
+    public function up(PDO $pdo) {
+        $sql = "
+            ALTER TABLE orders ADD COLUMN (
+                recipient_postal VARCHAR(20) NULL COMMENT 'Postal code',
+                address_text TEXT NULL COMMENT 'Full address text',
+                INDEX idx_recipient_postal (recipient_postal)
+            )
+        ";
+
+        $pdo->exec($sql);
+    }
+
+    /**
+     * Rollback the migration
+     */
+    public function down(PDO $pdo) {
+        $sql = "
+            ALTER TABLE orders DROP COLUMN recipient_postal,
+                                 DROP COLUMN address_text,
+                                 DROP INDEX idx_recipient_postal
+        ";
+
+        $pdo->exec($sql);
+    }
+}
+
+// Return instance for migration runner
+return new AddAddressTextAndPostalToOrdersMigration();


### PR DESCRIPTION
## Summary
- add migration for `recipient_postal` and `address_text` columns on orders
- fetch postal code via Cargus API during webhook import and store address text
- extend Cargus service and AWB endpoints to use and validate postal codes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e2d6142288320962f511883938410