### PR TITLE
fix: show subdivisions in Assign Location modal

### DIFF
--- a/products.php
+++ b/products.php
@@ -1019,7 +1019,7 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
 
                         <div class="form-group">
                             <label for="assign-location" class="form-label">Locație *</label>
-                            <select id="assign-location" name="location_id" class="form-control" required>
+                            <select id="assign-location" name="location_id" class="form-control" required onchange="loadAssignLocationLevels(this.value)">
                                 <option value="">Selectează locația</option>
                                 <?php foreach ($allLocations as $location): ?>
                                     <option value="<?= $location['id'] ?>">

--- a/scripts/products.js
+++ b/scripts/products.js
@@ -208,8 +208,14 @@ async function updateAssignSubdivisionOptions() {
 
 document.addEventListener('DOMContentLoaded', () => {
     const locSelect = document.getElementById('assign-location');
+    const levelSelect = document.getElementById('assign-shelf-level');
+
     if (locSelect) {
         locSelect.addEventListener('change', () => loadAssignLocationLevels(locSelect.value));
+    }
+
+    if (levelSelect) {
+        levelSelect.addEventListener('change', updateAssignSubdivisionOptions);
     }
 });
 
@@ -220,6 +226,7 @@ function assignLocationForProduct(productId) {
 window.assignLocationForProduct = assignLocationForProduct;
 window.closeAssignLocationModal = closeAssignLocationModal;
 window.updateAssignSubdivisionOptions = updateAssignSubdivisionOptions;
+window.loadAssignLocationLevels = loadAssignLocationLevels;
 
 /**
  * Form Management


### PR DESCRIPTION
## Summary
- restore inline dropdown change handlers for Assign Location modal
- expose JS helpers globally so subdivisions load

## Testing
- `npm test` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be8ab009808320844b714e36350a59