### PR TITLE
Add returns processing admin dashboard

### DIFF
--- a/api/returns/admin.php
+++ b/api/returns/admin.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Admin Returns API
+ * Provides summary, list, detail and stats for returns management.
+ */
+
+header('Content-Type: application/json');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+// Require admin or manager role
+if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'] ?? '', ['admin','manager'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Unauthorized']);
+    exit;
+}
+
+$config = require BASE_PATH . '/config/config.php';
+$db = $config['connection_factory']();
+
+$action = $_GET['action'] ?? 'list';
+
+try {
+    switch ($action) {
+        case 'summary':
+            summary($db);
+            break;
+        case 'stats':
+            stats($db);
+            break;
+        case 'detail':
+            $id = (int)($_GET['id'] ?? 0);
+            detail($db, $id);
+            break;
+        case 'list':
+        default:
+            listReturns($db);
+            break;
+    }
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+}
+
+function summary(PDO $db) {
+    $stmt = $db->query("SELECT
+            SUM(status='in_progress') AS in_progress,
+            SUM(status='pending') AS pending,
+            SUM(status='completed') AS completed
+        FROM returns");
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    $disc = $db->query("SELECT COUNT(*) FROM return_discrepancies WHERE resolution_status='pending'")->fetchColumn();
+    echo json_encode([
+        'success' => true,
+        'summary' => [
+            'in_progress' => (int)$row['in_progress'],
+            'pending' => (int)$row['pending'],
+            'completed' => (int)$row['completed'],
+            'discrepancies' => (int)$disc
+        ]
+    ]);
+}
+
+function stats(PDO $db) {
+    $stmt = $db->query("SELECT DATE(created_at) AS day, COUNT(*) AS total
+                        FROM returns
+                        WHERE created_at >= DATE_SUB(CURDATE(), INTERVAL 30 DAY)
+                        GROUP BY day ORDER BY day");
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode(['success' => true, 'stats' => $rows]);
+}
+
+function listReturns(PDO $db) {
+    $status = $_GET['status'] ?? '';
+    $search = trim($_GET['search'] ?? '');
+    $from = $_GET['from'] ?? '';
+    $to = $_GET['to'] ?? '';
+
+    $params = [];
+    $where = [];
+
+    if ($status !== '') {
+        $where[] = 'r.status = :status';
+        $params[':status'] = $status;
+    }
+    if ($search !== '') {
+        $where[] = '(o.order_number LIKE :search OR o.customer_name LIKE :search)';
+        $params[':search'] = "%$search%";
+    }
+    if ($from !== '') {
+        $where[] = 'r.created_at >= :from';
+        $params[':from'] = $from . ' 00:00:00';
+    }
+    if ($to !== '') {
+        $where[] = 'r.created_at <= :to';
+        $params[':to'] = $to . ' 23:59:59';
+    }
+
+    $sql = "SELECT r.id, o.order_number, o.customer_name, r.status,
+                   u.username AS processed_by, r.created_at, r.verified_at,
+                   (SELECT COUNT(*) FROM return_discrepancies rd WHERE rd.return_id = r.id) AS discrepancies
+            FROM returns r
+            JOIN orders o ON r.order_id = o.id
+            LEFT JOIN users u ON r.processed_by = u.id";
+    if ($where) {
+        $sql .= ' WHERE ' . implode(' AND ', $where);
+    }
+    $sql .= ' ORDER BY r.created_at DESC LIMIT 100';
+
+    $stmt = $db->prepare($sql);
+    $stmt->execute($params);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    if (isset($_GET['export']) && $_GET['export'] === 'csv') {
+        header('Content-Type: text/csv');
+        header('Content-Disposition: attachment; filename="returns.csv"');
+        $out = fopen('php://output', 'w');
+        fputcsv($out, ['ID','Order','Customer','Status','Processed By','Created At','Verified At','Discrepancies']);
+        foreach ($rows as $r) {
+            fputcsv($out, [$r['id'],$r['order_number'],$r['customer_name'],$r['status'],$r['processed_by'],$r['created_at'],$r['verified_at'],$r['discrepancies']]);
+        }
+        fclose($out);
+        return;
+    }
+
+    echo json_encode(['success' => true, 'returns' => $rows]);
+}
+
+function detail(PDO $db, int $id) {
+    if ($id <= 0) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'message' => 'Invalid ID']);
+        return;
+    }
+
+    $stmt = $db->prepare("SELECT r.id, r.status, r.notes, r.created_at, r.verified_at,
+                                   o.order_number, o.customer_name,
+                                   u.username AS processed_by, v.username AS verified_by
+                           FROM returns r
+                           JOIN orders o ON r.order_id = o.id
+                           LEFT JOIN users u ON r.processed_by = u.id
+                           LEFT JOIN users v ON r.verified_by = v.id
+                           WHERE r.id = :id");
+    $stmt->execute([':id' => $id]);
+    $return = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$return) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'message' => 'Return not found']);
+        return;
+    }
+
+    $itemsStmt = $db->prepare("SELECT ri.id, p.sku, p.name, ri.quantity_returned, ri.item_condition, ri.is_extra
+                               FROM return_items ri
+                               JOIN products p ON ri.product_id = p.product_id
+                               WHERE ri.return_id = :id");
+    $itemsStmt->execute([':id' => $id]);
+    $items = $itemsStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $discStmt = $db->prepare("SELECT rd.id, p.sku, p.name, rd.discrepancy_type, rd.expected_quantity,
+                                     rd.actual_quantity, rd.item_condition, rd.resolution_status
+                              FROM return_discrepancies rd
+                              JOIN products p ON rd.product_id = p.product_id
+                              WHERE rd.return_id = :id");
+    $discStmt->execute([':id' => $id]);
+    $discrepancies = $discStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode([
+        'success' => true,
+        'return' => $return,
+        'items' => $items,
+        'discrepancies' => $discrepancies
+    ]);
+}

--- a/includes/warehouse_footer.php
+++ b/includes/warehouse_footer.php
@@ -44,7 +44,8 @@ $warehousePageJS = [
     'mobile_picker'       => 'mobile_picker.js',        // Will use silent timing
     'warehouse_receiving' => 'warehouse_receiving.js',  // Will use silent timing
     'warehouse_inventory' => 'warehouse_inventory.js',
-    'warehouse_relocation' => 'warehouse_relocation.js'
+    'warehouse_relocation' => 'warehouse_relocation.js',
+    'returns_dashboard' => 'returns_dashboard.js'
 ];
 
 // Check if a specific script is defined for the current warehouse page

--- a/includes/warehouse_header.php
+++ b/includes/warehouse_header.php
@@ -41,7 +41,8 @@ $warehousePageCSS = [
     'warehouse_receiving' => 'warehouse_receiving.css',
     'warehouse_inventory' => 'warehouse_inventory.css',
     'warehouse_relocation' => 'warehouse_relocation.css',
-    'mobile_returns' => 'mobile_returns.css'
+    'mobile_returns' => 'mobile_returns.css',
+    'returns_dashboard' => 'returns_dashboard.css'
 ];
 
 if (isset($warehousePageCSS[$currentPage])) {

--- a/returns_dashboard.php
+++ b/returns_dashboard.php
@@ -1,0 +1,114 @@
+<?php
+// Admin Returns Dashboard
+error_reporting(E_ALL);
+ini_set('display_errors', 0);
+ini_set('log_errors', 1);
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', __DIR__);
+}
+require_once BASE_PATH . '/bootstrap.php';
+$config = require BASE_PATH . '/config/config.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+// Require admin/manager role
+if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'], ['admin','manager'])) {
+    header('Location: ' . getNavUrl('login.php'));
+    exit;
+}
+
+$currentPage = 'returns_dashboard';
+?>
+<!DOCTYPE html>
+<html lang="ro">
+<head>
+    <?php require_once __DIR__ . '/includes/warehouse_header.php'; ?>
+    <!-- DataTables & Chart.js -->
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <?php require_once __DIR__ . '/includes/warehouse_navbar.php'; ?>
+    <div class="main-container">
+        <div class="stats-grid">
+            <div class="stat-card">
+                <div id="stat-in-progress" class="stat-number">0</div>
+                <div class="stat-label">În verificare</div>
+            </div>
+            <div class="stat-card">
+                <div id="stat-pending" class="stat-number">0</div>
+                <div class="stat-label">Așteaptă inventariere</div>
+            </div>
+            <div class="stat-card">
+                <div id="stat-completed" class="stat-number">0</div>
+                <div class="stat-label">Finalizate</div>
+            </div>
+            <div class="stat-card">
+                <div id="stat-discrepancies" class="stat-number">0</div>
+                <div class="stat-label">Discrepanțe</div>
+            </div>
+        </div>
+
+        <form id="filter-form" class="filters">
+            <div>
+                <label for="from">De la</label>
+                <input type="date" id="from" name="from">
+            </div>
+            <div>
+                <label for="to">Până la</label>
+                <input type="date" id="to" name="to">
+            </div>
+            <div>
+                <label for="search">Caută</label>
+                <input type="text" id="search" name="search" placeholder="Comandă sau client">
+            </div>
+            <div>
+                <label for="status">Status</label>
+                <select id="status" name="status">
+                    <option value="">Toate</option>
+                    <option value="in_progress">În verificare</option>
+                    <option value="pending">Așteaptă inventariere</option>
+                    <option value="completed">Finalizate</option>
+                </select>
+            </div>
+            <button type="submit" class="btn btn-primary">Filtrează</button>
+            <button type="button" id="export-btn" class="btn btn-secondary">Exportă CSV</button>
+        </form>
+
+        <table id="returns-table" class="data-table">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Comandă</th>
+                    <th>Client</th>
+                    <th>Status</th>
+                    <th>Procesat de</th>
+                    <th>Creat</th>
+                    <th>Verificat</th>
+                    <th>Discrepanțe</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+
+        <div class="chart-card">
+            <canvas id="returns-chart" height="120"></canvas>
+        </div>
+    </div>
+
+    <!-- Detail Modal -->
+    <div id="return-modal" class="modal" style="display:none;">
+        <div class="modal-content">
+            <button class="modal-close" onclick="closeReturnModal()">&times;</button>
+            <div id="return-details"></div>
+        </div>
+    </div>
+
+    <?php require_once __DIR__ . '/includes/warehouse_footer.php'; ?>
+</body>
+</html>

--- a/scripts/warehouse-js/returns_dashboard.js
+++ b/scripts/warehouse-js/returns_dashboard.js
@@ -1,0 +1,118 @@
+// Returns Dashboard Logic
+let returnsTable;
+let returnsChart;
+
+async function fetchSummary() {
+    try {
+        const res = await fetch(`${WMS_CONFIG.apiBase}/returns/admin.php?action=summary`);
+        const data = await res.json();
+        if (data.summary) {
+            document.getElementById('stat-in-progress').textContent = data.summary.in_progress;
+            document.getElementById('stat-pending').textContent = data.summary.pending;
+            document.getElementById('stat-completed').textContent = data.summary.completed;
+            document.getElementById('stat-discrepancies').textContent = data.summary.discrepancies;
+        }
+    } catch (err) {
+        console.error('Summary error', err);
+    }
+}
+
+function initTable() {
+    returnsTable = $('#returns-table').DataTable({
+        ajax: {
+            url: `${WMS_CONFIG.apiBase}/returns/admin.php?action=list`,
+            dataSrc: function(json){ return json.returns || []; }
+        },
+        columns: [
+            { data: 'id' },
+            { data: 'order_number' },
+            { data: 'customer_name' },
+            { data: 'status' },
+            { data: 'processed_by' },
+            { data: 'created_at' },
+            { data: 'verified_at' },
+            { data: 'discrepancies' }
+        ]
+    });
+
+    $('#returns-table tbody').on('click', 'tr', function(){
+        const data = returnsTable.row(this).data();
+        if (data) {
+            loadReturnDetail(data.id);
+        }
+    });
+}
+
+async function loadReturnDetail(id) {
+    try {
+        const res = await fetch(`${WMS_CONFIG.apiBase}/returns/admin.php?action=detail&id=${id}`);
+        const data = await res.json();
+        if (!data.success) return;
+        const r = data.return;
+        let html = `<h3>Return #${r.id} - ${r.order_number}</h3>`;
+        html += `<p>Status: ${r.status}</p>`;
+        html += `<p>Client: ${r.customer_name}</p>`;
+        html += '<h4>Produse</h4><ul>';
+        data.items.forEach(i => {
+            html += `<li>${i.sku} - ${i.name} x ${i.quantity_returned} (${i.item_condition})</li>`;
+        });
+        html += '</ul><h4>Discrepanțe</h4><ul>';
+        if (data.discrepancies.length === 0) {
+            html += '<li>Nicio discrepanță</li>';
+        } else {
+            data.discrepancies.forEach(d => {
+                html += `<li>${d.sku} - ${d.discrepancy_type} (${d.resolution_status})</li>`;
+            });
+        }
+        html += '</ul>';
+        document.getElementById('return-details').innerHTML = html;
+        document.getElementById('return-modal').style.display = 'flex';
+    } catch (err) {
+        console.error('detail error', err);
+    }
+}
+
+function closeReturnModal(){
+    document.getElementById('return-modal').style.display = 'none';
+}
+
+async function loadChart(){
+    try {
+        const res = await fetch(`${WMS_CONFIG.apiBase}/returns/admin.php?action=stats`);
+        const data = await res.json();
+        const labels = data.stats.map(r => r.day);
+        const values = data.stats.map(r => r.total);
+        if (returnsChart) returnsChart.destroy();
+        const ctx = document.getElementById('returns-chart').getContext('2d');
+        returnsChart = new Chart(ctx, {
+            type: 'line',
+            data: { labels, datasets: [{ label: 'Returnări', data: values, borderColor: '#1a73e8', fill: false }]},
+            options: { scales: { y: { beginAtZero: true }}}
+        });
+    } catch (err){ console.error('chart error', err); }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    fetchSummary();
+    initTable();
+    loadChart();
+
+    // filter form
+    document.getElementById('filter-form').addEventListener('submit', e => {
+        e.preventDefault();
+        const params = new URLSearchParams(new FormData(e.target));
+        const url = `${WMS_CONFIG.apiBase}/returns/admin.php?action=list&${params.toString()}`;
+        returnsTable.ajax.url(url).load();
+    });
+
+    document.getElementById('export-btn').addEventListener('click', () => {
+        const params = new URLSearchParams(new FormData(document.getElementById('filter-form')));
+        window.open(`${WMS_CONFIG.apiBase}/returns/admin.php?action=list&export=csv&${params.toString()}`);
+    });
+
+    setInterval(() => {
+        fetchSummary();
+        loadChart();
+        returnsTable.ajax.reload(null, false);
+    }, 60000);
+});

--- a/styles/warehouse-css/returns_dashboard.css
+++ b/styles/warehouse-css/returns_dashboard.css
@@ -1,0 +1,116 @@
+/* ===== RETURNS DASHBOARD STYLES ===== */
+/* Uses global warehouse design language */
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+}
+
+.stat-card {
+    background: var(--bg-secondary);
+    padding: var(--spacing-md);
+    border: 1px solid var(--border-light);
+    border-radius: 6px;
+    box-shadow: var(--shadow-light);
+    text-align: center;
+}
+
+.stat-number {
+    font-size: var(--font-size-2xl);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.stat-label {
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm);
+    align-items: flex-end;
+    margin-bottom: var(--spacing-lg);
+}
+
+.filters label {
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+}
+
+.filters input,
+.filters select {
+    padding: var(--spacing-sm);
+    border: 1px solid var(--border-light);
+    border-radius: 4px;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+}
+
+.filters button {
+    padding: var(--spacing-sm) var(--spacing-md);
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--bg-secondary);
+    box-shadow: var(--shadow-light);
+}
+
+.data-table th,
+.data-table td {
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-bottom: 1px solid var(--border-light);
+    text-align: left;
+    font-size: var(--font-size-sm);
+}
+
+.data-table th {
+    background: var(--bg-tertiary);
+    font-weight: 500;
+}
+
+.chart-card {
+    margin-top: var(--spacing-xl);
+    background: var(--bg-secondary);
+    padding: var(--spacing-md);
+    border: 1px solid var(--border-light);
+    border-radius: 6px;
+    box-shadow: var(--shadow-light);
+}
+
+.modal {
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: var(--bg-secondary);
+    padding: var(--spacing-lg);
+    border-radius: 6px;
+    max-width: 600px;
+    width: 100%;
+    box-shadow: var(--shadow-medium);
+}
+
+.modal-close {
+    position: absolute;
+    top: var(--spacing-sm);
+    right: var(--spacing-sm);
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.5rem;
+    color: var(--text-secondary);
+}


### PR DESCRIPTION
## Summary
- implement admin returns dashboard with stats, filters, charts, and real-time updates
- add API endpoints to list, summarize, and detail returns for management
- map new dashboard assets in header/footer and provide styling and JS

## Testing
- `php test_api.php` *(fails: Invalid API key)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8a824408832096dcef1df66bc726