### PR TITLE
Use product lookup API in mobile picker

### DIFF
--- a/scripts/warehouse-js/mobile_picker.js
+++ b/scripts/warehouse-js/mobile_picker.js
@@ -856,23 +856,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const inputProduct = elements.productInput?.value?.trim().toUpperCase();
         if (elements.productInput) elements.productInput.value = '';
 
-        const expectedSku = (currentItem.sku || '').toUpperCase();
-        const expectedBarcode = (currentItem.product_barcode || '').toUpperCase();
-
         if (!inputProduct) {
             showMessage('Vă rugăm să introduceți codul produsului.', 'error');
             return;
         }
 
-        // First allow direct comparison against known SKU/barcode
-        if (inputProduct === expectedSku || inputProduct === expectedBarcode) {
-            scannedProduct = inputProduct;
-            showMessage('Produs verificat cu succes!', 'success');
-            setTimeout(() => showStep('quantity'), 1000);
-            return;
-        }
-
-        // Fallback to lookup API for supplier unit barcodes
+        // Use lookup API to resolve SKU or barcode to product ID
         try {
             const resp = await fetch(`${API_BASE}/products/lookup/${encodeURIComponent(inputProduct)}`);
             if (!resp.ok) {


### PR DESCRIPTION
## Summary
- Validate scanned products via `/api/products/lookup` instead of direct barcode comparison
- Show error when API lookup fails or resolves to a different product

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c718d822d08320a02e137594743b7d