### PR TITLE
Improve picking notifications visibility

### DIFF
--- a/scripts/warehouse-js/mobile_picker.js
+++ b/scripts/warehouse-js/mobile_picker.js
@@ -1057,11 +1057,11 @@ document.addEventListener('DOMContentLoaded', () => {
         
         elements.messageContainer.appendChild(messageEl);
         
-        // Auto-remove after 1.5 seconds for snappier feedback
+        // Auto-remove after 3 seconds for better visibility
         setTimeout(() => {
             messageEl.style.animation = 'slideUp 0.3s ease reverse';
-            setTimeout(() => messageEl.remove(), 200);
-        }, 1000);
+            setTimeout(() => messageEl.remove(), 300);
+        }, 3000);
         
         console.log(`${type.toUpperCase()}: ${message}`);
     }

--- a/styles/warehouse-css/mobile_picker.css
+++ b/styles/warehouse-css/mobile_picker.css
@@ -639,30 +639,45 @@ body {
 /* ===== MESSAGES ===== */
 .message-container {
   position: fixed;
-  top: 100px;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   z-index: 1500;
   max-width: 90%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 
 .message {
-  background-color: rgba(26, 26, 29, 0.95);
-  color: var(--white);
   padding: 1rem 1.5rem;
   border-radius: 6px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
   margin-bottom: 0.5rem;
   animation: slideDown 0.3s ease;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--white);
+  background-color: rgba(26, 26, 29, 0.95);
 }
 
 .message.success {
-  border-left: 4px solid var(--success-color);
+  background-color: var(--success-color);
 }
 
 .message.error {
-  border-left: 4px solid var(--danger-color);
+  background-color: var(--danger-color);
+}
+
+.message.warning {
+  background-color: var(--warning-color);
+  color: var(--black);
+}
+
+.message.info {
+  background-color: var(--info-color);
+  color: var(--black);
 }
 
 /* ===== ANIMATIONS ===== */


### PR DESCRIPTION
## Summary
- center picking notifications in viewport with bold contrasting styles
- keep messages visible for 3 seconds before auto dismiss

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bab0db63408320a26a0bd7b1feeac6