### PR TITLE
Fix relocation card navigation in warehouse hub

### DIFF
--- a/includes/warehouse_header.php
+++ b/includes/warehouse_header.php
@@ -61,6 +61,7 @@ if (isset($warehousePageCSS[$currentPage])) {
 <script>
     window.WMS_CONFIG = {
         apiBase: '<?= $apiBase ?>', // FIXED: Now works in both dev and production
+        baseUrl: '<?= rtrim(BASE_URL, '/') . '/' ?>', // Added for reliable navigation
         csrfToken: '<?= getCsrfToken() ?>', // FIXED: Added CSRF token from bootstrap
         warehouseMode: true,
         currentUser: <?= json_encode([

--- a/scripts/warehouse-js/warehouse_hub.js
+++ b/scripts/warehouse-js/warehouse_hub.js
@@ -4,6 +4,7 @@
 class WarehouseHub {
     constructor() {
         this.apiBase = window.WMS_CONFIG?.apiBase || '/api';
+        this.baseUrl = window.WMS_CONFIG?.baseUrl || '/';
         this.currentUser = null;
         this.stats = {};
         this.init();
@@ -271,27 +272,27 @@ class WarehouseHub {
                 switch(operation) {
                     case 'picking':
                         console.log('🛒 Navigating to picking orders dashboard...');
-                        window.location.href = 'warehouse_orders.php';
+                        window.location.href = `${this.baseUrl}warehouse_orders.php`;
                         break;
                     case 'receiving':
                         console.log('📦 Navigating to receiving interface...');
-                        window.location.href = 'warehouse_receiving.php';
+                        window.location.href = `${this.baseUrl}warehouse_receiving.php`;
                         break;
                     case 'inventory':
                         console.log('📋 Navigating to inventory search...');
-                        window.location.href = 'warehouse_inventory.php';
+                        window.location.href = `${this.baseUrl}warehouse_inventory.php`;
                         break;
                     case 'cycle-count':
                         console.log('🔍 Navigating to cycle count interface...');
-                        window.location.href = 'warehouse_cycle_count.php';
+                        window.location.href = `${this.baseUrl}warehouse_cycle_count.php`;
                         break;
                     case 'relocation':
                         console.log('🔄 Navigating to relocation tasks...');
-                        window.location.href = 'warehouse_relocation.php';
+                        window.location.href = `${this.baseUrl}warehouse_relocation.php`;
                         break;
                     case 'barcode':
                         console.log('📋 Navigating to barcode tasks...');
-                        window.location.href = 'warehouse_barcode_tasks.php';
+                        window.location.href = `${this.baseUrl}warehouse_barcode_tasks.php`;
                         break;
                     default:
                         console.warn(`⚠️ Unknown operation: ${operation}`);


### PR DESCRIPTION
## Summary
- add baseUrl to warehouse header config for consistent routing
- use baseUrl in warehouse hub navigation to direct relocation card to tasks page

## Testing
- `npm test` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7eb62899c8320a8ea2c99d68a8813