### PR TITLE
feat: add navbar and stats to relocation page

### DIFF
--- a/styles/warehouse-css/warehouse_relocation.css
+++ b/styles/warehouse-css/warehouse_relocation.css
@@ -2,6 +2,70 @@
 
 /* Mobile-friendly relocation styles */
 
+.main-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--spacing-lg);
+}
+
+.stats-section {
+  margin-bottom: var(--spacing-lg);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+.stat-card {
+  background-color: var(--dark-gray);
+  padding: 1rem 0.5rem;
+  border-radius: 6px;
+  text-align: center;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  position: relative;
+  transition: all 0.3s ease;
+}
+
+.stat-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background: linear-gradient(90deg, var(--white) 0%, var(--light-gray) 100%);
+}
+
+.stat-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+}
+
+.stat-icon {
+  font-size: 1.5rem;
+  color: var(--white);
+  margin-bottom: 1rem;
+}
+
+.stat-number {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--white);
+  display: block;
+  line-height: 1;
+  margin-bottom: 0.5rem;
+}
+
+.stat-label {
+  font-size: 0.9rem;
+  color: var(--light-gray);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 500;
+}
+
 .section-header {
   background-color: var(--dark-gray);
   padding: var(--spacing-md);


### PR DESCRIPTION
## Summary
- show pending, ready, and completed relocation counts at top of page
- add warehouse navbar for consistent navigation
- style relocation page with stat card layout

## Testing
- `php -l warehouse_relocation.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6894643217fc8320a692ea74a9ff524f