### PR TITLE
feat: add return item verification with progress tracking

### DIFF
--- a/database/migrations/2025_09_12_000000_add_opened_condition_to_returns.php
+++ b/database/migrations/2025_09_12_000000_add_opened_condition_to_returns.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Migration: add_opened_condition_to_returns
+ * Purpose: Allow 'opened' as an item condition for return items and discrepancies
+ */
+
+class AddOpenedConditionToReturnsMigration {
+    public function up(PDO $pdo) {
+        $pdo->exec("ALTER TABLE return_items MODIFY item_condition ENUM('good','damaged','defective','opened') NOT NULL DEFAULT 'good'");
+        $pdo->exec("ALTER TABLE return_discrepancies MODIFY item_condition ENUM('good','damaged','defective','opened') DEFAULT 'good'");
+    }
+
+    public function down(PDO $pdo) {
+        $pdo->exec("ALTER TABLE return_items MODIFY item_condition ENUM('good','damaged','defective') NOT NULL DEFAULT 'good'");
+        $pdo->exec("ALTER TABLE return_discrepancies MODIFY item_condition ENUM('good','damaged','defective') DEFAULT 'good'");
+    }
+}
+
+return new AddOpenedConditionToReturnsMigration();


### PR DESCRIPTION
## Summary
- enhance `/api/returns/{return_id}/verify-item` to match items to order lines, enforce quantity limits and track verification progress
- allow recording 'opened' condition for return items and discrepancies