### PR TITLE
Improve barcode scanning UX

### DIFF
--- a/warehouse_barcode_scan.php
+++ b/warehouse_barcode_scan.php
@@ -27,14 +27,14 @@ if (empty($task['assigned_to'])) {
 <html lang="ro">
 <head>
     <?php include_once 'includes/warehouse_header.php'; ?>
-    <title>Scan Task - WMS</title>
+    <title>Sarcină de Scanare - WMS</title>
 </head>
 <body>
 <?php include_once 'includes/warehouse_navbar.php'; ?>
 <div class="main-container scan-container">
     <h2><?= htmlspecialchars($task['product_name']) ?> - <?= htmlspecialchars($task['location_code']) ?></h2>
-    <p id="scan-progress">Unit <?= $task['scanned_quantity'] ?>/<?= $task['expected_quantity'] ?> scanned</p>
-    <input type="text" id="scan-input" class="barcode-input" autofocus placeholder="Scan barcode...">
+    <p id="scan-progress">Unități <?= $task['scanned_quantity'] ?>/<?= $task['expected_quantity'] ?> scanate</p>
+    <input type="text" id="scan-input" class="barcode-input" autofocus placeholder="Scanează codul de bare...">
     <div id="scanned-list" class="scanned-list"></div>
 </div>
 <?php include_once 'includes/warehouse_footer.php'; ?>
@@ -54,6 +54,8 @@ class BarcodeCapture {
         this.expected = <?= $task['expected_quantity'] ?>;
         this.scanned = <?= $task['scanned_quantity'] ?>;
         this.editingCard = null;
+        this.storageKey = `barcode_scans_${this.taskId}`;
+        this.inputTimer = null;
         this.init();
     }
     init() {
@@ -65,6 +67,10 @@ class BarcodeCapture {
                 this.submit();
             }
         });
+        this.input.addEventListener('input', () => {
+            clearTimeout(this.inputTimer);
+            this.inputTimer = setTimeout(() => this.submit(), 200);
+        });
         this.loadScans();
     }
     async loadScans() {
@@ -73,10 +79,17 @@ class BarcodeCapture {
             const data = await res.json();
             if (data.status === 'success') {
                 this.scanned = data.scanned;
-                this.progress.textContent = `Unit ${data.scanned}/${data.expected} scanned`;
-                data.scans.forEach(s => this.addCard(s.barcode, s.inventory_id, false));
+                this.progress.textContent = `Unități ${data.scanned}/${data.expected} scanate`;
+                if (data.scans.length) {
+                    this.list.innerHTML = '';
+                    data.scans.forEach(s => this.addCard(s.barcode, s.inventory_id, false));
+                    localStorage.setItem(this.storageKey, JSON.stringify(data.scans));
+                    return;
+                }
             }
         } catch (e) {}
+        const stored = JSON.parse(localStorage.getItem(this.storageKey) || '[]');
+        stored.forEach(s => this.addCard(s.barcode, s.inventory_id, false));
     }
     addCard(barcode, inventoryId, prepend = true) {
         const card = document.createElement('div');
@@ -90,11 +103,16 @@ class BarcodeCapture {
         } else {
             this.list.appendChild(card);
         }
+        if (prepend) {
+            const stored = JSON.parse(localStorage.getItem(this.storageKey) || '[]');
+            stored.unshift({barcode, inventory_id: inventoryId});
+            localStorage.setItem(this.storageKey, JSON.stringify(stored));
+        }
     }
     startEditing(card) {
         const barcode = card.dataset.barcode;
         if (!barcode) return;
-        if (!confirm('Delete this barcode?')) return;
+        if (!confirm('Ștergi acest cod de bare?')) return;
         this.deleteScan(card);
     }
     async deleteScan(card) {
@@ -109,18 +127,20 @@ class BarcodeCapture {
             const data = await res.json();
             if (data.status === 'success') {
                 this.scanned = data.scanned;
-                this.progress.textContent = `Unit ${data.scanned}/${data.expected} scanned`;
+                this.progress.textContent = `Unități ${data.scanned}/${data.expected} scanate`;
+                const stored = JSON.parse(localStorage.getItem(this.storageKey) || '[]').filter(s => !(s.barcode === barcode && s.inventory_id == inventoryId));
+                localStorage.setItem(this.storageKey, JSON.stringify(stored));
                 card.classList.add('editing');
                 card.dataset.barcode = '';
                 card.dataset.inventoryId = '';
-                card.textContent = 'Scan barcode...';
+                card.textContent = 'Scanează codul de bare...';
                 this.editingCard = card;
                 this.input.focus();
             } else {
-                alert(data.message || 'Error');
+                alert(data.message || 'Eroare');
             }
         } catch (e) {
-            alert('Network error');
+            alert('Eroare de rețea');
         }
     }
     async submit() {
@@ -135,7 +155,7 @@ class BarcodeCapture {
             const data = await res.json();
             if (data.status === 'success') {
                 this.scanned = data.scanned;
-                this.progress.textContent = `Unit ${data.scanned}/${data.expected} scanned`;
+                this.progress.textContent = `Unități ${data.scanned}/${data.expected} scanate`;
                 if (this.editingCard) {
                     this.editingCard.classList.remove('editing');
                     this.editingCard.dataset.barcode = code;
@@ -146,14 +166,14 @@ class BarcodeCapture {
                     this.addCard(code, data.inventory_id);
                 }
                 if (data.completed) {
-                    alert('Task completed');
+                    alert('Sarcină completată');
                     window.location.href = 'warehouse_barcode_tasks.php';
                 }
             } else {
-                alert(data.message || 'Error');
+                alert(data.message || 'Eroare');
             }
         } catch (e) {
-            alert('Network error');
+            alert('Eroare de rețea');
         }
         this.input.value = '';
         this.input.focus();


### PR DESCRIPTION
## Summary
- Translate warehouse barcode scanning interface text to Romanian
- Persist scanned barcodes locally to survive page refreshes
- Auto-submit scanned codes without requiring manual confirmation

## Testing
- `php -l warehouse_barcode_scan.php`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c7ad1791748320b32404b676a7094b