### PR TITLE
Make orders table horizontally scrollable on small screens

### DIFF
--- a/orders.php
+++ b/orders.php
@@ -246,6 +246,7 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                     <div class="card-body">
                         <?php if (!empty($orders)): ?>
                             <div class="table-container">
+                                <div class="table-responsive">
                                 <table class="table">
                                     <thead>
                                         <tr>
@@ -362,6 +363,7 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                                         <?php endforeach; ?>
                                     </tbody>
                                 </table>
+                                </div>
                             </div>
                             
                             <!-- Pagination -->

--- a/styles/orders.css
+++ b/styles/orders.css
@@ -153,6 +153,13 @@
     overflow: hidden;
 }
 
+.table-responsive {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    border: none;
+    border-radius: 0;
+}
+
 .table {
     width: 100%;
     border-collapse: collapse;


### PR DESCRIPTION
## Summary
- Wrap orders table in a responsive container so it can scroll horizontally on narrow viewports
- Add supporting CSS for smooth horizontal scrolling

## Testing
- `composer test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890df247b808320a1e9ef6ceb74923f