### PR TITLE
Allow assigning product location directly from products list

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -38,7 +38,7 @@ if (empty($apiKey)) {
 <?php
 // Define an array of page-specific JavaScript files.
 $pageSpecificJS = [
-    'products' => 'products.js',
+    'products' => ['products.js', 'inventory.js'],
     'inventory' => 'inventory.js',
     'users' => 'users.js',
     'transactions' => 'transactions.js',


### PR DESCRIPTION
## Summary
- show **Atribuie Locatie** button for products without a location
- reuse inventory's **Adaugă Stoc** modal on products page to assign location and stock
- load inventory scripts on products page to support the new modal