### PR TITLE
Fix duplicate level options in product location modal

### DIFF
--- a/products.php
+++ b/products.php
@@ -1019,7 +1019,7 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
 
                         <div class="form-group">
                             <label for="assign-location" class="form-label">Locație *</label>
-                            <select id="assign-location" name="location_id" class="form-control" required onchange="loadAssignLocationLevels(this.value)">
+                            <select id="assign-location" name="location_id" class="form-control" required>
                                 <option value="">Selectează locația</option>
                                 <?php foreach ($allLocations as $location): ?>
                                     <option value="<?= $location['id'] ?>">
@@ -1031,7 +1031,7 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
 
                         <div class="form-group">
                             <label for="assign-shelf-level" class="form-label">Nivel raft</label>
-                            <select id="assign-shelf-level" name="shelf_level" class="form-control" onchange="updateAssignSubdivisionOptions()">
+                            <select id="assign-shelf-level" name="shelf_level" class="form-control">
                                 <option value="">--</option>
                             </select>
                         </div>

--- a/scripts/products.js
+++ b/scripts/products.js
@@ -12,6 +12,7 @@ const assignLocationModal = document.getElementById('assignLocationModal');
 // Global variables
 let selectedFile = null;
 let importInProgress = false;
+const API_KEY = window.APP_CONFIG && window.APP_CONFIG.apiKey ? window.APP_CONFIG.apiKey : '';
 
 /**
  * Initialize page functionality
@@ -152,7 +153,9 @@ async function loadAssignLocationLevels(locationId) {
     if (!locationId) return;
 
     try {
-        const resp = await fetch(`api/location_info.php?id=${locationId}`);
+        const params = new URLSearchParams({ id: locationId });
+        if (API_KEY) params.append('api_key', API_KEY);
+        const resp = await fetch(`api/location_info.php?${params.toString()}`, { credentials: 'same-origin' });
         const data = await resp.json();
         if (resp.ok && data.levels) {
             data.levels.forEach(l => {
@@ -173,7 +176,6 @@ async function loadAssignLocationLevels(locationId) {
         }
     } catch (e) { console.error(e); }
 
-    // event listener handled via inline onchange in the HTML
 }
 
 async function updateAssignSubdivisionOptions() {
@@ -189,7 +191,9 @@ async function updateAssignSubdivisionOptions() {
     if (!locId || !levelNumber) { if (subContainer) subContainer.style.display = 'none'; return; }
 
     try {
-        const resp = await fetch(`api/subdivision_info.php?location_id=${locId}&level=${levelNumber}&product_id=${productId}`);
+        const params = new URLSearchParams({ location_id: locId, level: levelNumber, product_id: productId });
+        if (API_KEY) params.append('api_key', API_KEY);
+        const resp = await fetch(`api/subdivision_info.php?${params.toString()}`, { credentials: 'same-origin' });
         const data = await resp.json();
         if (resp.ok && Array.isArray(data.subdivisions) && data.subdivisions.length) {
             data.subdivisions.forEach(sd => {
@@ -218,6 +222,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (locSelect) {
         locSelect.addEventListener('change', () => loadAssignLocationLevels(locSelect.value));
+    }
+    if (levelSelect) {
+        levelSelect.addEventListener('change', updateAssignSubdivisionOptions);
     }
 });
 


### PR DESCRIPTION
## Summary
- Prevent duplicate shelf level entries in Assign Location modal by removing inline change handlers and wiring listeners in JS
- Enable subdivision dropdown to update when shelf level changes
- Include API key in location and subdivision fetches to avoid unauthorized errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be9aae47ac8320b7bfd397b223fa8f