### PR TITLE
Allow custom shelf level names

### DIFF
--- a/models/Inventory.php
+++ b/models/Inventory.php
@@ -238,8 +238,8 @@ class Inventory {
             require_once __DIR__ . '/LocationLevelSettings.php';
             $lls = new LocationLevelSettings($this->conn);
             $name = $lls->getLevelNameByNumber((int)$data['location_id'], (int)$shelfLevel);
-            $shelfLevel = $name ?: 'middle';
-        } elseif ($shelfLevel === null) {
+            $shelfLevel = $name ?: 'Nivel ' . $shelfLevel;
+        } elseif ($shelfLevel === null || $shelfLevel === '') {
             $shelfLevel = 'middle';
         }
 


### PR DESCRIPTION
## Summary
- Preserve numeric shelf levels by resolving to their custom names instead of defaulting to `middle`
- Support arbitrary level names in inventory table by converting `shelf_level` column to `VARCHAR`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68945e71c4688320a1e0d2ab80d31dca