### PR TITLE
style: improve printer selection modal layout

### DIFF
--- a/styles/orders.css
+++ b/styles/orders.css
@@ -133,6 +133,55 @@
     background-color: var(--surface-background);
 }
 
+/* ===== PRINTER SELECTION MODAL ===== */
+.printer-selection {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.printer-option-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    background-color: var(--button-background);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    color: var(--text-primary);
+    cursor: pointer;
+    text-align: left;
+    transition: var(--transition);
+}
+
+.printer-option-btn:hover {
+    background-color: var(--button-hover);
+    border-color: var(--border-color-strong);
+}
+
+.printer-option-btn .material-symbols-outlined {
+    font-size: 1.5rem;
+}
+
+.format-selection {
+    margin-top: 0.5rem;
+}
+
+.format-selection h4 {
+    margin-bottom: 0.5rem;
+}
+
+.printer-selection .btn-group {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.manual-print-btn {
+    margin-top: 1rem;
+    align-self: flex-start;
+}
+
 /* ===== FILTER FORM ===== */
 .filter-form {
     display: flex;


### PR DESCRIPTION
## Summary
- add dedicated styling for AWB printer selection modal
- space printer options and align manual download button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890e6132c8c8320bfc840d7fe75f355