### PR TITLE
Fix capacity for subdivided locations

### DIFF
--- a/locations.php
+++ b/locations.php
@@ -698,8 +698,14 @@ function processSubdivisionData($locationId, $postData) {
             }
         }
         
+        // After all subdivisions are processed, refresh the total capacity
+        // for the location using all level and subdivision settings.
+        $locationModel = new Location($db);
+        $totalCapacity = $locationModel->refreshCapacity($locationId);
+        debugLog("Updated location capacity to " . $totalCapacity);
+
         debugLog("=== SUBDIVISION PROCESSING DEBUG SUCCESS ===");
-        
+
         return [
             'success' => true,
             'message' => 'Subdiviziunile au fost configurate cu succes',


### PR DESCRIPTION
## Summary
- include subdivision items and capacity when computing level occupancy
- update location capacity after saving subdivisions so totals match
- centralize capacity recalculation into Location model to avoid NULL totals

## Testing
- `php -l models/Location.php`
- `php -l locations.php`
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b7db28f610832095cefe7261ab8e14