### PR TITLE
Add return processing test utilities

### DIFF
--- a/database/migrations/2025_10_01_000000_create_return_sessions_table.php
+++ b/database/migrations/2025_10_01_000000_create_return_sessions_table.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Migration: create_return_sessions_table
+ * Purpose: Track barcode scan sessions and timing for returns
+ */
+
+class CreateReturnSessionsTableMigration {
+    /**
+     * Run the migration
+     */
+    public function up(PDO $pdo) {
+        $pdo->exec("CREATE TABLE return_sessions (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            return_id INT NOT NULL,
+            barcode VARCHAR(100) NOT NULL,
+            processing_time_ms INT NOT NULL DEFAULT 0,
+            scanned_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (return_id) REFERENCES returns(id) ON DELETE CASCADE,
+            INDEX idx_return_id (return_id),
+            INDEX idx_barcode (barcode)
+        )");
+    }
+
+    /**
+     * Rollback the migration
+     */
+    public function down(PDO $pdo) {
+        $pdo->exec("DROP TABLE IF EXISTS return_sessions");
+    }
+}
+
+return new CreateReturnSessionsTableMigration();

--- a/docs/returns_testing.md
+++ b/docs/returns_testing.md
@@ -1,0 +1,28 @@
+# Return Processing Testing Guide
+
+## Generating Test Data
+Run `php scripts/generate_return_test_data.php` to insert sample products, orders and a pending return.
+
+## API Smoke Tests
+Use `scripts/test_returns_api.sh` against a running instance:
+```bash
+BASE_URL=http://localhost/api/returns ./scripts/test_returns_api.sh
+```
+
+## Unit Tests
+```bash
+composer install
+vendor/bin/phpunit --filter ReturnServiceTest
+```
+
+## Integration Tests
+```bash
+vendor/bin/phpunit --filter ReturnWorkflowTest
+```
+
+## Performance Tests
+```bash
+vendor/bin/phpunit --filter ReturnPerformanceTest
+```
+
+These tests cover edge cases such as duplicate returns, invalid order numbers and inventory conflicts.

--- a/scripts/generate_return_test_data.php
+++ b/scripts/generate_return_test_data.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Script: generate_return_test_data.php
+ * Purpose: Populate database with sample products, orders and returns
+ * Usage: php scripts/generate_return_test_data.php
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+
+$config = require __DIR__ . '/../config/config.php';
+$pdo = $config['connection_factory']();
+
+$pdo->beginTransaction();
+
+// Sample product
+$pdo->exec("INSERT INTO products (product_id, sku, name, stock) VALUES (1001, 'TESTSKU', 'Test Product', 10)");
+// Sample order
+$pdo->exec("INSERT INTO orders (id, order_number, status, shipped_date, order_date) VALUES (501, 'R-100', 'shipped', NOW(), NOW())");
+// Order item
+$pdo->exec("INSERT INTO order_items (id, order_id, product_id, quantity) VALUES (7001, 501, 1001, 2)");
+
+// Duplicate return edge case
+$pdo->exec("INSERT INTO returns (id, order_id, processed_by, status) VALUES (9001, 501, 1, 'in_progress')");
+
+$pdo->commit();
+
+echo "Sample data inserted\n";

--- a/scripts/test_returns_api.sh
+++ b/scripts/test_returns_api.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Simple API smoke tests for return endpoints
+BASE_URL=${BASE_URL:-http://localhost:8000/api/returns}
+
+set -e
+
+curl -s "$BASE_URL/index.php/lookup/R-100" | grep -q 'order_number' && echo "Lookup ok"
+
+curl -s -X POST "$BASE_URL/index.php/start" -H 'Content-Type: application/json' \
+     -d '{"order_number":"R-100","processed_by":1}' | grep -q 'return_id' && echo "Start ok"
+
+curl -s -X POST "$BASE_URL/index.php/1/verify-item" -H 'Content-Type: application/json' \
+     -d '{"product_id":1001,"quantity":1}' | grep -q 'success' && echo "Verify ok"
+
+curl -s -X POST "$BASE_URL/index.php/1/complete" -H 'Content-Type: application/json' \
+     -d '{"verified_by":2}' | grep -q 'completed' && echo "Complete ok"

--- a/services/ReturnService.php
+++ b/services/ReturnService.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * ReturnService
+ * Simplified service layer for processing returns.
+ */
+
+class ReturnService {
+    private PDO $db;
+
+    public function __construct(PDO $db) {
+        $this->db = $db;
+    }
+
+    public function startReturn(string $orderNumber, int $processedBy): int {
+        $stmt = $this->db->prepare("SELECT id, status FROM orders WHERE order_number = :num");
+        $stmt->execute([':num' => $orderNumber]);
+        $order = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$order) {
+            throw new InvalidArgumentException('Order not found');
+        }
+        if ($order['status'] !== 'shipped') {
+            throw new RuntimeException('Order not shipped');
+        }
+        $check = $this->db->prepare("SELECT id FROM returns WHERE order_id = :oid AND status IN ('in_progress','pending')");
+        $check->execute([':oid' => $order['id']]);
+        if ($check->fetch()) {
+            throw new RuntimeException('Return already in progress');
+        }
+        $ins = $this->db->prepare("INSERT INTO returns (order_id, processed_by, status) VALUES (:oid, :pid, 'in_progress')");
+        $ins->execute([':oid' => $order['id'], ':pid' => $processedBy]);
+        return (int)$this->db->lastInsertId();
+    }
+
+    public function verifyItem(int $returnId, int $productId, int $qty, string $condition = 'good', bool $isExtra = false): void {
+        $ret = $this->db->prepare("SELECT order_id FROM returns WHERE id = :id AND status = 'in_progress'");
+        $ret->execute([':id' => $returnId]);
+        $row = $ret->fetch(PDO::FETCH_ASSOC);
+        if (!$row) {
+            throw new RuntimeException('Return not active');
+        }
+        $orderId = (int)$row['order_id'];
+        $oi = $this->db->prepare("SELECT id, quantity FROM order_items WHERE order_id = :oid AND product_id = :pid");
+        $oi->execute([':oid' => $orderId, ':pid' => $productId]);
+        $orderItem = $oi->fetch(PDO::FETCH_ASSOC);
+        $orderItemId = $orderItem['id'] ?? null;
+        $expected = $orderItem['quantity'] ?? 0;
+        $ins = $this->db->prepare("INSERT INTO return_items (return_id, order_item_id, product_id, quantity_returned, item_condition, is_extra)
+                                   VALUES (:rid, :oiid, :pid, :qty, :cond, :extra)");
+        $ins->execute([
+            ':rid' => $returnId,
+            ':oiid' => $orderItemId,
+            ':pid' => $productId,
+            ':qty' => $qty,
+            ':cond' => $condition,
+            ':extra' => $isExtra ? 1 : 0
+        ]);
+        if ($qty > $expected || $isExtra) {
+            $this->recordDiscrepancy($returnId, $orderItemId, $productId, $isExtra ? 'extra' : 'damaged', $expected, $qty, $condition);
+        }
+    }
+
+    public function completeReturn(int $returnId, int $verifiedBy): void {
+        $up = $this->db->prepare("UPDATE returns SET status = 'completed', verified_by = :vb, verified_at = CURRENT_TIMESTAMP WHERE id = :id");
+        $up->execute([':id' => $returnId, ':vb' => $verifiedBy]);
+    }
+
+    public function recordDiscrepancy(?int $returnId, ?int $orderItemId, int $productId, string $type,
+        int $expected, int $actual, string $condition = 'good', string $notes = ''): int {
+        $check = $this->db->prepare("SELECT id FROM return_discrepancies WHERE return_id = :rid AND product_id = :pid AND discrepancy_type = :dtype");
+        $check->execute([':rid' => $returnId, ':pid' => $productId, ':dtype' => $type]);
+        $existing = $check->fetch(PDO::FETCH_ASSOC);
+        if ($existing) {
+            $upd = $this->db->prepare("UPDATE return_discrepancies SET expected_quantity = expected_quantity + :exp, actual_quantity = actual_quantity + :act, updated_at = CURRENT_TIMESTAMP WHERE id = :id");
+            $upd->execute([':exp' => $expected, ':act' => $actual, ':id' => $existing['id']]);
+            return (int)$existing['id'];
+        }
+        $ins = $this->db->prepare("INSERT INTO return_discrepancies (return_id, order_item_id, product_id, discrepancy_type, expected_quantity, actual_quantity, item_condition, notes)
+                                    VALUES (:rid, :oiid, :pid, :dtype, :exp, :act, :cond, :notes)");
+        $ins->bindValue(':rid', $returnId, PDO::PARAM_INT);
+        $ins->bindValue(':oiid', $orderItemId, $orderItemId === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+        $ins->bindValue(':pid', $productId, PDO::PARAM_INT);
+        $ins->bindValue(':dtype', $type, PDO::PARAM_STR);
+        $ins->bindValue(':exp', $expected, PDO::PARAM_INT);
+        $ins->bindValue(':act', $actual, PDO::PARAM_INT);
+        $ins->bindValue(':cond', $condition, PDO::PARAM_STR);
+        $ins->bindValue(':notes', $notes, PDO::PARAM_STR);
+        $ins->execute();
+        return (int)$this->db->lastInsertId();
+    }
+}

--- a/tests/ReturnPerformanceTest.php
+++ b/tests/ReturnPerformanceTest.php
@@ -1,0 +1,31 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../services/ReturnService.php';
+
+class ReturnPerformanceTest extends TestCase {
+    private PDO $pdo;
+    private ReturnService $service;
+
+    protected function setUp(): void {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $schema = file_get_contents(__DIR__ . '/schema_returns.sql');
+        $this->pdo->exec($schema);
+        $this->service = new ReturnService($this->pdo);
+
+        $this->pdo->exec("INSERT INTO products (product_id, sku, name) VALUES (1, 'P1', 'Prod')");
+        $this->pdo->exec("INSERT INTO orders (id, order_number, status) VALUES (1, 'O1', 'shipped')");
+        $this->pdo->exec("INSERT INTO order_items (id, order_id, product_id, quantity) VALUES (1,1,1,1)");
+        $this->returnId = $this->service->startReturn('O1', 1);
+    }
+
+    public function testBarcodeScanPerformance(): void {
+        $start = microtime(true);
+        for ($i = 0; $i < 100; $i++) {
+            $this->service->verifyItem($this->returnId, 1, 1, 'good', true);
+        }
+        $elapsed = microtime(true) - $start;
+        $this->assertLessThan(2, $elapsed, 'Scanning took too long');
+    }
+}

--- a/tests/ReturnServiceTest.php
+++ b/tests/ReturnServiceTest.php
@@ -1,0 +1,41 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../services/ReturnService.php';
+
+class ReturnServiceTest extends TestCase {
+    private PDO $pdo;
+    private ReturnService $service;
+
+    protected function setUp(): void {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $schema = file_get_contents(__DIR__ . '/schema_returns.sql');
+        $this->pdo->exec($schema);
+        $this->service = new ReturnService($this->pdo);
+
+        // seed product and order
+        $this->pdo->exec("INSERT INTO products (product_id, sku, name) VALUES (1, 'P1', 'Prod')");
+        $this->pdo->exec("INSERT INTO orders (id, order_number, status) VALUES (1, 'O1', 'shipped')");
+        $this->pdo->exec("INSERT INTO order_items (id, order_id, product_id, quantity) VALUES (1,1,1,1)");
+    }
+
+    public function testStartReturnDuplicate(): void {
+        $firstId = $this->service->startReturn('O1', 5);
+        $this->assertGreaterThan(0, $firstId);
+        $this->expectException(RuntimeException::class);
+        $this->service->startReturn('O1', 5);
+    }
+
+    public function testInvalidOrderNumber(): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->service->startReturn('BAD', 1);
+    }
+
+    public function testInventoryConflictCreatesDiscrepancy(): void {
+        $rid = $this->service->startReturn('O1', 1);
+        $this->service->verifyItem($rid, 1, 5); // more than ordered
+        $count = $this->pdo->query('SELECT COUNT(*) FROM return_discrepancies')->fetchColumn();
+        $this->assertEquals(1, $count);
+    }
+}

--- a/tests/ReturnWorkflowTest.php
+++ b/tests/ReturnWorkflowTest.php
@@ -1,0 +1,29 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../services/ReturnService.php';
+
+class ReturnWorkflowTest extends TestCase {
+    private PDO $pdo;
+    private ReturnService $service;
+
+    protected function setUp(): void {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $schema = file_get_contents(__DIR__ . '/schema_returns.sql');
+        $this->pdo->exec($schema);
+        $this->service = new ReturnService($this->pdo);
+
+        $this->pdo->exec("INSERT INTO products (product_id, sku, name) VALUES (1, 'P1', 'Prod')");
+        $this->pdo->exec("INSERT INTO orders (id, order_number, status) VALUES (1, 'O1', 'shipped')");
+        $this->pdo->exec("INSERT INTO order_items (id, order_id, product_id, quantity) VALUES (1,1,1,1)");
+    }
+
+    public function testFullWorkflow(): void {
+        $rid = $this->service->startReturn('O1', 1);
+        $this->service->verifyItem($rid, 1, 1);
+        $this->service->completeReturn($rid, 2);
+        $status = $this->pdo->query('SELECT status FROM returns WHERE id = ' . (int)$rid)->fetchColumn();
+        $this->assertEquals('completed', $status);
+    }
+}

--- a/tests/schema_returns.sql
+++ b/tests/schema_returns.sql
@@ -1,0 +1,45 @@
+CREATE TABLE products (
+    product_id INTEGER PRIMARY KEY,
+    sku TEXT,
+    name TEXT
+);
+CREATE TABLE orders (
+    id INTEGER PRIMARY KEY,
+    order_number TEXT,
+    status TEXT
+);
+CREATE TABLE order_items (
+    id INTEGER PRIMARY KEY,
+    order_id INTEGER,
+    product_id INTEGER,
+    quantity INTEGER
+);
+CREATE TABLE returns (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id INTEGER,
+    processed_by INTEGER,
+    verified_by INTEGER,
+    status TEXT,
+    verified_at TEXT
+);
+CREATE TABLE return_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    return_id INTEGER,
+    order_item_id INTEGER,
+    product_id INTEGER,
+    quantity_returned INTEGER,
+    item_condition TEXT,
+    is_extra INTEGER
+);
+CREATE TABLE return_discrepancies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    return_id INTEGER,
+    order_item_id INTEGER,
+    product_id INTEGER,
+    discrepancy_type TEXT,
+    expected_quantity INTEGER,
+    actual_quantity INTEGER,
+    item_condition TEXT,
+    notes TEXT,
+    updated_at TEXT
+);


### PR DESCRIPTION
## Summary
- add migration for return sessions to track barcode scans
- provide data generator and API smoke test scripts for returns
- introduce ReturnService with unit, integration, and performance tests
- document return testing procedures

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68ad8ec1986c8320a3769d657a982152