### PR TITLE
Fix relocation workflow and log relocation movements

### DIFF
--- a/models/Inventory.php
+++ b/models/Inventory.php
@@ -13,6 +13,7 @@ class Inventory {
     private $productsTable = "products";
     private $locationsTable = "locations";
     private ?InventoryTransactionService $transactionService = null;
+    private ?bool $inventoryTransactionsTableExists = null;
 
     public function __construct($db) {
         $this->conn = $db;
@@ -31,11 +32,27 @@ class Inventory {
 
     private function hasTransactionLogging(): bool {
         try {
-            return $this->getTransactionService() && 
+            return $this->getTransactionService() &&
                    $this->getTransactionService()->isTransactionSystemAvailable();
         } catch (Exception $e) {
             return false;
         }
+    }
+
+    private function hasInventoryTransactions(): bool
+    {
+        if ($this->inventoryTransactionsTableExists !== null) {
+            return $this->inventoryTransactionsTableExists;
+        }
+
+        try {
+            $stmt = $this->conn->query("SHOW TABLES LIKE 'inventory_transactions'");
+            $this->inventoryTransactionsTableExists = $stmt && $stmt->fetchColumn() ? true : false;
+        } catch (PDOException $e) {
+            $this->inventoryTransactionsTableExists = false;
+        }
+
+        return $this->inventoryTransactionsTableExists;
     }
 
     /**
@@ -1175,23 +1192,70 @@ public function getCriticalStockAlerts(int $limit = 10): array {
                                       string $sort = 'created_at', string $direction = 'DESC'): array {
         $offset = ($page - 1) * $pageSize;
 
-        $allowedSort = ['created_at', 'transaction_type', 'quantity_change', 'product_name'];
-        if (!in_array($sort, $allowedSort)) {
+        $sortColumnMap = [
+            'created_at' => 'records.created_at',
+            'transaction_type' => 'records.transaction_type',
+            'quantity_change' => 'records.quantity_change',
+            'product_name' => 'p.name',
+        ];
+
+        if (!array_key_exists($sort, $sortColumnMap)) {
             $sort = 'created_at';
         }
+        $sortColumn = $sortColumnMap[$sort];
         $direction = strtoupper($direction) === 'ASC' ? 'ASC' : 'DESC';
+
+        if (!$this->hasInventoryTransactions()) {
+            return [
+                'data' => [],
+                'total' => 0,
+            ];
+        }
+
+        $recordsSql = "SELECT
+                CAST(t.id AS CHAR) AS record_id,
+                CASE WHEN t.reason = 'Relocation' THEN 'relocation' ELSE 'transaction' END AS record_type,
+                CASE WHEN t.reason = 'Relocation' THEN 'relocation' ELSE t.transaction_type END AS transaction_type,
+                t.product_id,
+                t.location_id,
+                t.source_location_id,
+                t.quantity_change,
+                t.quantity_before,
+                t.quantity_after,
+                t.reason,
+                t.user_id,
+                t.duration_seconds,
+                t.reference_type,
+                t.reference_id,
+                t.created_at,
+                CASE WHEN t.reason = 'Relocation' THEN t.source_location_id ELSE NULL END AS relocation_target_location_id,
+                CASE
+                    WHEN t.reason = 'Relocation' AND t.quantity_change < 0 THEN 'out'
+                    WHEN t.reason = 'Relocation' AND t.quantity_change > 0 THEN 'in'
+                    ELSE NULL
+                END AS movement_direction
+            FROM inventory_transactions t";
+
+        $baseQuery = "FROM (
+                $recordsSql
+            ) records
+            LEFT JOIN products p ON records.product_id = p.product_id
+            LEFT JOIN locations loc ON records.location_id = loc.id
+            LEFT JOIN locations source_loc ON records.source_location_id = source_loc.id
+            LEFT JOIN locations target_loc ON records.relocation_target_location_id = target_loc.id
+            LEFT JOIN users u ON records.user_id = u.id";
 
         $where = [];
         $params = [];
 
         $dateFrom = $filters['date_from'] ?? date('Y-m-d', strtotime('-30 days'));
         $dateTo   = $filters['date_to'] ?? date('Y-m-d');
-        $where[] = 't.created_at BETWEEN :date_from AND :date_to';
+        $where[] = 'records.created_at BETWEEN :date_from AND :date_to';
         $params[':date_from'] = $dateFrom . ' 00:00:00';
         $params[':date_to']   = $dateTo . ' 23:59:59';
 
         if (!empty($filters['transaction_type']) && $filters['transaction_type'] !== 'all') {
-            $where[] = 't.transaction_type = :type';
+            $where[] = 'records.transaction_type = :type';
             $params[':type'] = $filters['transaction_type'];
         }
 
@@ -1201,34 +1265,54 @@ public function getCriticalStockAlerts(int $limit = 10): array {
         }
 
         if (!empty($filters['location_id'])) {
-            $where[] = '(t.location_id = :loc OR t.source_location_id = :loc)';
+            $where[] = '(
+                records.location_id = :loc
+                OR records.source_location_id = :loc
+                OR records.relocation_target_location_id = :loc
+            )';
             $params[':loc'] = $filters['location_id'];
         }
 
         if (!empty($filters['user_id'])) {
-            $where[] = 't.user_id = :user_id';
+            $where[] = 'records.user_id = :user_id';
             $params[':user_id'] = $filters['user_id'];
         }
 
         $whereSql = $where ? 'WHERE ' . implode(' AND ', $where) : '';
 
-        $baseQuery = "FROM inventory_transactions t
-                       LEFT JOIN products p ON t.product_id = p.product_id
-                       LEFT JOIN locations l ON t.location_id = l.id
-                       LEFT JOIN locations sl ON t.source_location_id = sl.id
-                       LEFT JOIN users u ON t.user_id = u.id
-                       $whereSql";
-
-        $countStmt = $this->conn->prepare("SELECT COUNT(*) " . $baseQuery);
+        $countStmt = $this->conn->prepare("SELECT COUNT(*) $baseQuery $whereSql");
         $countStmt->execute($params);
         $total = (int)$countStmt->fetchColumn();
 
-        $sql = "SELECT t.*, p.name AS product_name, p.sku,
-               l.location_code, sl.location_code AS source_location_code,
-               u.username AS full_name, u.username
-        " . $baseQuery . "
-        ORDER BY $sort $direction
-        LIMIT :limit OFFSET :offset";
+        $sql = "SELECT
+                records.record_id,
+                records.record_type,
+                records.transaction_type,
+                records.product_id,
+                records.location_id,
+                records.source_location_id,
+                records.quantity_change,
+                records.quantity_before,
+                records.quantity_after,
+                records.reason,
+                records.user_id,
+                records.duration_seconds,
+                records.reference_type,
+                records.reference_id,
+                records.created_at,
+                records.relocation_target_location_id,
+                records.movement_direction,
+                p.name AS product_name,
+                p.sku,
+                loc.location_code,
+                source_loc.location_code AS source_location_code,
+                target_loc.location_code AS target_location_code,
+                u.username AS full_name,
+                u.username AS username
+            $baseQuery
+            $whereSql
+            ORDER BY $sortColumn $direction
+            LIMIT :limit OFFSET :offset";
 
         $stmt = $this->conn->prepare($sql);
         foreach ($params as $key => $value) {

--- a/models/RelocationTask.php
+++ b/models/RelocationTask.php
@@ -5,6 +5,7 @@
 class RelocationTask {
     private $conn;
     private $table = 'relocation_tasks';
+    private ?bool $transactionTableExists = null;
 
     public function __construct($db) {
         $this->conn = $db;
@@ -118,6 +119,192 @@ class RelocationTask {
         } catch (PDOException $e) {
             error_log("Error updating relocation task status: " . $e->getMessage());
             return false;
+        }
+    }
+
+    /**
+     * Log inventory movements for a completed relocation task
+     */
+    public function logRelocationMovements(array $task, int $userId, array $quantitySnapshot = []): void
+    {
+        if (!$this->hasInventoryTransactionTable()) {
+            return;
+        }
+
+        $taskId = (int)($task['id'] ?? 0);
+        $productId = (int)($task['product_id'] ?? 0);
+        $fromLocationId = (int)($task['from_location_id'] ?? 0);
+        $toLocationId = (int)($task['to_location_id'] ?? 0);
+        $quantity = (int)($task['quantity'] ?? 0);
+
+        if ($taskId <= 0 || $productId <= 0 || $fromLocationId <= 0 || $toLocationId <= 0 || $quantity <= 0) {
+            return;
+        }
+
+        if ($userId <= 0) {
+            $userId = (int)($task['user_id'] ?? $task['assigned_to'] ?? 1);
+            if ($userId <= 0) {
+                $userId = 1;
+            }
+        }
+
+        $locationCodes = $this->getLocationCodes([$fromLocationId, $toLocationId]);
+        $fromCode = $locationCodes[$fromLocationId] ?? 'N/A';
+        $toCode = $locationCodes[$toLocationId] ?? 'N/A';
+
+        $fromBefore = array_key_exists('from_before', $quantitySnapshot)
+            ? (int)$quantitySnapshot['from_before']
+            : null;
+        $toBefore = array_key_exists('to_before', $quantitySnapshot)
+            ? (int)$quantitySnapshot['to_before']
+            : null;
+
+        if ($fromBefore === null) {
+            $fromBefore = $this->getInventoryQuantity($productId, $fromLocationId) + $quantity;
+        }
+        if ($toBefore === null) {
+            $currentTo = $this->getInventoryQuantity($productId, $toLocationId);
+            $toBefore = max(0, $currentTo - $quantity);
+        }
+
+        $fromAfter = max(0, $fromBefore - $quantity);
+        $toAfter = $toBefore + $quantity;
+
+        $sessionId = sprintf('relocation-%d', $taskId);
+
+        $entries = [
+            [
+                'location_id' => $fromLocationId,
+                'source_location_id' => $toLocationId,
+                'quantity_change' => -$quantity,
+                'quantity_before' => $fromBefore,
+                'quantity_after' => $fromAfter,
+                'notes' => sprintf('Relocation OUT → %s', $toCode),
+            ],
+            [
+                'location_id' => $toLocationId,
+                'source_location_id' => $fromLocationId,
+                'quantity_change' => $quantity,
+                'quantity_before' => $toBefore,
+                'quantity_after' => $toAfter,
+                'notes' => sprintf('Relocation IN ← %s', $fromCode),
+            ],
+        ];
+
+        $sql = "INSERT INTO inventory_transactions (
+                    transaction_type,
+                    quantity_change,
+                    quantity_before,
+                    quantity_after,
+                    product_id,
+                    location_id,
+                    source_location_id,
+                    user_id,
+                    reference_type,
+                    reference_id,
+                    reason,
+                    notes,
+                    session_id
+                ) VALUES (
+                    :transaction_type,
+                    :quantity_change,
+                    :quantity_before,
+                    :quantity_after,
+                    :product_id,
+                    :location_id,
+                    :source_location_id,
+                    :user_id,
+                    :reference_type,
+                    :reference_id,
+                    :reason,
+                    :notes,
+                    :session_id
+                )";
+
+        $stmt = $this->conn->prepare($sql);
+
+        foreach ($entries as $entry) {
+            try {
+                $stmt->execute([
+                    ':transaction_type' => 'move',
+                    ':quantity_change' => $entry['quantity_change'],
+                    ':quantity_before' => $entry['quantity_before'],
+                    ':quantity_after' => $entry['quantity_after'],
+                    ':product_id' => $productId,
+                    ':location_id' => $entry['location_id'],
+                    ':source_location_id' => $entry['source_location_id'],
+                    ':user_id' => $userId,
+                    ':reference_type' => 'system_auto',
+                    ':reference_id' => $taskId,
+                    ':reason' => 'Relocation',
+                    ':notes' => $entry['notes'],
+                    ':session_id' => $sessionId,
+                ]);
+            } catch (PDOException $e) {
+                error_log('Failed to record relocation transaction: ' . $e->getMessage());
+            }
+        }
+    }
+
+    private function getLocationCodes(array $locationIds): array
+    {
+        if (empty($locationIds)) {
+            return [];
+        }
+
+        $uniqueIds = array_values(array_unique(array_filter($locationIds, fn($id) => (int)$id > 0)));
+        if (empty($uniqueIds)) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($uniqueIds), '?'));
+        $query = "SELECT id, location_code FROM locations WHERE id IN ($placeholders)";
+        $stmt = $this->conn->prepare($query);
+        foreach ($uniqueIds as $index => $id) {
+            $stmt->bindValue($index + 1, $id, PDO::PARAM_INT);
+        }
+        $stmt->execute();
+
+        $codes = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $codes[(int)$row['id']] = $row['location_code'];
+        }
+
+        return $codes;
+    }
+
+    private function hasInventoryTransactionTable(): bool
+    {
+        if ($this->transactionTableExists !== null) {
+            return $this->transactionTableExists;
+        }
+
+        try {
+            $stmt = $this->conn->query("SHOW TABLES LIKE 'inventory_transactions'");
+            $this->transactionTableExists = $stmt && $stmt->fetchColumn() ? true : false;
+        } catch (PDOException $e) {
+            $this->transactionTableExists = false;
+        }
+
+        return $this->transactionTableExists;
+    }
+
+    private function getInventoryQuantity(int $productId, int $locationId): int
+    {
+        if ($productId <= 0 || $locationId <= 0) {
+            return 0;
+        }
+
+        try {
+            $stmt = $this->conn->prepare('SELECT COALESCE(SUM(quantity), 0) FROM inventory WHERE product_id = :product_id AND location_id = :location_id');
+            $stmt->execute([
+                ':product_id' => $productId,
+                ':location_id' => $locationId,
+            ]);
+
+            return (int)$stmt->fetchColumn();
+        } catch (PDOException $e) {
+            return 0;
         }
     }
 }

--- a/scripts/warehouse-js/warehouse_relocation.js
+++ b/scripts/warehouse-js/warehouse_relocation.js
@@ -68,7 +68,6 @@
             this.stepCompletion = {
                 source: false,
                 product: false,
-                destination: false,
             };
             this.autoSubmitTimer = null;
 
@@ -120,15 +119,9 @@
                     expectedKey: 'product_sku',
                 },
                 {
-                    id: 'destination',
-                    title: 'Pasul 3 - Scanare destinație',
-                    status: 'Scanați locația destinație (F3)',
-                    expectedKey: 'to_location',
-                },
-                {
-                    id: 'confirm',
-                    title: 'Pasul 4 - Confirmare relocare',
-                    status: 'Apăsați F1 pentru confirmare',
+                    id: 'quantity',
+                    title: 'Pasul 3 - Confirmare cantitate',
+                    status: 'Verificați cantitatea și apăsați F1',
                     expectedKey: null,
                 },
             ];
@@ -286,7 +279,6 @@
             this.stepCompletion = {
                 source: false,
                 product: false,
-                destination: false,
             };
             this.updateTaskSummary();
             this.updateProgress();
@@ -337,7 +329,9 @@
 
             this.elements.stepTitle.textContent = step.title;
             this.elements.stepStatus.textContent = step.status;
-            if (step.expectedKey && this.currentTask) {
+            if (step.id === 'quantity' && this.currentTask) {
+                this.elements.expectedValue.textContent = `Cantitate de mutat: ${this.currentTask.quantity ?? 0}`;
+            } else if (step.expectedKey && this.currentTask) {
                 const value = this.currentTask[step.expectedKey] || '--';
                 if (step.id === 'product') {
                     this.elements.expectedValue.textContent = `SKU așteptat: ${value}`;
@@ -348,7 +342,10 @@
                 this.elements.expectedValue.textContent = '--';
             }
 
-            if (this.scannerActive) {
+            if (step.id === 'quantity') {
+                this.elements.scannerState.textContent = 'Confirmați cantitatea și apăsați F1 pentru finalizare.';
+                this.elements.scannerState.classList.remove('error');
+            } else if (this.scannerActive) {
                 this.elements.scannerState.textContent = 'Scanner laser activ - scanați codul';
                 this.elements.scannerState.classList.remove('error');
             } else {
@@ -434,18 +431,11 @@
                     this.setFunctionKeyState('F4', this.manualMode ? 'Ascunde' : 'Manual', false);
                     this.setFunctionKeyState('F5', 'Înapoi', false);
                     break;
-                case 'destination':
-                    this.setFunctionKeyState('F1', this.manualMode ? 'Confirmă' : 'Confirmă', this.manualMode ? false : !this.stepCompletion.destination);
-                    this.setFunctionKeyState('F2', 'Următor', false);
-                    this.setFunctionKeyState('F3', this.scannerActive ? 'Oprește' : 'Scanează', false);
-                    this.setFunctionKeyState('F4', this.manualMode ? 'Ascunde' : 'Manual', false);
-                    this.setFunctionKeyState('F5', 'Înapoi', false);
-                    break;
-                case 'confirm':
+                case 'quantity':
                     this.setFunctionKeyState('F1', 'Finalizează', false);
                     this.setFunctionKeyState('F2', 'Următor', this.total <= 1);
-                    this.setFunctionKeyState('F3', this.scannerActive ? 'Oprește' : 'Scanează', true);
-                    this.setFunctionKeyState('F4', this.manualMode ? 'Ascunde' : 'Manual', true);
+                    this.setFunctionKeyState('F3', 'Scanează', true);
+                    this.setFunctionKeyState('F4', 'Manual', true);
                     this.setFunctionKeyState('F5', 'Înapoi', false);
                     break;
                 default:
@@ -467,6 +457,10 @@
             } else {
                 element.classList.remove('disabled');
             }
+        }
+
+        stepRequiresScanner(stepId) {
+            return ['source', 'product'].includes(stepId);
         }
 
         handleF1() {
@@ -492,7 +486,7 @@
                     this.audio.play('navigate');
                     this.setStep(1);
                     break;
-                case 'confirm':
+                case 'quantity':
                     this.completeTask();
                     break;
                 default:
@@ -514,10 +508,18 @@
         }
 
         handleF3() {
+            const step = this.stepConfig[this.stepIndex];
+            if (!this.currentTask || !this.stepRequiresScanner(step?.id)) {
+                return;
+            }
             this.toggleScanner();
         }
 
         handleF4() {
+            const step = this.stepConfig[this.stepIndex];
+            if (!this.currentTask || !this.stepRequiresScanner(step?.id)) {
+                return;
+            }
             this.toggleManualMode(!this.manualMode);
         }
 
@@ -547,6 +549,19 @@
                 index = this.stepConfig.length - 1;
             }
             this.stepIndex = index;
+            const step = this.stepConfig[this.stepIndex];
+            if (!this.stepRequiresScanner(step?.id)) {
+                this.manualMode = false;
+                this.scannerActive = false;
+                this.scannerPaused = false;
+                if (this.elements.manualEntry) {
+                    this.elements.manualEntry.hidden = true;
+                }
+                if (this.elements.manualInput) {
+                    this.elements.manualInput.value = '';
+                    this.elements.manualInput.readOnly = true;
+                }
+            }
             this.updateStepUI();
             this.updateFunctionBar();
         }
@@ -729,7 +744,10 @@
                     this.pauseScanner().then(() => {
                         setTimeout(() => {
                             this.advanceStep();
-                            this.resumeScanner();
+                            const nextStep = this.stepConfig[this.stepIndex];
+                            if (this.stepRequiresScanner(nextStep?.id)) {
+                                this.resumeScanner();
+                            }
                         }, 300);
                     });
                 } else {
@@ -760,14 +778,16 @@
             if (!this.elements.manualInput) {
                 return;
             }
+            this.elements.manualInput.value = '';
+            if (this.autoSubmitTimer) {
+                clearTimeout(this.autoSubmitTimer);
+                this.autoSubmitTimer = null;
+            }
+
             if (isManual) {
-                this.elements.manualInput.select();
+                this.elements.manualInput.focus();
             } else if (this.scannerActive) {
                 this.elements.manualInput.focus();
-                if (this.autoSubmitTimer) {
-                    clearTimeout(this.autoSubmitTimer);
-                    this.autoSubmitTimer = null;
-                }
             }
         }
 


### PR DESCRIPTION
## Summary
- update the mobile relocation workflow so it stops after the quantity confirmation step, clears invalid scans, and no longer advances to a phantom step
- record paired relocation entries in the `inventory_transactions` table whenever a relocation task is completed, including before/after snapshots for both locations
- surface relocation movements in the inventory movements report with clear source and destination context by reading the transaction log

## Testing
- php -l warehouse_relocation.php
- php -l inventory.php
- php -l models/RelocationTask.php
- php -l models/Inventory.php

------
https://chatgpt.com/codex/tasks/task_e_68cd05a5a2b88320abd3d1b80aaac20f