### PR TITLE
Fix dashboard recent orders and stock alerts

### DIFF
--- a/models/Inventory.php
+++ b/models/Inventory.php
@@ -1066,13 +1066,14 @@ public function getCriticalStockAlerts(int $limit = 10): array {
     try {
         $query = "SELECT p.product_id, p.sku, p.name, p.min_stock_level,
                          COALESCE(i.total_qty, 0) as quantity
-                  FROM products p 
+                  FROM products p
                   LEFT JOIN (
-                      SELECT product_id, SUM(quantity) as total_qty 
-                      FROM inventory 
+                      SELECT product_id, SUM(quantity) as total_qty
+                      FROM inventory
                       GROUP BY product_id
                   ) i ON p.product_id = i.product_id
                   WHERE COALESCE(i.total_qty, 0) <= p.min_stock_level
+                    AND LOWER(p.category) = 'marfa'
                   ORDER BY (COALESCE(i.total_qty, 0) / GREATEST(p.min_stock_level, 1)) ASC
                   LIMIT :limit";
         

--- a/models/Order.php
+++ b/models/Order.php
@@ -334,16 +334,16 @@ class Order
      */
     public function getRecentOrders(int $limit = 10): array {
         try {
-            $query = "SELECT id, customer_name, status, total_amount, created_at
-                    FROM orders 
-                    ORDER BY created_at DESC 
+            $query = "SELECT id, order_number, customer_name, status, total_value, order_date
+                    FROM {$this->table}
+                    ORDER BY order_date DESC
                     LIMIT :limit";
-            
+
             $stmt = $this->conn->prepare($query);
             $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
             $stmt->execute();
             return $stmt->fetchAll(PDO::FETCH_ASSOC);
-            
+
         } catch (PDOException $e) {
             error_log("Error getting recent orders: " . $e->getMessage());
             return [];


### PR DESCRIPTION
## Summary
- fix getRecentOrders query to use correct columns and order by order_date
- restrict critical stock alerts to low-stock products in the Marfa category

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a1a6f1223483208955133a21b547d7