### PR TITLE
Add global F-key shortcuts for mobile picker

### DIFF
--- a/mobile_picker.php
+++ b/mobile_picker.php
@@ -30,15 +30,15 @@ $hasOrderFromUrl = !empty($orderNumber);
             <div class="order-actions-btns">
                 <button id="print-invoice-btn" class="btn btn-primary <?= !$hasOrderFromUrl ? 'hidden' : '' ?>" title="Printează Factura">
                     <span class="material-symbols-outlined">print</span>
-                    Printează Factura
+                    F1 - Printează Factura
                 </button>
                 <button id="generate-awb-btn" class="btn btn-primary generate-awb-btn hidden" title="Generează AWB">
                     <span class="material-symbols-outlined">local_shipping</span>
-                    Generează AWB
+                    F2 - Generează AWB
                 </button>
                 <button id="print-awb-btn" class="btn btn-success hidden" title="Printează AWB">
                     <span class="material-symbols-outlined">print</span>
-                    Printează AWB
+                    F2 - Printează AWB
                 </button>
             </div>
         </div>

--- a/scripts/warehouse-js/mobile_picker.js
+++ b/scripts/warehouse-js/mobile_picker.js
@@ -111,6 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function init() {
         setupEventListeners();
+        setupKeyboardShortcuts();
         updateAwbButtons();
         loadAvailablePrinters();
 
@@ -180,6 +181,44 @@ document.addEventListener('DOMContentLoaded', () => {
         
         // Quantity input validation
         elements.pickedQuantityInput?.addEventListener('input', validateQuantityInput);
+    }
+
+    function setupKeyboardShortcuts() {
+        document.addEventListener('keydown', handleFunctionKeys);
+    }
+
+    function handleFunctionKeys(e) {
+        switch (e.key) {
+            case 'F1':
+                e.preventDefault();
+                if (currentOrder) {
+                    printInvoice();
+                } else {
+                    showMessage('Nicio comandă activă pentru printarea facturii.', 'error');
+                }
+                break;
+            case 'F2':
+                e.preventDefault();
+                if (!currentOrder) {
+                    showMessage('Nicio comandă activă pentru AWB.', 'error');
+                    return;
+                }
+                const awbCode = currentOrder.awb_barcode;
+                if (awbCode) {
+                    printAWBDirect(currentOrder.id, awbCode, currentOrder.order_number);
+                } else if (!elements.generateAwbBtn.classList.contains('hidden')) {
+                    generateAWB(currentOrder.id);
+                } else {
+                    showMessage('AWB lipsă pentru această comandă.', 'error');
+                }
+                break;
+            case 'F3':
+            case 'F4':
+            case 'F5':
+                e.preventDefault();
+                // Reserved for future use
+                break;
+        }
     }
 
     // Add this function to load available printers


### PR DESCRIPTION
## Summary
- add global keyboard listeners for F1–F5 in mobile picking interface
- F1 prints invoice and F2 generates or prints AWB depending on availability
- show F-key indicators on invoice and AWB buttons

## Testing
- `npm test` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baa7f6024c8320981d6ad5268f2192