### PR TITLE
Remove overwrite option from Excel product import

### DIFF
--- a/products.php
+++ b/products.php
@@ -745,17 +745,6 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                         
                         <div class="option-group">
                             <label class="checkbox-option">
-                                <input type="checkbox" id="overwriteExisting" checked>
-                                <span class="checkmark"></span>
-                                <div class="option-text">
-                                    <strong>Actualizează produsele existente</strong>
-                                    <small>Suprascrie datele produselor care au același SKU</small>
-                                </div>
-                            </label>
-                        </div>
-                        
-                        <div class="option-group">
-                            <label class="checkbox-option">
                                 <input type="checkbox" id="syncSmartBill">
                                 <span class="checkmark"></span>
                                 <div class="option-text">

--- a/scripts/products.js
+++ b/scripts/products.js
@@ -875,7 +875,6 @@ async function startProcessing() {
         const formData = new FormData();
         formData.append('excel_file', selectedFile);
         formData.append('sync_smartbill', document.getElementById('syncSmartBill')?.checked || false);
-        formData.append('overwrite_existing', document.getElementById('overwriteExisting')?.checked || false);
         
         // Upload and process
         const response = await fetch('api/excel_import.php', {


### PR DESCRIPTION
## Summary
- drop checkbox for updating existing products during Excel import
- send SmartBill sync option only
- match products exclusively by SKU and skip rows missing location or shelf level
- permit inventory import for products mapped to whole levels by treating subdivision as optional

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bec0681e988320af288247d73f1ad4