### PR TITLE
Restrict AWB generation to picked orders

### DIFF
--- a/api/awb/generate_awb.php
+++ b/api/awb/generate_awb.php
@@ -67,6 +67,18 @@ try {
                 respond(['success' => false, 'error' => 'Order not found'], 404);
             }
 
+            // Ensure order is picked before generating AWB
+            if (($order['status'] ?? '') !== 'picked') {
+                respond([
+                    'success' => false,
+                    'error' => 'AWB can only be generated for orders with status picked',
+                    'data' => [
+                        'order_id' => $orderId,
+                        'order_status' => $order['status'] ?? null
+                    ]
+                ], 400);
+            }
+
             $awbValid = !empty($order['awb_barcode']) && preg_match('/^\d+$/', (string)$order['awb_barcode']);
             $attempts = (int)($order['awb_generation_attempts'] ?? 0);
 
@@ -216,7 +228,21 @@ try {
             if (!$order) {
                 respond(['success' => false, 'error' => 'Order not found'], 404);
             }
-            
+
+            // Ensure order is picked before allowing AWB generation
+            if (($order['status'] ?? '') !== 'picked') {
+                respond([
+                    'success' => true,
+                    'data' => [
+                        'can_generate' => false,
+                        'requirements' => ['Order status must be picked'],
+                        'weight_info' => ['weight' => 0, 'source' => 'status'],
+                        'address_parsed' => null,
+                        'order_data' => $order
+                    ]
+                ]);
+            }
+
             if (!empty($order['awb_barcode']) && preg_match('/^\d+$/', (string)$order['awb_barcode'])) {
                 respond([
                     'success' => true,

--- a/api/index.php
+++ b/api/index.php
@@ -416,6 +416,10 @@ class ProductionWMSAPI {
             throw new Exception('Order not found', 404);
         }
 
+        if (($order['status'] ?? '') !== 'picked') {
+            throw new Exception('AWB can only be generated for orders with status picked', 400);
+        }
+
         if (empty($order['recipient_county_id'])) {
             throw new Exception('Order missing AWB data', 400);
         }

--- a/models/CargusService.php
+++ b/models/CargusService.php
@@ -245,6 +245,15 @@ class CargusService
      */
     public function generateAWB($order) {
         try {
+            // Ensure order is eligible for AWB generation
+            if (($order['status'] ?? '') !== 'picked') {
+                return [
+                    'success' => false,
+                    'error' => 'Order status must be picked',
+                    'code' => 400
+                ];
+            }
+
             // Authenticate first
             if (!$this->authenticate()) {
                 return [

--- a/models/Order.php
+++ b/models/Order.php
@@ -653,7 +653,12 @@ class Order
         }
         
         $errors = [];
-        
+
+        // Status validation
+        if (($order['status'] ?? '') !== 'picked') {
+            $errors[] = 'Order status must be picked';
+        }
+
         // AWB already exists check
         if (!empty($order['awb_barcode'])) {
             $errors[] = 'AWB already generated: ' . $order['awb_barcode'];

--- a/web/controllers/AWBController.php
+++ b/web/controllers/AWBController.php
@@ -58,7 +58,12 @@ class AWBController {
             if (!$order) {
                 throw new Exception('Order not found', 404);
             }
-            
+
+            // Ensure order is in picked status
+            if (($order['status'] ?? '') !== 'picked') {
+                throw new Exception('AWB can only be generated for orders with status picked', 400);
+            }
+
             // Check if AWB already exists
             if (!empty($order['awb_barcode'])) {
                 throw new Exception('AWB already exists: ' . $order['awb_barcode'], 400);


### PR DESCRIPTION
## Summary
- require order status to be `picked` before generating AWB
- add status validation to AWB controller and service
- include status check in legacy API and order validation