### PR TITLE
Add unified barcode lookup

### DIFF
--- a/mobile_picker.php
+++ b/mobile_picker.php
@@ -125,25 +125,25 @@ $hasOrderFromUrl = !empty($orderNumber);
                         <span class="material-symbols-outlined">inventory_2</span>
                         <div>
                             <div><strong id="target-product-name">Product Name</strong></div>
-                            <div>SKU: <span id="target-product-sku">SKU123</span></div>
+                            <div>Cod Produs/QR: <span id="target-product-sku">SKU123</span></div>
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="scan-section" id="product-scan-section">
                     <button id="scan-product-btn" class="btn btn-primary btn-large">
                         <span class="material-symbols-outlined">qr_code_scanner</span>
-                        Scanează Produsul
+                        Scanează codul produsului/QR
                     </button>
                     <button id="manual-product-btn" class="btn btn-secondary">
                         <span class="material-symbols-outlined">keyboard</span>
                         Introdu Manual
                     </button>
                 </div>
-                
+
                 <div class="manual-section hidden" id="product-manual-section">
-                    <label for="product-input">Codul produsului:</label>
-                    <input type="text" id="product-input" class="form-control" placeholder="SKU sau Barcode" inputmode="none" readonly>
+                    <label for="product-input">Cod produs/QR:</label>
+                    <input type="text" id="product-input" class="form-control" placeholder="Cod produs sau cod QR" inputmode="none" readonly>
                     <button id="verify-product-btn" class="btn btn-primary">
                         <span class="material-symbols-outlined">check</span>
                         Verifică Produsul


### PR DESCRIPTION
## Summary
- handle both internal SKUs and supplier unit barcodes using inventory batch numbers
- remove product_barcodes migration and track supplier barcodes in inventory
- expose GET /api/products/lookup/{barcode} to return product and unit info
- allow pickers to scan supplier barcodes by validating via product lookup API
- retain direct SKU/barcode comparison before falling back to lookup API

## Testing
- `php -l mobile_picker.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6aacb47d08320ae0740cf2de96258