### PR TITLE
Implement return lookup and start endpoints

### DIFF
--- a/database/migrations/2025_08_26_081803_create_returns_tables.php
+++ b/database/migrations/2025_08_26_081803_create_returns_tables.php
@@ -17,7 +17,7 @@ class CreateReturnsTablesMigration {
                 order_id INT NOT NULL,
                 processed_by INT NOT NULL,
                 verified_by INT NULL,
-                status ENUM('pending','verified','completed','rejected') DEFAULT 'pending',
+                status ENUM('in_progress','pending','verified','completed','rejected') DEFAULT 'in_progress',
                 notes TEXT,
                 verified_at TIMESTAMP NULL,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary
- add return eligibility checks and remaining quantity calculations to `/api/returns/lookup/{order}`
- create transactional `/api/returns/start` endpoint with in_progress status
- extend returns table to include `in_progress` status

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68ad82215bf88320b743321da23e2e2c