### PR TITLE
feat: add stock filters for category and seller

### DIFF
--- a/product-units.php
+++ b/product-units.php
@@ -434,6 +434,14 @@ $currentPage = 'product-units';
 
                         <div class="stock-search-bar">
                             <input type="text" id="stockSearch" class="stock-search-input" placeholder="Caută produs...">
+                            <select id="stockCategoryFilter" class="stock-filter-select">
+                                <option value="">Toate categoriile</option>
+                            </select>
+                            <select id="stockSellerFilter" class="stock-filter-select">
+                                <option value="">Toți furnizorii</option>
+                                <option value="assigned">Cu furnizor</option>
+                                <option value="unassigned">Fără furnizor</option>
+                            </select>
                         </div>
                         <div class="table-container">
                             <table class="data-table">

--- a/scripts/product-units.js
+++ b/scripts/product-units.js
@@ -39,6 +39,8 @@ const ProductUnitsApp = {
         pendingList: [],
         pendingSearch: '',
         stockSearch: '',
+        stockCategory: '',
+        stockSeller: '',
         barrelDimensions: [],
         filteredData: [],
         isLoading: false,
@@ -104,6 +106,8 @@ const ProductUnitsApp = {
             addStockSetting: document.getElementById('addStockSetting'),
             stockSettingsBody: document.getElementById('stockSettingsBody'),
             stockSearchInput: document.getElementById('stockSearch'),
+            stockCategoryFilter: document.getElementById('stockCategoryFilter'),
+            stockSellerFilter: document.getElementById('stockSellerFilter'),
             stockPagination: document.getElementById('stockPagination'),
             stockSettingsModal: document.getElementById('stockSettingsModal'),
             stockSettingsForm: document.getElementById('stockSettingsForm'),
@@ -285,6 +289,22 @@ const ProductUnitsApp = {
                 this.state.stockPagination.offset = 0;
                 this.loadStockSettings();
             }, this.config.debounceDelay));
+        }
+
+        if (this.elements.stockCategoryFilter) {
+            this.elements.stockCategoryFilter.addEventListener('change', () => {
+                this.state.stockCategory = this.elements.stockCategoryFilter.value;
+                this.state.stockPagination.offset = 0;
+                this.loadStockSettings();
+            });
+        }
+
+        if (this.elements.stockSellerFilter) {
+            this.elements.stockSellerFilter.addEventListener('change', () => {
+                this.state.stockSeller = this.elements.stockSellerFilter.value;
+                this.state.stockPagination.offset = 0;
+                this.loadStockSettings();
+            });
         }
 
         if (this.elements.pendingSearchInput) {
@@ -487,7 +507,8 @@ const ProductUnitsApp = {
             const url = `${this.config.apiEndpoints.products}?limit=1000`;
             const response = await this.apiCall('GET', url);
             this.state.products = response.data || response;
-            
+            this.populateStockCategoryFilter();
+
             console.log(`Loaded ${this.state.products.length} products`);
         } catch (error) {
             console.error('Error loading products:', error);
@@ -514,6 +535,19 @@ const ProductUnitsApp = {
             const opt = document.createElement('option');
             opt.value = dim.id;
             opt.textContent = dim.label;
+            select.appendChild(opt);
+        });
+    },
+
+    populateStockCategoryFilter() {
+        if (!this.elements.stockCategoryFilter) return;
+        const select = this.elements.stockCategoryFilter;
+        const categories = [...new Set(this.state.products.map(p => p.category).filter(Boolean))].sort();
+        select.innerHTML = '<option value="">Toate categoriile</option>';
+        categories.forEach(cat => {
+            const opt = document.createElement('option');
+            opt.value = cat;
+            opt.textContent = cat;
             select.appendChild(opt);
         });
     },
@@ -1739,6 +1773,12 @@ showNotification(message, type = 'info') {
                 limit: this.state.stockPagination.limit,
                 offset: this.state.stockPagination.offset
             });
+            if (this.state.stockCategory) {
+                params.append('category', this.state.stockCategory);
+            }
+            if (this.state.stockSeller) {
+                params.append('seller', this.state.stockSeller);
+            }
             const url = `${this.config.apiEndpoints.stockSettings}?${params.toString()}`;
             const response = await this.apiCall('GET', url);
             this.state.stockSettings = response.data || [];

--- a/styles/product-units.css
+++ b/styles/product-units.css
@@ -1108,6 +1108,10 @@ option {
 /* === STOCK MANAGEMENT SEARCH & PAGINATION === */
 .stock-search-bar {
     margin-bottom: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
 }
 
 .stock-search-input {
@@ -1118,6 +1122,25 @@ option {
     color: var(--text-primary);
     width: 100%;
     max-width: 300px;
+}
+
+.stock-filter-select {
+    padding: 0.75rem;
+    border: 1px solid var(--input-border);
+    border-radius: var(--border-radius);
+    background: var(--input-background);
+    color: var(--text-primary);
+    max-width: 200px;
+}
+
+.stock-filter-select:focus {
+    outline: none;
+    border-color: var(--input-focus);
+    box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.1);
+}
+
+.stock-filter-select option {
+    background-color: var(--container-background);
 }
 
 .pagination-wrapper {


### PR DESCRIPTION
## Summary
- add category and seller dropdown filters to stock management
- populate filters and apply them when loading stock settings
- support new filters in API and style dropdown options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1aa6ba9208320a6bb2eeb6baffcdc