### PR TITLE
Fix duplicate level options in product location modal

### DIFF
--- a/products.php
+++ b/products.php
@@ -1019,7 +1019,7 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
 
                         <div class="form-group">
                             <label for="assign-location" class="form-label">Locație *</label>
-                            <select id="assign-location" name="location_id" class="form-control" required onchange="loadAssignLocationLevels(this.value)">
+                            <select id="assign-location" name="location_id" class="form-control" required>
                                 <option value="">Selectează locația</option>
                                 <?php foreach ($allLocations as $location): ?>
                                     <option value="<?= $location['id'] ?>">
@@ -1031,7 +1031,7 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
 
                         <div class="form-group">
                             <label for="assign-shelf-level" class="form-label">Nivel raft</label>
-                            <select id="assign-shelf-level" name="shelf_level" class="form-control" onchange="updateAssignSubdivisionOptions()">
+                            <select id="assign-shelf-level" name="shelf_level" class="form-control">
                                 <option value="">--</option>
                             </select>
                         </div>

--- a/scripts/products.js
+++ b/scripts/products.js
@@ -219,6 +219,9 @@ document.addEventListener('DOMContentLoaded', () => {
     if (locSelect) {
         locSelect.addEventListener('change', () => loadAssignLocationLevels(locSelect.value));
     }
+    if (levelSelect) {
+        levelSelect.addEventListener('change', updateAssignSubdivisionOptions);
+    }
 });
 
 function assignLocationForProduct(productId) {


### PR DESCRIPTION
## Summary
- Prevent duplicate shelf level entries in Assign Location modal by removing inline change handlers and wiring listeners in JS
- Enable subdivision dropdown to update when shelf level changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be9aae47ac8320b7bfd397b223fa8f