### PR TITLE
Add quick expiry date options for stock entries

### DIFF
--- a/inventory.php
+++ b/inventory.php
@@ -880,6 +880,13 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                             <div class="form-group">
                                 <label for="add-expiry" class="form-label">Data Expirării</label>
                                 <input type="date" id="add-expiry" name="expiry_date" class="form-control">
+                                <div class="expiry-quick-options">
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="setExpiry('none')">Fără dată de expirare</button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="setExpiry('6m')">6 luni</button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="setExpiry('1y')">1 an</button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="setExpiry('2y')">2 ani</button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" onclick="setExpiry('3y')">3 ani</button>
+                                </div>
                             </div>
                         </div>
                         

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -238,6 +238,33 @@ function generateBatchLot() {
     if (lot) lot.value = 'L' + Math.floor(Math.random()*900000 + 100000);
 }
 
+function setExpiry(option) {
+    const input = document.getElementById('add-expiry');
+    if (!input) return;
+    const date = new Date();
+    switch (option) {
+        case 'none':
+            input.value = '';
+            break;
+        case '6m':
+            date.setMonth(date.getMonth() + 6);
+            input.value = date.toISOString().slice(0, 10);
+            break;
+        case '1y':
+            date.setFullYear(date.getFullYear() + 1);
+            input.value = date.toISOString().slice(0, 10);
+            break;
+        case '2y':
+            date.setFullYear(date.getFullYear() + 2);
+            input.value = date.toISOString().slice(0, 10);
+            break;
+        case '3y':
+            date.setFullYear(date.getFullYear() + 3);
+            input.value = date.toISOString().slice(0, 10);
+            break;
+    }
+}
+
 function escapeHtml(text) {
     const div = document.createElement('div');
     div.textContent = text;
@@ -248,6 +275,7 @@ window.searchProducts = searchProducts;
 window.showProductResults = showProductResults;
 window.addStockForProduct = addStockForProduct;
 window.updateSubdivisionOptions = updateSubdivisionOptions;
+window.setExpiry = setExpiry;
 
 function setDateRange(period) {
     const from = document.getElementById('date_from');


### PR DESCRIPTION
## Summary
- add quick-select buttons for common expiry intervals in Add Stock modal
- implement `setExpiry` helper in inventory JS to set expiry date or clear it

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bac1a03ed0832089293c513ce0d02b