### PR TITLE
Add label preview button for production receipts

### DIFF
--- a/warehouse_receiving.php
+++ b/warehouse_receiving.php
@@ -221,6 +221,10 @@ $currentPage = 'warehouse_receiving';
                             <span class="material-symbols-outlined">print</span>
                             Printează Etichete
                         </button>
+                        <button type="button" class="btn btn-outline-secondary btn-sm" id="preview-label-btn" style="margin-left:5px;">
+                            <span class="material-symbols-outlined">visibility</span>
+                            Preview
+                        </button>
                         <button type="button" class="btn btn-success" id="add-stock-btn" style="display:none;" disabled>
                             <span class="material-symbols-outlined">inventory_2</span>
                             Adaugă în Stoc


### PR DESCRIPTION
## Summary
- revert preview confirmation behavior
- support preview-only action in production receipt API
- add optional Preview Label button next to print

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68ac50c314848320ba8fa2fc510c5442