### PR TITLE
Allow AWB generation for any order status

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -416,10 +416,6 @@ class ProductionWMSAPI {
             throw new Exception('Order not found', 404);
         }
 
-        if (strtolower($order['status']) !== 'picked') {
-            throw new Exception('AWB can only be generated for picked orders', 400);
-        }
-
         if (empty($order['recipient_county_id'])) {
             throw new Exception('Order missing AWB data', 400);
         }

--- a/models/Order.php
+++ b/models/Order.php
@@ -548,9 +548,8 @@ class Order
                 o.updated_at,
                 c.name as customer_name,
                 c.phone as customer_phone,
-                CASE 
+                CASE
                     WHEN o.awb_barcode IS NOT NULL AND o.awb_barcode != '' THEN 'Generat'
-                    WHEN o.status = 'picked' THEN 'Pregătit pentru AWB'
                     ELSE 'În așteptare'
                 END as awb_status,
                 CASE
@@ -560,8 +559,8 @@ class Order
             FROM orders o
             LEFT JOIN customers c ON o.customer_id = c.id
             WHERE {$whereClause}
-            ORDER BY 
-                CASE WHEN o.status = 'picked' AND (o.awb_barcode IS NULL OR o.awb_barcode = '') THEN 0 ELSE 1 END,
+            ORDER BY
+                CASE WHEN (o.awb_barcode IS NULL OR o.awb_barcode = '') THEN 0 ELSE 1 END,
                 o.created_at DESC
         ";
         
@@ -626,8 +625,7 @@ class Order
             FROM orders o
             LEFT JOIN customers c ON o.customer_id = c.id
             LEFT JOIN order_items oi ON o.id = oi.order_id
-            WHERE o.status = 'picked'
-                AND (o.awb_barcode IS NULL OR o.awb_barcode = '')
+            WHERE (o.awb_barcode IS NULL OR o.awb_barcode = '')
                 AND o.recipient_county_id IS NOT NULL
                 AND o.recipient_locality_id IS NOT NULL
                 AND o.recipient_phone IS NOT NULL
@@ -655,11 +653,6 @@ class Order
         }
         
         $errors = [];
-        
-        // Status check
-        if (strtolower($order['status']) !== 'picked') {
-            $errors[] = 'Order status must be "picked"';
-        }
         
         // AWB already exists check
         if (!empty($order['awb_barcode'])) {
@@ -926,8 +919,7 @@ class Order
         $stmt = $this->conn->prepare("
             SELECT COUNT(*) as count
             FROM orders 
-            WHERE status = 'picked' 
-            AND (awb_barcode IS NULL OR awb_barcode = '')
+            WHERE (awb_barcode IS NULL OR awb_barcode = '')
             AND recipient_county_id IS NOT NULL
             AND recipient_locality_id IS NOT NULL
             AND recipient_phone IS NOT NULL

--- a/orders.php
+++ b/orders.php
@@ -335,13 +335,12 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                                                                 title="Schimbă status">
                                                             <span class="material-symbols-outlined">edit</span>
                                                         </button>
-                                                        <?php $awbDisabled = strtolower($order['status']) !== 'picked'; ?>
                                                         <?php if (!empty($order['awb_barcode'])): ?>
                                                             <button class="btn btn-sm btn-outline-success" onclick="printAWB('<?= htmlspecialchars($order['awb_barcode']) ?>')" title="Printează AWB">
                                                                 <span class="material-symbols-outlined">local_shipping</span>
                                                             </button>
                                                         <?php else: ?>
-                                                            <button class="btn btn-sm btn-outline-warning" onclick="generateAWB(<?= $order['id'] ?>)" title="Generează AWB" <?= $awbDisabled ? 'disabled' : '' ?>>
+                                                            <button class="btn btn-sm btn-outline-warning" onclick="generateAWB(<?= $order['id'] ?>)" title="Generează AWB">
                                                                 <span class="material-symbols-outlined">local_shipping</span>
                                                             </button>
                                                         <?php endif; ?>

--- a/scripts/orders.js
+++ b/scripts/orders.js
@@ -318,9 +318,7 @@ function generateAWB(orderId) {
         } else if (error.message.includes('CSRF')) {
             errorMessage = 'Eroare de securitate. Reîncărcați pagina și încercați din nou.';
         } else if (error.message.includes('Order not found')) {
-            errorMessage = 'Comanda nu a fost găsită sau nu este în starea corectă pentru generarea AWB.';
-        } else if (error.message.includes('AWB can only be generated for picked orders')) {
-            errorMessage = 'AWB poate fi generat doar pentru comenzile în starea "Pregătit pentru expediere".';
+            errorMessage = 'Comanda nu a fost găsită.';
         } else if (error.message.includes('AWB already exists')) {
             errorMessage = 'AWB-ul a fost deja generat pentru această comandă.';
         } else if (error.message) {

--- a/web/controllers/AWBController.php
+++ b/web/controllers/AWBController.php
@@ -59,11 +59,6 @@ class AWBController {
                 throw new Exception('Order not found', 404);
             }
             
-            // Validate order status
-            if (strtolower($order['status']) !== 'picked') {
-                throw new Exception('AWB can only be generated for picked orders', 400);
-            }
-            
             // Check if AWB already exists
             if (!empty($order['awb_barcode'])) {
                 throw new Exception('AWB already exists: ' . $order['awb_barcode'], 400);


### PR DESCRIPTION
## Summary
- Remove order status checks from AWB generation endpoints
- Enable AWB generation UI for orders in any status
- Adjust order queries and stats to drop `picked` status requirement