### PR TITLE
Enable subdivision selection when assigning product location

### DIFF
--- a/products.php
+++ b/products.php
@@ -1031,14 +1031,16 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
 
                         <div class="form-group">
                             <label for="assign-shelf-level" class="form-label">Nivel raft</label>
-                            <select id="assign-shelf-level" name="shelf_level" class="form-control">
+                            <select id="assign-shelf-level" name="shelf_level" class="form-control" onchange="updateAssignSubdivisionOptions()">
                                 <option value="">--</option>
                             </select>
                         </div>
 
                         <div class="form-group" id="assign-subdivision-container" style="display:none;">
                             <label for="assign-subdivision-number" class="form-label">Subdiviziune</label>
-                            <select id="assign-subdivision-number" name="subdivision_number" class="form-control"></select>
+                            <select id="assign-subdivision-number" name="subdivision_number" class="form-control">
+                                <option value="">--</option>
+                            </select>
                         </div>
                     </div>
                     <div class="modal-footer">

--- a/scripts/products.js
+++ b/scripts/products.js
@@ -129,7 +129,7 @@ function openAssignLocationModal(productId) {
     if (locSelect) locSelect.value = '';
     if (levelSelect) levelSelect.innerHTML = '<option value="">--</option>';
     if (subContainer) subContainer.style.display = 'none';
-    if (subSelect) subSelect.innerHTML = '';
+    if (subSelect) subSelect.innerHTML = '<option value="">--</option>';
 
     showModal(assignLocationModal);
 }
@@ -145,10 +145,9 @@ async function loadAssignLocationLevels(locationId) {
 
     if (levelSelect) {
         levelSelect.innerHTML = '<option value="">--</option>';
-        levelSelect.removeEventListener('change', updateAssignSubdivisionOptions);
     }
     if (subContainer) subContainer.style.display = 'none';
-    if (subSelect) subSelect.innerHTML = '';
+    if (subSelect) subSelect.innerHTML = '<option value="">--</option>';
 
     if (!locationId) return;
 
@@ -172,9 +171,7 @@ async function loadAssignLocationLevels(locationId) {
         }
     } catch (e) { console.error(e); }
 
-    if (levelSelect) {
-        levelSelect.addEventListener('change', updateAssignSubdivisionOptions);
-    }
+    // event listener handled via inline onchange in the HTML
 }
 
 async function updateAssignSubdivisionOptions() {
@@ -185,7 +182,7 @@ async function updateAssignSubdivisionOptions() {
     const subSelect = document.getElementById('assign-subdivision-number');
     const levelNumber = levelSelect ? levelSelect.value : '';
 
-    if (subSelect) subSelect.innerHTML = '';
+    if (subSelect) subSelect.innerHTML = '<option value="">--</option>';
 
     if (!locId || !levelNumber) { if (subContainer) subContainer.style.display = 'none'; return; }
 
@@ -219,10 +216,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (locSelect) {
         locSelect.addEventListener('change', () => loadAssignLocationLevels(locSelect.value));
-    }
-
-    if (levelSelect) {
-        levelSelect.addEventListener('change', updateAssignSubdivisionOptions);
     }
 });
 


### PR DESCRIPTION
## Summary
- allow choosing shelf subdivisions in Atribuie Locație modal
- reset subdivision dropdowns to include placeholders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be90320bf883208ac84b298c985516