### PR TITLE
Ensure purchase order emails are copied to Sent folder

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -149,7 +149,18 @@ return [
         'password' => 'WTG7498&$%',
         'from_email' => 'comenzi@wartung.ro',
         'from_name' => 'Wartung - Departament Achizitii',
-        'reply_to' => 'comenzi@wartung.ro'
+        'reply_to' => 'comenzi@wartung.ro',
+        // Optional IMAP settings used for saving a copy of the email in the Sent folder
+        'imap_host' => 'mail.wartung.ro',
+        'imap_port' => 993,
+        // Accept both valid and self-signed certificates by default
+        'imap_flags' => [
+            '/imap/ssl/validate-cert',
+            '/imap/ssl/novalidate-cert',
+            '/imap/ssl'
+        ],
+        // Ordered list of folders to probe when appending the message
+        'imap_sent_folders' => ['INBOX.Sent', 'Sent', 'INBOX/Sent', 'Sent Items', 'Sent Messages']
     ],
 
     'label_left_offset_mm' => 4,   // 3–6 mm de obicei e suficient


### PR DESCRIPTION
## Summary
- add configurable IMAP connection options to the email configuration
- enhance the Sent-folder helper to probe multiple IMAP combinations and build RFC-compliant messages
- pass the new IMAP settings when sending purchase order emails

## Testing
- php -l purchase_orders.php
- php -l config/config.php

------
https://chatgpt.com/codex/tasks/task_e_68cd0da08d10832082dbe3f2aec0bdb4