### PR TITLE
Refactor relocation interface for mobile

### DIFF
--- a/styles/warehouse-css/warehouse_relocation.css
+++ b/styles/warehouse-css/warehouse_relocation.css
@@ -1,454 +1,85 @@
-/* ===== WAREHOUSE RELOCATION STYLES ===== */
-/* Following the exact monochrome design language from the WMS system */
+@import 'mobile_picker.css';
 
-/* ===== CSS VARIABLES (Inherited from global.css) ===== */
-:root {
-    --black: #0F1013;
-    --dark-gray: #1A1A1D;
-    --darker-gray: #16161A;
-    --light-gray: #94A1B2;
-    --lighter-gray: #AAAAAA;
-    --white: #FEFFFF;
-    --success: #28a745;
-    --danger: #dc3545;
-    --warning: #ffc107;
-    --info: #17a2b8;
-    --primary: #007bff;
-  }
-  
-  /* ===== MAIN LAYOUT ===== */
-  body {
-      font-family: 'Poppins', sans-serif;
-      background: linear-gradient(135deg, var(--black) 0%, var(--darker-gray) 100%);
-      color: var(--white);
-      margin: 0;
-      padding: 0;
-      min-height: 100vh;
-  }
-  
-  .main-container {
-      max-width: 1400px;
-      margin: 0 auto;
-      padding: 2rem;
-      min-height: calc(100vh - 120px);
-  }
-  
-  /* ===== PAGE HEADER ===== */
-  .page-header {
-      margin-bottom: 2rem;
-      text-align: center;
-  }
-  
-  .page-title {
-      font-size: 2.5rem;
-      font-weight: 700;
-      color: var(--white);
-      margin: 0 0 0.5rem 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 1rem;
-  }
-  
-  .page-title .material-symbols-outlined {
-      font-size: 2.5rem;
-      color: var(--primary);
-  }
-  
-  .page-subtitle {
-      font-size: 1.1rem;
-      color: var(--light-gray);
-      margin: 0;
-      font-weight: 400;
-  }
-  
-  /* ===== ALERT MESSAGES ===== */
-  .alert {
-      padding: 1rem 1.5rem;
-      margin-bottom: 1.5rem;
-      border-radius: 12px;
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-      font-weight: 500;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-      transition: opacity 0.3s ease;
-  }
-  
-  .alert-success {
-      background: linear-gradient(145deg, rgba(40, 167, 69, 0.15) 0%, rgba(40, 167, 69, 0.1) 100%);
-      color: var(--success);
-      border: 1px solid rgba(40, 167, 69, 0.3);
-  }
-  
-  .alert-danger {
-      background: linear-gradient(145deg, rgba(220, 53, 69, 0.15) 0%, rgba(220, 53, 69, 0.1) 100%);
-      color: var(--danger);
-      border: 1px solid rgba(220, 53, 69, 0.3);
-  }
-  
-  .alert .material-symbols-outlined {
-      font-size: 1.5rem;
-  }
-  
-  /* ===== STATS SECTION ===== */
-  .stats-section {
-      margin-bottom: 3rem;
-  }
-  
-  .stats-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 1.5rem;
-  }
-  
-  .stat-card {
-      background: linear-gradient(145deg, var(--darker-gray) 0%, var(--dark-gray) 100%);
-      border-radius: 16px;
-      padding: 2rem;
-      text-align: center;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      transition: transform 0.3s ease, box-shadow 0.3s ease;
-  }
-  
-  .stat-card:hover {
-      transform: translateY(-5px);
-      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
-  }
-  
-  .stat-icon {
-      font-size: 3rem;
-      color: var(--primary);
-      margin-bottom: 1rem;
-      display: block;
-  }
-  
-  .stat-number {
-      font-size: 2.5rem;
-      font-weight: 700;
-      color: var(--white);
-      margin-bottom: 0.5rem;
-  }
-  
-  .stat-label {
-      font-size: 1rem;
-      color: var(--light-gray);
-      font-weight: 500;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-  }
-  
-  /* ===== SECTIONS ===== */
-  .action-section,
-  .tasks-section {
-      margin-bottom: 3rem;
-  }
-  
-  .section-header {
-      margin-bottom: 1.5rem;
-  }
-  
-  .section-title {
-      font-size: 1.5rem;
-      font-weight: 600;
-      color: var(--white);
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-      margin: 0;
-  }
-  
-  .section-title .material-symbols-outlined {
-      color: var(--primary);
-      font-size: 1.5rem;
-  }
-  
-  /* ===== CARDS ===== */
-  .card {
-      background: linear-gradient(145deg, var(--darker-gray) 0%, var(--dark-gray) 100%);
-      border-radius: 16px;
-      padding: 2rem;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-  }
-  
-  /* ===== FORMS ===== */
-  .form-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-      gap: 1.5rem;
-      margin-bottom: 2rem;
-  }
-  
-  .form-group {
-      display: flex;
-      flex-direction: column;
-  }
-  
-  .form-label {
-      font-weight: 600;
-      color: var(--white);
-      margin-bottom: 0.5rem;
-      font-size: 0.9rem;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-  }
-  
-  .form-select,
-  .form-input {
-      padding: 1rem;
-      border: 2px solid rgba(255, 255, 255, 0.1);
-      border-radius: 8px;
-      background: rgba(255, 255, 255, 0.05);
-      color: var(--white);
-      font-size: 1rem;
-      transition: border-color 0.3s ease, background-color 0.3s ease;
-  }
-  
-  .form-select:focus,
-  .form-input:focus {
-      outline: none;
-      border-color: var(--primary);
-      background: rgba(255, 255, 255, 0.1);
-  }
-  
-  .form-select option {
-      background: var(--dark-gray);
-      color: var(--white);
-  }
-  
-  .form-select option:disabled {
-      color: var(--light-gray);
-      background: var(--darker-gray);
-  }
-  
-  .form-hint {
-      color: var(--light-gray);
-      font-size: 0.85rem;
-      margin-top: 0.5rem;
-  }
-  
-  .form-actions {
-      display: flex;
-      justify-content: center;
-      gap: 1rem;
-  }
-  
-  /* ===== BUTTONS ===== */
-  .btn {
-      padding: 1rem 2rem;
-      border: none;
-      border-radius: 8px;
-      font-weight: 600;
-      font-size: 1rem;
-      cursor: pointer;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      text-decoration: none;
-      transition: all 0.3s ease;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-  }
-  
-  .btn-primary {
-      background: linear-gradient(145deg, var(--primary) 0%, #0056b3 100%);
-      color: var(--white);
-      box-shadow: 0 4px 15px rgba(0, 123, 255, 0.3);
-  }
-  
-  .btn-primary:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 6px 20px rgba(0, 123, 255, 0.4);
-  }
-  
-  .btn-success {
-      background: linear-gradient(145deg, var(--success) 0%, #1e7e34 100%);
-      color: var(--white);
-      box-shadow: 0 4px 15px rgba(40, 167, 69, 0.3);
-  }
-  
-  .btn-success:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 6px 20px rgba(40, 167, 69, 0.4);
-  }
-  
-  .btn-sm {
-      padding: 0.5rem 1rem;
-      font-size: 0.875rem;
-  }
-  
-  .btn .material-symbols-outlined {
-      font-size: 1.2rem;
-  }
-  
-  /* ===== TABLES ===== */
-  .table-container {
-      overflow-x: auto;
-      border-radius: 12px;
-      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
-  }
-  
-  .data-table {
-      width: 100%;
-      border-collapse: collapse;
-      background: var(--darker-gray);
-  }
-  
-  .data-table th,
-  .data-table td {
-      padding: 1rem;
-      text-align: left;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  }
-  
-  .data-table th {
-      background: var(--dark-gray);
-      color: var(--white);
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-      font-size: 0.85rem;
-  }
-  
-  .data-table td {
-      color: var(--light-gray);
-  }
-  
-  .data-table tr:hover {
-      background: rgba(255, 255, 255, 0.05);
-  }
-  
-  /* ===== SPECIFIC COMPONENTS ===== */
-  .product-info {
-      display: flex;
-      flex-direction: column;
-      gap: 0.25rem;
-  }
-  
-  .product-info strong {
-      color: var(--white);
-  }
-  
-  .product-info small {
-      color: var(--light-gray);
-      font-size: 0.8rem;
-  }
-  
-  .location-badge {
-      display: inline-block;
-      padding: 0.25rem 0.75rem;
-      background: rgba(23, 162, 184, 0.2);
-      color: var(--info);
-      border-radius: 20px;
-      font-size: 0.8rem;
-      font-weight: 500;
-      border: 1px solid rgba(23, 162, 184, 0.3);
-  }
-  
-  .status-badge {
-      display: inline-block;
-      padding: 0.25rem 0.75rem;
-      border-radius: 20px;
-      font-size: 0.8rem;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-  }
-  
-  .status-pending {
-      background: rgba(255, 193, 7, 0.2);
-      color: var(--warning);
-      border: 1px solid rgba(255, 193, 7, 0.3);
-  }
-  
-  .status-ready {
-      background: rgba(40, 167, 69, 0.2);
-      color: var(--success);
-      border: 1px solid rgba(40, 167, 69, 0.3);
-  }
-  
-  .status-completed {
-      background: rgba(108, 117, 125, 0.2);
-      color: var(--light-gray);
-      border: 1px solid rgba(108, 117, 125, 0.3);
-  }
-  
-  /* ===== EMPTY STATE ===== */
-  .empty-state {
-      text-align: center;
-      padding: 3rem;
-      color: var(--light-gray);
-  }
-  
-  .empty-icon {
-      font-size: 4rem;
-      color: rgba(255, 255, 255, 0.3);
-      margin-bottom: 1rem;
-      display: block;
-  }
-  
-  .empty-text {
-      font-size: 1.1rem;
-      margin: 0;
-  }
-  
-  /* ===== RESPONSIVE DESIGN ===== */
-  @media (max-width: 768px) {
-      .main-container {
-          padding: 1rem;
-      }
-      
-      .page-title {
-          font-size: 2rem;
-          flex-direction: column;
-          gap: 0.5rem;
-      }
-      
-      .stats-grid {
-          grid-template-columns: 1fr;
-          gap: 1rem;
-      }
-      
-      .form-grid {
-          grid-template-columns: 1fr;
-          gap: 1rem;
-      }
-      
-      .card {
-          padding: 1.5rem;
-      }
-      
-      .table-container {
-          font-size: 0.875rem;
-      }
-      
-      .data-table th,
-      .data-table td {
-          padding: 0.75rem 0.5rem;
-      }
-  }
-  
-  @media (max-width: 480px) {
-      .page-title {
-          font-size: 1.5rem;
-      }
-      
-      .page-title .material-symbols-outlined {
-          font-size: 2rem;
-      }
-      
-      .stat-card {
-          padding: 1.5rem;
-      }
-      
-      .stat-number {
-          font-size: 2rem;
-      }
-      
-      .btn {
-          padding: 0.875rem 1.5rem;
-          font-size: 0.9rem;
-      }
-  }
+/* Mobile-friendly relocation styles */
+
+.section-header {
+  background-color: var(--dark-gray);
+  padding: var(--spacing-md);
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  margin-bottom: var(--spacing-md);
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  color: var(--white);
+}
+
+.card {
+  background-color: var(--dark-gray);
+  border-radius: 6px;
+  padding: var(--spacing-md);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.table-container {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+  padding: var(--spacing-sm);
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  font-size: var(--font-size-sm);
+}
+
+.location-badge {
+  display: inline-block;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  color: var(--white);
+  font-size: var(--font-size-sm);
+}
+
+.status-badge {
+  border-radius: 4px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  color: var(--black);
+  text-transform: capitalize;
+}
+
+.status-pending {
+  background-color: var(--warning-color);
+}
+
+.status-ready {
+  background-color: var(--info-color);
+}
+
+.status-completed {
+  background-color: var(--success-color);
+}
+
+.empty-state {
+  text-align: center;
+  padding: var(--spacing-lg);
+  color: var(--light-gray);
+}
+
+.empty-icon {
+  font-size: 3rem;
+  display: block;
+  margin-bottom: var(--spacing-md);
+}
+

--- a/warehouse_relocation.php
+++ b/warehouse_relocation.php
@@ -1,15 +1,13 @@
 <?php
 /**
  * Warehouse Relocation Management
- * File: warehouse_relocation.php
- * Follows WMS design language and standards
+ * Mobile-friendly interface for relocation tasks
  */
 
 error_reporting(E_ALL);
 ini_set('display_errors', 0);
 ini_set('log_errors', 1);
 
-// Bootstrap and configuration
 if (!defined('BASE_PATH')) {
     define('BASE_PATH', __DIR__);
 }
@@ -17,147 +15,77 @@ if (!defined('BASE_PATH')) {
 require_once BASE_PATH . '/bootstrap.php';
 $config = require BASE_PATH . '/config/config.php';
 
-// Session and authentication check
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 
-// Authentication check
 if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'], ['warehouse', 'admin', 'manager'])) {
     header('Location: ' . getNavUrl('login.php'));
     exit;
 }
 
-// Database connection
 $dbFactory = $config['connection_factory'];
 $db = $dbFactory();
 
-// Include required models
-require_once BASE_PATH . '/models/Location.php';
-require_once BASE_PATH . '/models/Product.php';
-require_once BASE_PATH . '/models/Inventory.php';
-
-// Include relocation model if exists
-if (file_exists(BASE_PATH . '/models/RelocationTask.php')) {
-    require_once BASE_PATH . '/models/RelocationTask.php';
-    $relocationModel = new RelocationTask($db);
-}
-
-$locationModel = new Location($db);
-$productModel = new Product($db);
-$inventoryModel = new Inventory($db);
-
-// Handle form submissions and operations
 $message = '';
 $messageType = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? '';
-    
-    // CSRF Protection
+
     if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
         $message = 'Sesiune expirată. Vă rugăm să reîncărcați pagina.';
         $messageType = 'error';
     } else {
         try {
-            switch ($action) {
-                case 'create_relocation':
-                    $productId = intval($_POST['product_id'] ?? 0);
-                    $fromLocationId = intval($_POST['from_location_id'] ?? 0);
-                    $toLocationId = intval($_POST['to_location_id'] ?? 0);
-                    $quantity = intval($_POST['quantity'] ?? 0);
-                    
-                    if ($productId <= 0 || $fromLocationId <= 0 || $toLocationId <= 0 || $quantity <= 0) {
-                        throw new Exception('Date invalide pentru crearea relocării.');
-                    }
-                    
-                    if ($fromLocationId === $toLocationId) {
-                        throw new Exception('Locațiile de origine și destinație nu pot fi identice.');
-                    }
-                    
-                    // Verify sufficient stock at source location - FIXED: Use direct query
+            if ($action === 'complete_relocation') {
+                $taskId = intval($_POST['task_id'] ?? 0);
+
+                if ($taskId <= 0) {
+                    throw new Exception('ID task invalid.');
+                }
+
+                $stmt = $db->prepare("SELECT * FROM relocation_tasks WHERE id = :task_id AND status IN ('pending', 'ready')");
+                $stmt->execute([':task_id' => $taskId]);
+                $task = $stmt->fetch(PDO::FETCH_ASSOC);
+
+                if (!$task) {
+                    throw new Exception('Task-ul nu a fost găsit sau este deja completat.');
+                }
+
+                $db->beginTransaction();
+                try {
                     $stmt = $db->prepare("
-                        SELECT COALESCE(SUM(quantity), 0) as available_stock 
-                        FROM inventory 
-                        WHERE product_id = :product_id AND location_id = :location_id AND quantity > 0
+                        UPDATE inventory
+                        SET location_id = :to_location
+                        WHERE product_id = :product_id
+                        AND location_id = :from_location
+                        AND quantity >= :quantity
+                        LIMIT 1
                     ");
-                    $stmt->execute([
-                        ':product_id' => $productId,
-                        ':location_id' => $fromLocationId
+                    $moveResult = $stmt->execute([
+                        ':to_location' => $task['to_location_id'],
+                        ':product_id' => $task['product_id'],
+                        ':from_location' => $task['from_location_id'],
+                        ':quantity' => $task['quantity']
                     ]);
-                    $availableStock = (int)$stmt->fetchColumn();
-                    
-                    if ($availableStock < $quantity) {
-                        throw new Exception('Stoc insuficient în locația de origine. Disponibil: ' . $availableStock);
+
+                    if (!$moveResult || $stmt->rowCount() === 0) {
+                        throw new Exception('Nu s-a putut muta stocul. Verificați disponibilitatea.');
                     }
-                    
-                    // Create relocation task
-                    if (isset($relocationModel) && $relocationModel->createTask($productId, $fromLocationId, $toLocationId, $quantity)) {
-                        $message = 'Task de relocare creat cu succes.';
-                        $messageType = 'success';
-                    } else {
-                        throw new Exception('Eroare la crearea task-ului de relocare.');
-                    }
-                    break;
-                    
-                case 'complete_relocation':
-                    $taskId = intval($_POST['task_id'] ?? 0);
-                    
-                    if ($taskId <= 0) {
-                        throw new Exception('ID task invalid.');
-                    }
-                    
-                    // Get task details
-                    $stmt = $db->prepare("SELECT * FROM relocation_tasks WHERE id = :task_id AND status IN ('pending', 'ready')");
+
+                    $stmt = $db->prepare("UPDATE relocation_tasks SET status = 'completed', updated_at = NOW() WHERE id = :task_id");
                     $stmt->execute([':task_id' => $taskId]);
-                    $task = $stmt->fetch(PDO::FETCH_ASSOC);
-                    
-                    if (!$task) {
-                        throw new Exception('Task-ul nu a fost găsit sau este deja completat.');
-                    }
-                    
-                    // Start transaction for relocation
-                    $db->beginTransaction();
-                    
-                    try {
-                        // Move inventory from source to destination location
-                        // This is a simplified version - you may need more complex logic based on your inventory structure
-                        $stmt = $db->prepare("
-                            UPDATE inventory 
-                            SET location_id = :to_location 
-                            WHERE product_id = :product_id 
-                            AND location_id = :from_location 
-                            AND quantity >= :quantity
-                            LIMIT 1
-                        ");
-                        
-                        $moveResult = $stmt->execute([
-                            ':to_location' => $task['to_location_id'],
-                            ':product_id' => $task['product_id'],
-                            ':from_location' => $task['from_location_id'],
-                            ':quantity' => $task['quantity']
-                        ]);
-                        
-                        if (!$moveResult || $stmt->rowCount() === 0) {
-                            throw new Exception('Nu s-a putut muta stocul. Verificați disponibilitatea.');
-                        }
-                        
-                        // Update task status to completed
-                        $stmt = $db->prepare("UPDATE relocation_tasks SET status = 'completed', updated_at = NOW() WHERE id = :task_id");
-                        $stmt->execute([':task_id' => $taskId]);
-                        
-                        $db->commit();
-                        $message = 'Relocarea a fost finalizată cu succes.';
-                        $messageType = 'success';
-                        
-                    } catch (Exception $e) {
-                        $db->rollBack();
-                        throw $e;
-                    }
-                    break;
-                    
-                default:
-                    throw new Exception('Acțiune nerecunoscută.');
+
+                    $db->commit();
+                    $message = 'Relocarea a fost finalizată cu succes.';
+                    $messageType = 'success';
+                } catch (Exception $e) {
+                    $db->rollBack();
+                    throw $e;
+                }
+            } else {
+                throw new Exception('Acțiune nerecunoscută.');
             }
         } catch (Exception $e) {
             $message = $e->getMessage();
@@ -166,64 +94,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
-// Get data for display
 try {
-    // Get active locations - FIXED: Use correct method name
-    $activeLocations = $locationModel->getActiveLocations();
-    
-    // Get products for dropdown
-    $allProducts = $productModel->getAllProductsForDropdown();
-    
-    // Get pending relocation tasks - FIXED: Use direct query since method doesn't exist
-    $pendingTasks = [];
-    if (isset($relocationModel)) {
-        $stmt = $db->prepare("
-            SELECT rt.*, 
-                   p.name as product_name, p.sku as product_sku,
-                   l1.location_code as from_location, l2.location_code as to_location
-            FROM relocation_tasks rt
-            LEFT JOIN products p ON rt.product_id = p.product_id  
-            LEFT JOIN locations l1 ON rt.from_location_id = l1.id
-            LEFT JOIN locations l2 ON rt.to_location_id = l2.id
-            WHERE rt.status IN ('pending', 'ready')
-            ORDER BY rt.created_at ASC
-        ");
-        $stmt->execute();
-        $pendingTasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
-    }
-    
-    // Get relocation statistics - FIXED: Use direct queries
+    $stmt = $db->prepare("
+        SELECT rt.*,
+               p.name as product_name, p.sku as product_sku,
+               l1.location_code as from_location, l2.location_code as to_location
+        FROM relocation_tasks rt
+        LEFT JOIN products p ON rt.product_id = p.product_id
+        LEFT JOIN locations l1 ON rt.from_location_id = l1.id
+        LEFT JOIN locations l2 ON rt.to_location_id = l2.id
+        WHERE rt.status IN ('pending', 'ready')
+        ORDER BY rt.created_at ASC
+    ");
+    $stmt->execute();
+    $pendingTasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
     $pendingTasksCount = count($pendingTasks);
-    $completedTodayCount = 0;
-    $totalThisMonthCount = 0;
-    
-    if (isset($relocationModel)) {
-        // Count completed today
-        $stmt = $db->prepare("SELECT COUNT(*) FROM relocation_tasks WHERE status = 'completed' AND DATE(updated_at) = CURDATE()");
-        $stmt->execute();
-        $completedTodayCount = (int)$stmt->fetchColumn();
-        
-        // Count total this month
-        $stmt = $db->prepare("SELECT COUNT(*) FROM relocation_tasks WHERE status = 'completed' AND YEAR(updated_at) = YEAR(NOW()) AND MONTH(updated_at) = MONTH(NOW())");
-        $stmt->execute();
-        $totalThisMonthCount = (int)$stmt->fetchColumn();
-    }
-    
-    $relocationStats = [
-        'pending_tasks' => $pendingTasksCount,
-        'completed_today' => $completedTodayCount,
-        'total_this_month' => $totalThisMonthCount
-    ];
-    
 } catch (Exception $e) {
     error_log("Error fetching relocation data: " . $e->getMessage());
-    $activeLocations = [];
-    $allProducts = [];
     $pendingTasks = [];
-    $relocationStats = ['pending_tasks' => 0, 'completed_today' => 0, 'total_this_month' => 0];
+    $pendingTasksCount = 0;
 }
 
-// Define current page for navigation
 $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
 ?>
 <!DOCTYPE html>
@@ -233,20 +124,18 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
     <title>Relocări Depozit - WMS</title>
 </head>
 <body>
-    <?php require_once __DIR__ . '/includes/warehouse_navbar.php'; ?>
-    
-    <!-- Main Container (following WMS design language) -->
-    <div class="main-container">
-        <!-- Page Header -->
-        <div class="page-header">
-            <h1 class="page-title">
-                <span class="material-symbols-outlined">move_location</span>
-                Relocări Depozit
-            </h1>
-            <p class="page-subtitle">Gestionează relocările produselor între locații</p>
+    <div class="mobile-picker-container">
+        <div class="picker-header">
+            <div class="header-content">
+                <h1><span class="material-symbols-outlined">move_location</span>Relocări Depozit</h1>
+                <div class="order-info">
+                    <div class="top-row">
+                        <div class="order-number">În așteptare: <span><?= $pendingTasksCount ?></span></div>
+                    </div>
+                </div>
+            </div>
         </div>
 
-        <!-- Alert Messages -->
         <?php if (!empty($message)): ?>
             <div class="alert alert-<?= $messageType === 'success' ? 'success' : 'danger' ?>" role="alert">
                 <span class="material-symbols-outlined">
@@ -256,113 +145,18 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
             </div>
         <?php endif; ?>
 
-        <!-- Stats Section (following warehouse design pattern) -->
-        <div class="stats-section">
-            <div class="stats-grid">
-                <div class="stat-card">
-                    <span class="material-symbols-outlined stat-icon">pending_actions</span>
-                    <div class="stat-number"><?= $relocationStats['pending_tasks'] ?></div>
-                    <div class="stat-label">În așteptare</div>
-                </div>
-                
-                <div class="stat-card">
-                    <span class="material-symbols-outlined stat-icon">task_alt</span>
-                    <div class="stat-number"><?= $relocationStats['completed_today'] ?></div>
-                    <div class="stat-label">Finalizate azi</div>
-                </div>
-                
-                <div class="stat-card">
-                    <span class="material-symbols-outlined stat-icon">trending_up</span>
-                    <div class="stat-number"><?= $relocationStats['total_this_month'] ?></div>
-                    <div class="stat-label">Total luna curentă</div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Action Section -->
-        <div class="action-section">
+        <div class="content-section">
             <div class="section-header">
-                <h2 class="section-title">
-                    <span class="material-symbols-outlined">add_task</span>
-                    Creare Task Relocare
-                </h2>
+                <h2>Task-uri În Așteptare</h2>
             </div>
-            
-            <div class="card">
-                <form method="POST" id="relocation-form">
-                    <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?>">
-                    <input type="hidden" name="action" value="create_relocation">
-                    
-                    <div class="form-grid">
-                        <div class="form-group">
-                            <label for="product_id" class="form-label">Produs</label>
-                            <select name="product_id" id="product_id" class="form-select" required>
-                                <option value="">Selectează produsul</option>
-                                <?php foreach ($allProducts as $product): ?>
-                                    <option value="<?= $product['product_id'] ?>">
-                                        <?= htmlspecialchars($product['name']) ?> (<?= htmlspecialchars($product['sku']) ?>)
-                                    </option>
-                                <?php endforeach; ?>
-                            </select>
-                        </div>
-                        
-                        <div class="form-group">
-                            <label for="from_location_id" class="form-label">Locația de origine</label>
-                            <select name="from_location_id" id="from_location_id" class="form-select" required>
-                                <option value="">Selectează locația de origine</option>
-                                <?php foreach ($activeLocations as $location): ?>
-                                    <option value="<?= $location['id'] ?>">
-                                        <?= htmlspecialchars($location['location_code']) ?> - <?= htmlspecialchars($location['zone']) ?>
-                                    </option>
-                                <?php endforeach; ?>
-                            </select>
-                        </div>
-                        
-                        <div class="form-group">
-                            <label for="to_location_id" class="form-label">Locația de destinație</label>
-                            <select name="to_location_id" id="to_location_id" class="form-select" required>
-                                <option value="">Selectează locația de destinație</option>
-                                <?php foreach ($activeLocations as $location): ?>
-                                    <option value="<?= $location['id'] ?>">
-                                        <?= htmlspecialchars($location['location_code']) ?> - <?= htmlspecialchars($location['zone']) ?>
-                                    </option>
-                                <?php endforeach; ?>
-                            </select>
-                        </div>
-                        
-                        <div class="form-group">
-                            <label for="quantity" class="form-label">Cantitate</label>
-                            <input type="number" name="quantity" id="quantity" class="form-input" min="1" required>
-                            <small class="form-hint">Cantitatea de relocat</small>
-                        </div>
-                    </div>
-                    
-                    <div class="form-actions">
-                        <button type="submit" class="btn btn-primary">
-                            <span class="material-symbols-outlined">add</span>
-                            Creează Task Relocare
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
 
-        <!-- Pending Tasks Section -->
-        <div class="tasks-section">
-            <div class="section-header">
-                <h2 class="section-title">
-                    <span class="material-symbols-outlined">format_list_bulleted</span>
-                    Task-uri În Așteptare
-                </h2>
-            </div>
-            
-            <div class="card">
-                <?php if (empty($pendingTasks)): ?>
-                    <div class="empty-state">
-                        <span class="material-symbols-outlined empty-icon">inbox</span>
-                        <p class="empty-text">Nu există task-uri de relocare în așteptare.</p>
-                    </div>
-                <?php else: ?>
+            <?php if (empty($pendingTasks)): ?>
+                <div class="empty-state">
+                    <span class="material-symbols-outlined empty-icon">inbox</span>
+                    <p class="empty-text">Nu există task-uri de relocare în așteptare.</p>
+                </div>
+            <?php else: ?>
+                <div class="card">
                     <div class="table-container">
                         <table class="data-table">
                             <thead>
@@ -403,12 +197,11 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                                         </td>
                                         <td><?= date('d.m.Y H:i', strtotime($task['created_at'] ?? '')) ?></td>
                                         <td>
-                                            <form method="POST" style="display: inline;">
+                                            <form method="POST" style="display:inline;">
                                                 <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token'] ?>">
                                                 <input type="hidden" name="action" value="complete_relocation">
                                                 <input type="hidden" name="task_id" value="<?= $task['id'] ?>">
-                                                <button type="submit" class="btn btn-sm btn-success" 
-                                                        onclick="return confirm('Finalizezi această relocare?')">
+                                                <button type="submit" class="btn btn-sm btn-success" onclick="return confirm('Finalizezi această relocare?')">
                                                     <span class="material-symbols-outlined">check</span>
                                                     Finalizează
                                                 </button>
@@ -419,50 +212,13 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                             </tbody>
                         </table>
                     </div>
-                <?php endif; ?>
-            </div>
+                </div>
+            <?php endif; ?>
         </div>
     </div>
 
-    <?php require_once __DIR__ . '/includes/warehouse_footer.php'; ?>
-
-    <!-- JavaScript for enhanced functionality -->
     <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            // Form validation and UX enhancements
-            const form = document.getElementById('relocation-form');
-            const fromLocationSelect = document.getElementById('from_location_id');
-            const toLocationSelect = document.getElementById('to_location_id');
-            
-            // Prevent selecting same location for origin and destination
-            function updateLocationOptions() {
-                const fromValue = fromLocationSelect.value;
-                const toOptions = toLocationSelect.querySelectorAll('option');
-                
-                toOptions.forEach(option => {
-                    if (option.value === fromValue && fromValue !== '') {
-                        option.disabled = true;
-                    } else {
-                        option.disabled = false;
-                    }
-                });
-            }
-            
-            fromLocationSelect.addEventListener('change', updateLocationOptions);
-            toLocationSelect.addEventListener('change', function() {
-                const toValue = this.value;
-                const fromOptions = fromLocationSelect.querySelectorAll('option');
-                
-                fromOptions.forEach(option => {
-                    if (option.value === toValue && toValue !== '') {
-                        option.disabled = true;
-                    } else {
-                        option.disabled = false;
-                    }
-                });
-            });
-            
-            // Auto-hide alerts after 5 seconds
+        document.addEventListener('DOMContentLoaded', function () {
             const alerts = document.querySelectorAll('.alert');
             alerts.forEach(alert => {
                 setTimeout(() => {
@@ -472,3 +228,7 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
             });
         });
     </script>
+    <?php require_once __DIR__ . '/includes/warehouse_footer.php'; ?>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- Rework warehouse relocation page with mobile picker layout
- Remove manual relocation task creation
- Add mobile-first styles for relocation tasks

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68945fba12008320b4eb57d0db50eb2e