### PR TITLE
Fix Cargus parcel code counts

### DIFF
--- a/models/CargusService.php
+++ b/models/CargusService.php
@@ -351,7 +351,7 @@ class CargusService
                 
                 $parcelCodes[] = [
                     'Code' => (string)$i,
-                    'Type' => 0, // 0 = parcel (per documentation)
+                    'Type' => 1, // 1 = parcel (per documentation)
                     'Weight' => $thisParcelWeight,
                     'Length' => 20,
                     'Width' => 20,
@@ -360,16 +360,16 @@ class CargusService
                 ];
             }
         }
-        
-        // Generate ParcelCodes for ENVELOPES (Type = 1) - even if envelopesCount = 0
+
+        // Generate ParcelCodes for ENVELOPES (Type = 0) - even if envelopesCount = 0
         if ($envelopesCount > 0) {
             for ($i = 0; $i < $envelopesCount; $i++) {
                 $envelopeWeight = 1; // 0.1kg in API units
                 $this->debugLog("Envelope {$i}: Weight = {$envelopeWeight} API units");
-                
+
                 $parcelCodes[] = [
                     'Code' => (string)($parcelsCount + $i),
-                    'Type' => 1, // 1 = envelope (per documentation)
+                    'Type' => 0, // 0 = envelope (per documentation)
                     'Weight' => $envelopeWeight,
                     'Length' => 25,
                     'Width' => 15,
@@ -378,13 +378,13 @@ class CargusService
                 ];
             }
         }
-        
+
         // VERIFICATION: Ensure we have the right counts
-        $actualParcels = array_filter($parcelCodes, fn($p) => $p['Type'] == 0);
-        $actualEnvelopes = array_filter($parcelCodes, fn($p) => $p['Type'] == 1);
-        
-        $this->debugLog("Generated parcels (Type=0): " . count($actualParcels) . " (expected: {$parcelsCount})");
-        $this->debugLog("Generated envelopes (Type=1): " . count($actualEnvelopes) . " (expected: {$envelopesCount})");
+        $actualParcels = array_filter($parcelCodes, fn($p) => $p['Type'] == 1);
+        $actualEnvelopes = array_filter($parcelCodes, fn($p) => $p['Type'] == 0);
+
+        $this->debugLog("Generated parcels (Type=1): " . count($actualParcels) . " (expected: {$parcelsCount})");
+        $this->debugLog("Generated envelopes (Type=0): " . count($actualEnvelopes) . " (expected: {$envelopesCount})");
         
         if (count($actualParcels) != $parcelsCount) {
             $this->debugLog("🚨 MISMATCH: Generated parcels != declared parcels");
@@ -396,7 +396,8 @@ class CargusService
         $this->debugLog("Total parcel codes generated: " . count($parcelCodes));
         $this->debugLog("=== PARCEL CODES DEBUG END ===");
         
-        return $parcelCodes;
+        // Reindex to ensure a clean 0..n numeric array as required by Cargus
+        return array_values($parcelCodes);
     }
     /**
      * Map recipient address using address_location_mappings table
@@ -699,9 +700,10 @@ class CargusService
                 'CodPostal' => $order['recipient_postal'] ?? '',
                 'CountryId' => 0
             ],
-            'Parcels' => $calculatedData['parcels_count'],
-            'Envelopes' => $order['envelopes_count'] ?? 0,
-            'TotalWeight' => (int)($calculatedData['total_weight'] * 10),
+            // Use the calculated integer counts to match ParcelCodes exactly
+            'Parcels' => $parcelsCount,
+            'Envelopes' => $envelopesCount,
+            'TotalWeight' => $totalWeight,
             'DeclaredValue' => intval($order['declared_value'] ?? $order['total_value'] ?? 0),
             'CashRepayment' => intval($order['cash_repayment'] ?? 0),
             'BankRepayment' => intval($order['bank_repayment'] ?? 0),


### PR DESCRIPTION
## Summary
- use calculated parcel and envelope counts when building AWB payload
- reindex generated ParcelCodes to ensure numeric array
- set correct Cargus type flags (1 for parcels, 0 for envelopes)

## Testing
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e465408548320873ac7309cb18a54