### PR TITLE
Preselect processing orders on mobile picker and fix completed counter

### DIFF
--- a/models/Order.php
+++ b/models/Order.php
@@ -316,7 +316,7 @@ class Order
     public function countCompletedToday(): int {
         try {
             $query = "SELECT COUNT(*) FROM orders
-                    WHERE LOWER(status) = 'completed' AND DATE(updated_at) = CURDATE()";
+                    WHERE LOWER(status) IN ('completed','ready','ready_to_ship') AND DATE(updated_at) = CURDATE()";
             $stmt = $this->conn->prepare($query);
             $stmt->execute();
             return (int)$stmt->fetchColumn();

--- a/scripts/warehouse-js/warehouse_orders.js
+++ b/scripts/warehouse-js/warehouse_orders.js
@@ -15,9 +15,18 @@ console.log('Warehouse Orders JS loaded, API_BASE:', API_BASE);
 document.addEventListener('DOMContentLoaded', function() {
     console.log('DOM loaded, initializing warehouse orders dashboard');
     initializeEventListeners();
+    setDefaultFilter();
     loadOrders();
     setInterval(loadOrders, 30000); // Auto-refresh every 30 seconds
 });
+
+function setDefaultFilter() {
+    activeStatusFilter = 'processing';
+    const processingCard = document.querySelector('.stat-card[data-status="processing"]');
+    if (processingCard) {
+        processingCard.classList.add('active');
+    }
+}
 
 /**
  * Initialize event listeners
@@ -99,6 +108,12 @@ async function loadOrders() {
  */
 function applyFilters() {
     filteredOrders = allOrders.filter(order => {
+        if (activeStatusFilter === 'processing') {
+            return order.status === 'processing' || order.status === 'assigned';
+        }
+        if (activeStatusFilter === 'completed') {
+            return order.status === 'completed' || order.status === 'ready';
+        }
         return !activeStatusFilter || order.status === activeStatusFilter;
     });
 


### PR DESCRIPTION
## Summary
- Auto-select "In procesare" filter and include assigned orders in processing filter
- Count today's completed orders when status is completed or ready