### PR TITLE
fix: restore activity logging after schema update

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -106,12 +106,34 @@ try {
     error_log('Activity log init failed: ' . $e->getMessage());
 }
 
-function logActivity($userId, $action, $resourceType, $resourceId, $description, $oldValues = null, $newValues = null) {
+function logActivity(
+    $userId,
+    $action,
+    $entityType,
+    $entityId,
+    $description,
+    $oldValues = null,
+    $newValues = null,
+    $resourceType = null,
+    $resourceId = null
+) {
     $logger = $GLOBALS['activityLog'] ?? null;
     if ($logger instanceof ActivityLog) {
         $ip = $_SERVER['REMOTE_ADDR'] ?? null;
         $agent = $_SERVER['HTTP_USER_AGENT'] ?? null;
-        return $logger->log($userId, $action, $resourceType, $resourceId, $description, $oldValues, $newValues, $ip, $agent);
+        return $logger->log(
+            $userId,
+            $action,
+            $entityType,
+            $entityId,
+            $description,
+            $oldValues,
+            $newValues,
+            $resourceType,
+            $resourceId,
+            $ip,
+            $agent
+        );
     }
     return false;
 }

--- a/models/ActivityLog.php
+++ b/models/ActivityLog.php
@@ -13,22 +13,26 @@ class ActivityLog {
     public function log(
         int $userId,
         string $action,
-        string $resourceType,
-        int|string $resourceId,
+        string $entityType,
+        int|string $entityId,
         string $description,
         $oldValues = null,
         $newValues = null,
+        ?string $resourceType = null,
+        int|string|null $resourceId = null,
         ?string $ipAddress = null,
         ?string $userAgent = null
     ): bool {
         $query = "INSERT INTO {$this->table}
-                  (user_id, action, resource_type, resource_id, description, old_values, new_values, ip_address, user_agent, created_at)
-                  VALUES (:user_id, :action, :resource_type, :resource_id, :description, :old_values, :new_values, :ip_address, :user_agent, NOW())";
+                  (user_id, action, entity_type, entity_id, resource_type, resource_id, description, old_values, new_values, ip_address, user_agent, created_at)
+                  VALUES (:user_id, :action, :entity_type, :entity_id, :resource_type, :resource_id, :description, :old_values, :new_values, :ip_address, :user_agent, NOW())";
 
         try {
             $stmt = $this->conn->prepare($query);
             $stmt->bindValue(':user_id', $userId, PDO::PARAM_INT);
             $stmt->bindValue(':action', $action);
+            $stmt->bindValue(':entity_type', $entityType);
+            $stmt->bindValue(':entity_id', $entityId);
             $stmt->bindValue(':resource_type', $resourceType);
             $stmt->bindValue(':resource_id', $resourceId);
             $stmt->bindValue(':description', $description);


### PR DESCRIPTION
## Summary
- support new `entity_type` and `entity_id` columns when recording activity logs
- expand global `logActivity` helper to handle optional resource context

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a597b0b4b483208ffce11769ae75d0