### PR TITLE
Display order weight breakdown in orders table

### DIFF
--- a/orders.php
+++ b/orders.php
@@ -251,12 +251,26 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                                             <th>Prioritate</th>
                                             <th>Valoare</th>
                                             <th>Produse</th>
-                                            <th>AWB</th> 
+                                            <th>Greutate</th>
+                                            <th>AWB</th>
                                             <th>Acțiuni</th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         <?php foreach ($orders as $order): ?>
+                                            <?php
+                                                $orderItems = $orderModel->getOrderItems($order['id']);
+                                                $weightParts = [];
+                                                $calculatedWeight = 0;
+                                                foreach ($orderItems as $item) {
+                                                    $itemWeightPerUnit = (float)($item['weight_per_unit'] ?? 0);
+                                                    $itemWeight = $itemWeightPerUnit * (int)$item['quantity'];
+                                                    $calculatedWeight += $itemWeight;
+                                                    $weightParts[] = $item['product_name'] . ' (' . $item['quantity'] . '×' . number_format($itemWeightPerUnit, 3, '.', '') . 'kg)';
+                                                }
+                                                $displayWeight = $order['total_weight'] > 0 ? $order['total_weight'] : $calculatedWeight;
+                                                $weightBreakdown = htmlspecialchars(implode(' + ', $weightParts));
+                                            ?>
                                             <tr>
                                                 <td>
                                                     <code class="order-number"><?= htmlspecialchars($order['order_number']) ?></code>
@@ -287,6 +301,9 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                                                 </td>
                                                 <td>
                                                     <span class="text-center"><?= $order['total_items'] ?? 0 ?> produse</span>
+                                                </td>
+                                                <td>
+                                                    <span title="<?= $weightBreakdown ?>"><?= number_format($displayWeight, 3, '.', '') ?> kg</span>
                                                 </td>
                                                 <td class="awb-column">
                                                     <?php if (!empty($order['awb_barcode'])): ?>


### PR DESCRIPTION
## Summary
- add Greutate column to orders list
- calculate each order's weight from items and show breakdown via tooltip

## Testing
- `php -l orders.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688e36c32a0c83208e81467e33be1c80