### PR TITLE
Add inventory stock import feature

### DIFF
--- a/api/inventory_stock_import.php
+++ b/api/inventory_stock_import.php
@@ -1,0 +1,225 @@
+<?php
+// Inventory Stock Import Handler
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    exit(0);
+}
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+require_once BASE_PATH . '/vendor/autoload.php';
+require_once BASE_PATH . '/models/Inventory.php';
+
+use PhpOffice\PhpSpreadsheet\IOFactory;
+
+session_start();
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'admin') {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Unauthorized']);
+    exit;
+}
+
+$config = require BASE_PATH . '/config/config.php';
+$db = $config['connection_factory']();
+
+$importer = new InventoryStockImporter($db);
+$result = $importer->processUpload();
+
+echo json_encode($result);
+
+class InventoryStockImporter {
+    private $db;
+    private $inventoryModel;
+    private array $results = [
+        'success' => false,
+        'processed' => 0,
+        'stock_added' => 0,
+        'skipped' => 0,
+        'message' => '',
+        'warnings' => [],
+        'errors' => []
+    ];
+
+    public function __construct(PDO $db) {
+        $this->db = $db;
+        $this->inventoryModel = new Inventory($db);
+    }
+
+    public function processUpload(): array {
+        try {
+            if (!isset($_FILES['excel_file']) || $_FILES['excel_file']['error'] !== UPLOAD_ERR_OK) {
+                throw new Exception('No file uploaded or upload error occurred');
+            }
+            $file = $_FILES['excel_file'];
+            $ext = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+            if (!in_array($ext, ['xls', 'xlsx'])) {
+                throw new Exception('Invalid file type. Only .xls and .xlsx allowed');
+            }
+            if ($file['size'] > 10 * 1024 * 1024) {
+                throw new Exception('File too large');
+            }
+            $tmpPath = $file['tmp_name'];
+            $this->processInventoryExcel($tmpPath);
+            if (empty($this->results['errors'])) {
+                $this->results['success'] = true;
+                $this->results['message'] = 'Import completed successfully';
+            } else {
+                $this->results['message'] = 'Import completed with errors';
+            }
+        } catch (Exception $e) {
+            $this->results['errors'][] = $e->getMessage();
+            $this->results['message'] = $e->getMessage();
+        }
+        return $this->results;
+    }
+
+    private function processInventoryExcel(string $filePath): void {
+        $spreadsheet = IOFactory::load($filePath);
+        $worksheet = $spreadsheet->getActiveSheet();
+        $rows = $worksheet->toArray();
+        if (empty($rows)) {
+            throw new Exception('Excel file is empty');
+        }
+        $headerInfo = $this->findHeaderRow($rows);
+        if ($headerInfo['row'] === -1) {
+            throw new Exception('Could not find header row');
+        }
+        $headerRow = $headerInfo['row'];
+        $map = $this->mapColumns($headerInfo['headers']);
+        if (!isset($map['sku']) || !isset($map['quantity'])) {
+            throw new Exception('Required columns not found');
+        }
+        $this->db->beginTransaction();
+        try {
+            for ($i = $headerRow + 1; $i < count($rows); $i++) {
+                $row = $rows[$i];
+                if ($this->isEmptyRow($row)) {
+                    continue;
+                }
+                $this->results['processed']++;
+                try {
+                    $this->processInventoryRow($row, $map, $i + 1);
+                } catch (Exception $e) {
+                    $this->results['errors'][] = 'Row ' . ($i + 1) . ': ' . $e->getMessage();
+                    $this->results['skipped']++;
+                }
+            }
+            $this->db->commit();
+        } catch (Exception $e) {
+            if ($this->db->inTransaction()) {
+                $this->db->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    private function processInventoryRow(array $row, array $map, int $rowNumber): void {
+        $sku = trim((string)($row[$map['sku']] ?? ''));
+        $qtyRaw = $row[$map['quantity']] ?? null;
+        $qty = is_numeric($qtyRaw) ? (int)$qtyRaw : null;
+        if ($sku === '' || $qty === null || $qty <= 0) {
+            $this->results['warnings'][] = "Row $rowNumber: Invalid SKU or quantity";
+            $this->results['skipped']++;
+            return;
+        }
+        $product = $this->findProductBySku($sku);
+        if (!$product) {
+            $this->results['warnings'][] = "Row $rowNumber: Product $sku not found";
+            $this->results['skipped']++;
+            return;
+        }
+        $location = $this->findProductLocation($product['product_id']);
+        if (!$location) {
+            $this->results['warnings'][] = "Row $rowNumber: Location not found for $sku";
+            $this->results['skipped']++;
+            return;
+        }
+        $added = $this->addStockToProduct($product['product_id'], $location, $qty);
+        if ($added) {
+            $this->results['stock_added']++;
+        } else {
+            $this->results['errors'][] = "Row $rowNumber: Failed to add stock for $sku";
+            $this->results['skipped']++;
+        }
+    }
+
+    private function findProductBySku(string $sku): ?array {
+        $stmt = $this->db->prepare('SELECT product_id FROM products WHERE sku = ? LIMIT 1');
+        $stmt->execute([$sku]);
+        $product = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $product ?: null;
+    }
+
+    private function findProductLocation(int $productId): ?array {
+        $stmt = $this->db->prepare('SELECT location_id, shelf_level FROM inventory WHERE product_id = ? ORDER BY id ASC LIMIT 1');
+        $stmt->execute([$productId]);
+        $loc = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $loc ?: null;
+    }
+
+    private function addStockToProduct(int $productId, array $location, int $quantity): bool {
+        $stockData = [
+            'product_id' => $productId,
+            'location_id' => $location['location_id'],
+            'quantity' => $quantity,
+            'shelf_level' => $location['shelf_level'],
+            'subdivision_number' => null,
+            'batch_number' => 'EXCEL-' . date('Ymd-Hi') . '-' . $productId,
+            'received_at' => date('Y-m-d H:i:s'),
+            'reference_type' => 'excel_import'
+        ];
+        return (bool)$this->inventoryModel->addStock($stockData, false);
+    }
+
+    private function findHeaderRow(array $rows): array {
+        $skuPatterns = ['sku', 'cod', 'code', 'article', 'produs'];
+        $qtyPatterns = ['quantity', 'qty', 'cantitate', 'stoc', 'stock', 'sold'];
+        foreach ($rows as $index => $row) {
+            foreach ($row as $cell) {
+                if (!is_string($cell)) continue;
+                $cellLower = strtolower(trim($cell));
+                if (in_array($cellLower, $skuPatterns, true)) {
+                    // Look for quantity in same row
+                    foreach ($row as $cell2) {
+                        if (!is_string($cell2)) continue;
+                        if (in_array(strtolower(trim($cell2)), $qtyPatterns, true)) {
+                            return ['row' => $index, 'headers' => $row];
+                        }
+                    }
+                }
+            }
+        }
+        return ['row' => -1, 'headers' => []];
+    }
+
+    private function mapColumns(array $headers): array {
+        $map = [];
+        $skuPatterns = ['sku', 'cod', 'code', 'article', 'produs'];
+        $qtyPatterns = ['quantity', 'qty', 'cantitate', 'stoc', 'stock', 'sold'];
+        foreach ($headers as $idx => $header) {
+            $headerLower = strtolower(trim((string)$header));
+            if (in_array($headerLower, $skuPatterns, true)) {
+                $map['sku'] = $idx;
+            } elseif (in_array($headerLower, $qtyPatterns, true)) {
+                $map['quantity'] = $idx;
+            }
+        }
+        return $map;
+    }
+
+    private function isEmptyRow(array $row): bool {
+        foreach ($row as $cell) {
+            if ($cell !== null && trim((string)$cell) !== '') {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -39,7 +39,7 @@ if (empty($apiKey)) {
 // Define an array of page-specific JavaScript files.
 $pageSpecificJS = [
     'products' => ['products.js', 'inventory.js'],
-    'inventory' => 'inventory.js',
+    'inventory' => ['inventory.js', 'inventory-stock-import.js'],
     'users' => 'users.js',
     'transactions' => 'transactions.js',
     'theme-toggle' => 'theme-toggle.js',
@@ -47,7 +47,7 @@ $pageSpecificJS = [
     'smartbill-sync' => 'smartbill_sync.js',
     'locations' => 'locations.js',
     'orders' => ['orders.js', 'orders_awb.js'],
-    'sellers' => 'sellers.js',
+    'sellers' => ['sellers.js', 'sellers-import.js'],
     'purchase_orders' => 'purchase_orders.js',
     'product-units' => 'product-units.js',
     'printer-management' => 'printer-management.js',

--- a/includes/header.php
+++ b/includes/header.php
@@ -64,8 +64,6 @@ if (file_exists($universalJsPath)) {
 
 // Load development-only scripts
 if (!in_prod()) {
-    echo '<script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>';
-    
     $themeToggleJsPath = BASE_PATH . '/scripts/theme-toggle.js';
     if(file_exists($themeToggleJsPath)) {
         echo '<script src="' . BASE_URL . 'scripts/theme-toggle.js?v=' . filemtime($themeToggleJsPath) . '" defer></script>';
@@ -74,4 +72,3 @@ if (!in_prod()) {
 ?>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
-<script src="scripts/sellers-import.js"></script>

--- a/inventory.php
+++ b/inventory.php
@@ -280,6 +280,10 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                             <span class="material-symbols-outlined">add_box</span>
                             Adaugă Stoc
                         </button>
+                        <button class="btn btn-secondary" onclick="openImportStockModal()" style="margin-left:10px;">
+                            <span class="material-symbols-outlined">upload_file</span>
+                            Import Stoc
+                        </button>
                     </div>
                 </header>
                 
@@ -1009,4 +1013,49 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
             </div>
         </div>
     </div>
+
+    <!-- Stock Import Modal -->
+    <div class="modal" id="importStockModal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3 class="modal-title">Import Stoc</h3>
+                    <button class="modal-close" onclick="closeImportStockModal()">
+                        <span class="material-symbols-outlined">close</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div id="stock-import-upload" class="stock-import-step">
+                        <div id="stock-import-drop" class="file-drop-area">
+                            <span class="material-symbols-outlined">upload_file</span>
+                            <p>Trage fișierul aici sau apasă pentru selectare</p>
+                            <input type="file" id="stock-import-file" accept=".xls,.xlsx" style="display:none;">
+                        </div>
+                        <div id="stock-import-selected" class="selected-file" style="display:none; gap:10px; align-items:center; margin-top:10px;">
+                            <span id="stock-import-filename"></span>
+                            <button type="button" class="btn btn-sm btn-secondary" id="stock-import-remove">Șterge</button>
+                        </div>
+                        <div style="margin-top:15px;">
+                            <button type="button" class="btn btn-primary" id="stock-import-start" disabled>Importă</button>
+                        </div>
+                    </div>
+                    <div id="stock-import-progress" class="stock-import-step" style="display:none;">
+                        <div class="progress-bar" style="height:20px;background:#f0f0f0;border-radius:4px;overflow:hidden;">
+                            <div id="stock-import-progress-bar" class="progress" style="height:100%;width:0;background:#4caf50;"></div>
+                        </div>
+                        <p style="margin-top:10px;">Procesare fișier...</p>
+                    </div>
+                    <div id="stock-import-results" class="stock-import-step" style="display:none;">
+                        <div id="stock-import-summary"></div>
+                        <div id="stock-import-warnings" style="margin-top:10px;"></div>
+                        <div id="stock-import-errors" style="margin-top:10px;"></div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" onclick="closeImportStockModal()">Închide</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <?php require_once __DIR__ . '/includes/footer.php'; ?>

--- a/scripts/inventory-stock-import.js
+++ b/scripts/inventory-stock-import.js
@@ -1,0 +1,128 @@
+// Inventory Stock Import Frontend
+let stockImportFile = null;
+
+function openImportStockModal() {
+    resetStockImportModal();
+    document.getElementById('importStockModal').classList.add('show');
+}
+
+function closeImportStockModal() {
+    document.getElementById('importStockModal').classList.remove('show');
+}
+
+function resetStockImportModal() {
+    stockImportFile = null;
+    document.getElementById('stock-import-file').value = '';
+    document.getElementById('stock-import-selected').style.display = 'none';
+    document.getElementById('stock-import-start').disabled = true;
+    showStockImportStep('upload');
+}
+
+function showStockImportStep(step) {
+    ['upload','progress','results'].forEach(s => {
+        const el = document.getElementById('stock-import-' + s);
+        if (el) el.style.display = (s === step) ? 'block' : 'none';
+    });
+}
+
+function handleStockImportFile(file) {
+    stockImportFile = file;
+    document.getElementById('stock-import-filename').textContent = file.name;
+    document.getElementById('stock-import-selected').style.display = 'flex';
+    document.getElementById('stock-import-start').disabled = false;
+}
+
+document.getElementById('stock-import-file').addEventListener('change', e => {
+    const file = e.target.files[0];
+    if (file) handleStockImportFile(file);
+});
+
+document.getElementById('stock-import-remove').addEventListener('click', () => {
+    stockImportFile = null;
+    document.getElementById('stock-import-selected').style.display = 'none';
+    document.getElementById('stock-import-start').disabled = true;
+});
+
+const dropArea = document.getElementById('stock-import-drop');
+if (dropArea) {
+    dropArea.addEventListener('dragover', e => {
+        e.preventDefault();
+        dropArea.classList.add('dragover');
+    });
+    dropArea.addEventListener('dragleave', () => dropArea.classList.remove('dragover'));
+    dropArea.addEventListener('drop', e => {
+        e.preventDefault();
+        dropArea.classList.remove('dragover');
+        const file = e.dataTransfer.files[0];
+        if (file) {
+            if (validateStockImportFile(file)) {
+                handleStockImportFile(file);
+            }
+        }
+    });
+    dropArea.addEventListener('click', () => {
+        document.getElementById('stock-import-file').click();
+    });
+}
+
+function validateStockImportFile(file) {
+    const allowed = ['application/vnd.ms-excel','application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'];
+    if (!allowed.includes(file.type)) {
+        showNotification('Tip fișier invalid', 'error');
+        return false;
+    }
+    if (file.size > 10 * 1024 * 1024) {
+        showNotification('Fișier prea mare (max 10MB)', 'error');
+        return false;
+    }
+    return true;
+}
+
+document.getElementById('stock-import-start').addEventListener('click', () => {
+    if (!stockImportFile) return;
+    if (!validateStockImportFile(stockImportFile)) return;
+    showStockImportStep('progress');
+    const formData = new FormData();
+    formData.append('excel_file', stockImportFile);
+    const progressBar = document.getElementById('stock-import-progress-bar');
+    progressBar.style.width = '10%';
+    fetch('api/inventory_stock_import.php', { method: 'POST', body: formData })
+        .then(r => r.json())
+        .then(data => {
+            progressBar.style.width = '100%';
+            displayStockImportResults(data);
+        })
+        .catch(() => {
+            progressBar.style.width = '100%';
+            displayStockImportResults({success:false,message:'Eroare la încărcare'});
+        });
+});
+
+function displayStockImportResults(data) {
+    showStockImportStep('results');
+    document.getElementById('stock-import-summary').innerHTML = `
+        <p>Procesate: ${data.processed || 0}</p>
+        <p>Adăugate: ${data.stock_added || 0}</p>
+        <p>Sărite: ${data.skipped || 0}</p>
+        <p>${data.message || ''}</p>`;
+    const warnList = document.getElementById('stock-import-warnings');
+    warnList.innerHTML = '';
+    if (data.warnings && data.warnings.length) {
+        warnList.innerHTML = '<h5>Avertizări</h5><ul>' + data.warnings.map(w => `<li>${w}</li>`).join('') + '</ul>';
+    }
+    const errList = document.getElementById('stock-import-errors');
+    errList.innerHTML = '';
+    if (data.errors && data.errors.length) {
+        errList.innerHTML = '<h5>Erori</h5><ul>' + data.errors.map(e => `<li>${e}</li>`).join('') + '</ul>';
+    }
+    if (typeof showNotification === 'function') {
+        showNotification(data.message || 'Import finalizat', data.success ? 'success' : 'error');
+    } else {
+        alert(data.message || 'Import finalizat');
+    }
+}
+
+// fallback notification if none defined
+if (typeof showNotification !== 'function') {
+    function showNotification(msg) { alert(msg); }
+}

--- a/scripts/sellers-import.js
+++ b/scripts/sellers-import.js
@@ -4,6 +4,9 @@
 let selectedSellersFile = null;
 let sellersImportInProgress = false;
 
+// Preserve any existing global notification handler
+const existingShowNotification = window.showNotification;
+
 /**
  * Initialize sellers import functionality
  */
@@ -193,12 +196,12 @@ function formatFileSize(bytes) {
  * Show notification message
  */
 function showNotification(message, type = 'info') {
-    // Try to use existing notification system first
-    if (typeof window.showNotification === 'function') {
-        window.showNotification(message, type);
+    // Try to use previously defined notification system first
+    if (typeof existingShowNotification === 'function') {
+        existingShowNotification(message, type);
         return;
     }
-    
+
     // Fallback: create simple notification
     const notification = document.createElement('div');
     notification.className = `notification notification-${type}`;
@@ -216,9 +219,9 @@ function showNotification(message, type = 'info') {
         word-wrap: break-word;
     `;
     notification.textContent = message;
-    
+
     document.body.appendChild(notification);
-    
+
     // Auto remove after 5 seconds
     setTimeout(() => {
         if (notification.parentNode) {


### PR DESCRIPTION
## Summary
- Add backend API to import stock from Excel and update inventory locations
- Add frontend modal and drag-and-drop upload for stock imports
- Integrate stock import UI into inventory management page
- Scope sellers-import script to sellers page and fix notification recursion

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c005aec58c832086cf890bf136f208