### PR TITLE
Enable F3 to confirm picked quantity

### DIFF
--- a/mobile_picker.php
+++ b/mobile_picker.php
@@ -175,9 +175,9 @@ $hasOrderFromUrl = !empty($orderNumber);
                         <button class="qty-btn" id="qty-increase">+</button>
                     </div>
                     <div class="quantity-actions">
-                        <button id="confirm-quantity-btn" class="btn btn-success btn-large">
+                        <button id="confirm-quantity-btn" class="btn btn-success btn-large" title="Confirmă Colectarea (F3)">
                             <span class="material-symbols-outlined">check_circle</span>
-                            Confirmă Colectarea
+                            F3 - Confirmă Colectarea
                         </button>
                         <button id="back-to-product" class="btn btn-secondary">
                             <span class="material-symbols-outlined">arrow_back</span>

--- a/scripts/warehouse-js/mobile_picker.js
+++ b/scripts/warehouse-js/mobile_picker.js
@@ -253,6 +253,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 break;
             case 'F3':
+                e.preventDefault();
+                if (currentStep === 'quantity') {
+                    elements.confirmQuantityBtn?.click();
+                }
+                break;
             case 'F4':
             case 'F5':
                 e.preventDefault();


### PR DESCRIPTION
## Summary
- Allow F3 key to confirm quantity in picking workflow
- Show F3 shortcut hint on "Confirmă Colectarea" button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfe8173ee08320b5f12c6889a6d685