### PR TITLE
feat: allow assigning multiple products to level

### DIFF
--- a/styles/locations.css
+++ b/styles/locations.css
@@ -1394,6 +1394,38 @@
     border-bottom: none;
 }
 
+/* Multiple product selection */
+.multi-product-search {
+    margin-top: 0.5rem;
+}
+
+.selected-products {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-top: 0.5rem;
+}
+
+.selected-product-item {
+    background: var(--primary-light);
+    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.85rem;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.selected-product-item button {
+    background: none;
+    border: none;
+    color: var(--danger-color);
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 0;
+}
+
 .search-result-item.no-results {
     color: var(--text-secondary);
     font-style: italic;


### PR DESCRIPTION
## Summary
- show multi-product search when choosing "Multiple Produse" policy without subdivisions
- collect and persist allowed products for each level
- style product selection list

## Testing
- `composer install --no-interaction`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689465024dc88320815ec65db9141ca7