### PR TITLE
Improve picking notifications visibility

### DIFF
--- a/scripts/orders_awb.js
+++ b/scripts/orders_awb.js
@@ -535,72 +535,29 @@ async function performAwbPrint(orderId, awbCode, orderNumber, printerId = null, 
  * Show AWB requirements modal
  */
 function showAWBRequirementsModal(orderId, requirements) {
-    const modalHtml = `
-        <div id="awb-requirements-modal" class="modal" style="display: flex;">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h3>Cerințe pentru generarea AWB</h3>
-                    <button type="button" class="close-modal" onclick="closeAWBModal()">
-                        <span class="material-symbols-outlined">close</span>
-                    </button>
-                </div>
-                <div class="modal-body">
-                    ${requirements.existing_barcode ? `
-                        <div class="alert alert-info">
-                            <span class="material-symbols-outlined">info</span>
-                            AWB deja generat: <strong>${requirements.existing_barcode}</strong>
-                        </div>
-                    ` : `
-                        <div class="alert alert-warning">
-                            <span class="material-symbols-outlined">warning</span>
-                            Nu se poate genera AWB. Cerințe lipsă:
-                        </div>
-                        <ul class="requirements-list">
-                            ${requirements.requirements.map(req => `<li>${req}</li>`).join('')}
-                        </ul>
-                        
-                        ${requirements.weight_info && requirements.weight_info.weight > 0 ? `
-                            <div class="weight-info">
-                                <p><strong>Greutate calculată:</strong> ${requirements.weight_info.weight} kg</p>
-                                ${requirements.weight_info.warning ? `<p class="warning">${requirements.weight_info.warning}</p>` : ''}
-                            </div>
-                        ` : ''}
-                        
-                        ${requirements.address_parsed ? `
-                            <div class="address-info">
-                                <p><strong>Adresă detectată:</strong></p>
-                                <ul>
-                                    ${requirements.address_parsed.county ? `<li>Județ: ${requirements.address_parsed.county}</li>` : ''}
-                                    ${requirements.address_parsed.locality ? `<li>Localitate: ${requirements.address_parsed.locality}</li>` : ''}
-                                    ${requirements.address_parsed.street ? `<li>Stradă: ${requirements.address_parsed.street}</li>` : ''}
-                                </ul>
-                            </div>
-                        ` : ''}
-                    `}
-                    
-                    <div class="modal-actions">
-                        <button type="button" class="btn btn-secondary" onclick="closeAWBModal()">
-                            Închide
-                        </button>
-                        ${!requirements.existing_barcode && requirements.requirements.length > 0 ? `
-                            <button type="button" class="btn btn-primary" onclick="showAWBManualInputModal(${orderId}, ${JSON.stringify(requirements).replace(/"/g, '&quot;')})">
-                                Completează Manual
-                            </button>
-                        ` : ''}
-                    </div>
-                </div>
-            </div>
-        </div>
-    `;
-    
-    // Remove existing modal if any
     const existing = document.getElementById('awb-requirements-modal');
     if (existing) {
         existing.remove();
     }
-    
-    document.body.insertAdjacentHTML('beforeend', modalHtml);
-    document.body.style.overflow = 'hidden';
+
+    const container = document.createElement('div');
+    container.id = 'awb-requirements-modal';
+    container.className = 'message-container';
+
+    const messageEl = document.createElement('div');
+    messageEl.className = 'message error';
+    messageEl.textContent = 'Nu se poate genera AWB pentru această comandă.';
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'message-close';
+    closeBtn.innerHTML = '&times;';
+    closeBtn.addEventListener('click', () => closeAWBModal());
+    messageEl.appendChild(closeBtn);
+
+    container.appendChild(messageEl);
+    document.body.appendChild(container);
+
+    setTimeout(() => closeAWBModal(), 3000);
 }
 
 /**

--- a/scripts/warehouse-js/mobile_picker.js
+++ b/scripts/warehouse-js/mobile_picker.js
@@ -1054,15 +1054,21 @@ document.addEventListener('DOMContentLoaded', () => {
         const messageEl = document.createElement('div');
         messageEl.className = `message ${type}`;
         messageEl.textContent = message;
-        
+
+        const closeBtn = document.createElement('button');
+        closeBtn.className = 'message-close';
+        closeBtn.innerHTML = '&times;';
+        closeBtn.addEventListener('click', () => messageEl.remove());
+        messageEl.appendChild(closeBtn);
+
         elements.messageContainer.appendChild(messageEl);
-        
-        // Auto-remove after 1.5 seconds for snappier feedback
+
+        // Auto-remove after 3 seconds for better visibility
         setTimeout(() => {
             messageEl.style.animation = 'slideUp 0.3s ease reverse';
-            setTimeout(() => messageEl.remove(), 200);
-        }, 1000);
-        
+            setTimeout(() => messageEl.remove(), 300);
+        }, 3000);
+
         console.log(`${type.toUpperCase()}: ${message}`);
     }
 

--- a/styles/awb_generation.css
+++ b/styles/awb_generation.css
@@ -95,3 +95,56 @@
         font-size: 0.85rem;
     }
 }
+
+/* Notifications for AWB requirements */
+.message-container {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1500;
+    max-width: 90%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.message {
+    position: relative;
+    padding: 1rem 1.5rem;
+    border-radius: 6px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+    margin-bottom: 0.5rem;
+    animation: slideDown 0.3s ease;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #fff;
+    background-color: rgba(26, 26, 29, 0.95);
+}
+
+.message.error {
+    background-color: #dc3545;
+}
+
+.message-close {
+    position: absolute;
+    top: 4px;
+    right: 8px;
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-size: 1.2rem;
+    cursor: pointer;
+    line-height: 1;
+}
+
+@keyframes slideDown {
+    from { transform: translateY(-20px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes slideUp {
+    from { transform: translateY(0); opacity: 1; }
+    to { transform: translateY(-20px); opacity: 0; }
+}

--- a/styles/warehouse-css/mobile_picker.css
+++ b/styles/warehouse-css/mobile_picker.css
@@ -639,30 +639,58 @@ body {
 /* ===== MESSAGES ===== */
 .message-container {
   position: fixed;
-  top: 100px;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   z-index: 1500;
   max-width: 90%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 
 .message {
-  background-color: rgba(26, 26, 29, 0.95);
-  color: var(--white);
+  position: relative;
   padding: 1rem 1.5rem;
   border-radius: 6px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
   margin-bottom: 0.5rem;
   animation: slideDown 0.3s ease;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--white);
+  background-color: rgba(26, 26, 29, 0.95);
+}
+
+.message-close {
+  position: absolute;
+  top: 4px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.2rem;
+  cursor: pointer;
+  line-height: 1;
 }
 
 .message.success {
-  border-left: 4px solid var(--success-color);
+  background-color: var(--success-color);
 }
 
 .message.error {
-  border-left: 4px solid var(--danger-color);
+  background-color: var(--danger-color);
+}
+
+.message.warning {
+  background-color: var(--warning-color);
+  color: var(--black);
+}
+
+.message.info {
+  background-color: var(--info-color);
+  color: var(--black);
 }
 
 /* ===== ANIMATIONS ===== */


### PR DESCRIPTION
## Summary
- add close-only picker notifications for clearer dismiss actions
- replace AWB requirements modal with centered high-contrast alert

## Testing
- `npm test` *(fails: phpunit not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bab0db63408320a26a0bd7b1feeac6