### PR TITLE
Fix receiving alerts to display at top for 3 seconds

### DIFF
--- a/scripts/warehouse-js/warehouse_receiving.js
+++ b/scripts/warehouse-js/warehouse_receiving.js
@@ -982,26 +982,23 @@ class WarehouseReceiving {
     showMessage(message, type) {
         // Create alert element
         const alertEl = document.createElement('div');
-        alertEl.className = `alert alert-${type === 'success' ? 'success' : 'danger'}`;
+        alertEl.className = `alert alert-${type === 'success' ? 'success' : 'danger'} alert-floating`;
         alertEl.innerHTML = `
             <span class="material-symbols-outlined">
                 ${type === 'success' ? 'check_circle' : 'error'}
             </span>
             ${this.escapeHtml(message)}
         `;
-        
-        // Insert at top of main content
-        const mainContent = document.querySelector('.receiving-container');
-        if (mainContent) {
-            mainContent.insertBefore(alertEl, mainContent.firstChild);
-            
-            // Auto-hide after 5 seconds
-            setTimeout(() => {
-                if (alertEl.parentNode) {
-                    alertEl.parentNode.removeChild(alertEl);
-                }
-            }, 5000);
-        }
+
+        // Display at top of screen
+        document.body.appendChild(alertEl);
+
+        // Auto-hide after 3 seconds
+        setTimeout(() => {
+            if (alertEl.parentNode) {
+                alertEl.parentNode.removeChild(alertEl);
+            }
+        }, 3000);
     }
 
     getStatusText(status) {
@@ -1089,6 +1086,16 @@ class WarehouseReceiving {
 // Initialize when DOM is loaded
 document.addEventListener('DOMContentLoaded', function() {
     window.receivingSystem = new WarehouseReceiving();
+
+    // Auto-hide any pre-rendered alerts
+    const existingAlert = document.querySelector('.alert-floating');
+    if (existingAlert) {
+        setTimeout(() => {
+            if (existingAlert.parentNode) {
+                existingAlert.parentNode.removeChild(existingAlert);
+            }
+        }, 3000);
+    }
 });
 
 // Global functions for onclick handlers

--- a/styles/warehouse-css/warehouse_receiving.css
+++ b/styles/warehouse-css/warehouse_receiving.css
@@ -94,6 +94,15 @@ body {
   border: 1px solid rgba(220, 53, 69, 0.3);
 }
 
+.alert-floating {
+  position: fixed;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  margin: 0;
+}
+
 /* ===== STEP SECTIONS ===== */
 .step-section {
   display: none;

--- a/warehouse_receiving.php
+++ b/warehouse_receiving.php
@@ -151,7 +151,7 @@ $currentPage = 'warehouse_receiving';
 
                 <!-- Alert Messages -->
                 <?php if (!empty($message)): ?>
-                    <div class="alert alert-<?= $messageType === 'success' ? 'success' : 'danger' ?>" role="alert">
+                    <div class="alert alert-<?= $messageType === 'success' ? 'success' : 'danger' ?> alert-floating" role="alert">
                         <span class="material-symbols-outlined">
                             <?= $messageType === 'success' ? 'check_circle' : 'error' ?>
                         </span>


### PR DESCRIPTION
## Summary
- Ensure receiving workflow alerts float at the top of the viewport and auto-dismiss after 3 seconds
- Add floating alert style and apply it to server-rendered messages
- Clean up pre-rendered alerts on page load