### PR TITLE
Ensure Cargus AWBs default to envelope and show barcode

### DIFF
--- a/api/awb/generate_awb.php
+++ b/api/awb/generate_awb.php
@@ -81,7 +81,7 @@ try {
             $manualFields = [
                 'recipient_name', 'recipient_contact_person', 'recipient_phone', 'recipient_email',
                 'recipient_county_id', 'recipient_locality_id', 'recipient_county_name', 'recipient_locality_name',
-                'shipping_address', 'address_text', 'recipient_postal', 'total_weight', 'declared_value', 'parcels_count', 'envelopes_count',
+                'shipping_address', 'address_text', 'recipient_postal', 'total_weight', 'parcels_count', 'envelopes_count',
                 'package_content', 'cash_repayment', 'bank_repayment', 'saturday_delivery',
                 'morning_delivery', 'open_package', 'observations', 'recipient_reference1', 'recipient_reference2'
             ];
@@ -93,7 +93,7 @@ try {
                     // Type casting for specific fields
                     if (in_array($field, ['recipient_county_id', 'recipient_locality_id', 'parcels_count', 'envelopes_count'])) {
                         $value = intval($value);
-                    } elseif (in_array($field, ['total_weight', 'declared_value', 'cash_repayment', 'bank_repayment'])) {
+                    } elseif (in_array($field, ['total_weight', 'cash_repayment', 'bank_repayment'])) {
                         $value = floatval($value);
                     } elseif (in_array($field, ['saturday_delivery', 'morning_delivery', 'open_package'])) {
                         $value = boolval($value);
@@ -105,6 +105,12 @@ try {
             
             // Apply manual overrides to order data
             $order = array_merge($order, $manualData);
+            // Ensure no declared value is sent
+            $order['declared_value'] = 0;
+            // Default to one envelope if none specified
+            if (empty($order['envelopes_count']) || $order['envelopes_count'] <= 0) {
+                $order['envelopes_count'] = 1;
+            }
             
             // Generate AWB
             $result = $cargusService->generateAWB($order);

--- a/models/CargusService.php
+++ b/models/CargusService.php
@@ -677,7 +677,10 @@ class CargusService
     private function buildAWBData($order, $calculatedData, $senderLocation) {
 
     $parcelsCount = (int)($calculatedData['parcels_count'] ?? 1);
-    $envelopesCount = (int)($calculatedData['envelopes_count'] ?? $order['envelopes_count'] ?? 0);
+    $envelopesCount = (int)($calculatedData['envelopes_count'] ?? $order['envelopes_count'] ?? 1);
+    if ($envelopesCount <= 0) {
+        $envelopesCount = 1;
+    }
 
     $this->debugLog("=== CARGUS AWB DEBUG START ===");
     $this->debugLog("Order Number: " . $order['order_number']);
@@ -743,7 +746,8 @@ class CargusService
         'Parcels' => $parcelsCount,
         'Envelopes' => $envelopesCount,
         'TotalWeight' => $totalWeight,
-        'DeclaredValue' => intval($order['declared_value'] ?? $order['total_value'] ?? 0),
+        // No declared value is sent for Cargus AWBs
+        'DeclaredValue' => 0,
         'CashRepayment' => intval($order['cash_repayment'] ?? 0),
         'BankRepayment' => intval($order['bank_repayment'] ?? 0),
         'OtherRepayment' => '',

--- a/scripts/orders.js
+++ b/scripts/orders.js
@@ -301,9 +301,9 @@ function generateAWB(orderId) {
     .then(data => {
         console.log('Success response:', data);
 
-        if (data.success && data.data) {
-            const barcode = data.data.awb_barcode || data.data.barcode;
-            alert(`AWB ${barcode} a fost generat cu succes! Pagina se va reîncărca.`);
+        if (data.success) {
+            const barcode = data.data?.awb_barcode || data.data?.barcode || data.barcode || data.awb_barcode || '';
+            alert(`AWB ${barcode || 'necunoscut'} a fost generat cu succes! Pagina se va reîncărca.`);
             location.reload();
         } else {
             alert(`Eroare la generarea AWB: ${data.error || 'Răspuns nevalid de la server.'}`);

--- a/scripts/orders_awb.js
+++ b/scripts/orders_awb.js
@@ -86,10 +86,11 @@ async function generateAWBDirect(orderId, manualData = {}) {
         const result = await response.json();
         
         if (result.success) {
-            showNotification(`AWB generat cu succes: ${result.barcode}`, 'success');
-            
+            const awbCode = result.barcode || result.awb_barcode || '';
+            showNotification(`AWB generat cu succes: ${awbCode || 'necunoscut'}`, 'success');
+
             // Update UI to show AWB was generated
-            updateOrderAWBStatus(orderId, result.barcode);
+            updateOrderAWBStatus(orderId, awbCode);
             
             // Optionally reload page to show updated status
             setTimeout(() => {
@@ -261,13 +262,8 @@ function showAWBManualInputModal(orderId, requirementsData) {
                                 <div class="form-row">
                                     <div class="form-group">
                                         <label>Greutate (kg) *</label>
-                                        <input type="number" step="0.1" name="total_weight" 
+                                        <input type="number" step="0.1" name="total_weight"
                                                value="${requirementsData.weight_info?.weight || ''}" required>
-                                    </div>
-                                    <div class="form-group">
-                                        <label>Valoare declarată</label>
-                                        <input type="number" step="0.01" name="declared_value" 
-                                               value="${orderData.total_value || ''}">
                                     </div>
                                 </div>
                                 <div class="form-row">
@@ -277,7 +273,7 @@ function showAWBManualInputModal(orderId, requirementsData) {
                                     </div>
                                     <div class="form-group">
                                         <label>Plicuri</label>
-                                        <input type="number" name="envelopes_count" value="${orderData.envelopes_count || 0}" max="9">
+                                        <input type="number" name="envelopes_count" value="${orderData.envelopes_count || 1}" max="9">
                                     </div>
                                 </div>
                                 <div class="form-group">


### PR DESCRIPTION
## Summary
- Default AWB payloads to include one envelope and no declared value
- Remove declared value field from manual AWB modal
- Fix AWB generation notifications to display the real barcode