### PR TITLE
Add auto-order management UI and APIs

### DIFF
--- a/api/auto_order_test.php
+++ b/api/auto_order_test.php
@@ -1,0 +1,190 @@
+<?php
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    exit;
+}
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+$config = require BASE_PATH . '/config/config.php';
+$dbFactory = $config['connection_factory'] ?? null;
+
+if (!$dbFactory || !is_callable($dbFactory)) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Database connection factory not configured.'
+    ]);
+    exit;
+}
+
+try {
+    $db = $dbFactory();
+    require_once BASE_PATH . '/models/Inventory.php';
+    require_once BASE_PATH . '/models/AutoOrderManager.php';
+
+    $inventory = new Inventory($db);
+    $autoManager = new AutoOrderManager($db);
+
+    if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+        $productId = isset($_GET['product_id']) ? (int)$_GET['product_id'] : 0;
+        if ($productId <= 0) {
+            http_response_code(400);
+            echo json_encode([
+                'success' => false,
+                'message' => 'Parametrul product_id este obligatoriu.'
+            ]);
+            exit;
+        }
+
+        $result = $inventory->testAutoOrder($productId);
+        if (empty($result)) {
+            echo json_encode([
+                'success' => false,
+                'message' => 'Nu s-a putut genera simularea pentru acest produs.'
+            ]);
+            exit;
+        }
+
+        $emailData = $result['email'] ?? null;
+        $subject = $emailData['subiect'] ?? '';
+        $body = $emailData['corp'] ?? '';
+        if ($subject) {
+            $subject = trim(preg_replace('/^[^\pL\d]+/u', '', $subject));
+        }
+
+        $response = [
+            'validari' => $result['validari'] ?? [],
+            'template' => [
+                'subject_preview' => $subject,
+                'body_preview' => $body
+            ],
+            'simulation' => [
+                'poate_comanda' => (bool)($result['poate_comanda'] ?? false),
+                'produs' => $result['produs'] ?? null,
+                'furnizor' => $result['furnizor'] ?? null,
+                'comanda' => $result['comanda'] ?? null,
+                'payload' => $result['payload_simulat'] ?? $result['payload'] ?? null
+            ]
+        ];
+
+        echo json_encode([
+            'success' => true,
+            'data' => $response
+        ]);
+        exit;
+    }
+
+    $payload = json_decode(file_get_contents('php://input'), true) ?: [];
+    $action = $payload['action'] ?? '';
+    $productId = isset($payload['product_id']) ? (int)$payload['product_id'] : 0;
+
+    if ($productId <= 0) {
+        http_response_code(400);
+        echo json_encode([
+            'success' => false,
+            'message' => 'Parametrul product_id este obligatoriu.'
+        ]);
+        exit;
+    }
+
+    switch ($action) {
+        case 'send_test_email':
+            $result = $inventory->testAutoOrder($productId);
+            $emailData = $result['email'] ?? null;
+            if (empty($emailData) || empty($result['furnizor']['email'])) {
+                echo json_encode([
+                    'success' => false,
+                    'message' => 'Nu există un email valid pentru furnizor.'
+                ]);
+                exit;
+            }
+
+            $smtpConfig = $config['email'] ?? [];
+            if (empty($smtpConfig)) {
+                echo json_encode([
+                    'success' => false,
+                    'message' => 'Configurația de email nu este definită.'
+                ]);
+                exit;
+            }
+
+            require_once BASE_PATH . '/lib/PHPMailer/PHPMailer.php';
+            require_once BASE_PATH . '/lib/PHPMailer/SMTP.php';
+            require_once BASE_PATH . '/lib/PHPMailer/Exception.php';
+
+            $mailer = new PHPMailer\PHPMailer\PHPMailer(true);
+            try {
+                $mailer->isSMTP();
+                $mailer->Host = $smtpConfig['host'] ?? '';
+                $mailer->Port = (int)($smtpConfig['port'] ?? 0);
+                $mailer->SMTPAuth = true;
+                $mailer->Username = $smtpConfig['username'] ?? '';
+                $mailer->Password = $smtpConfig['password'] ?? '';
+                if (!empty($smtpConfig['encryption'])) {
+                    $mailer->SMTPSecure = $smtpConfig['encryption'];
+                }
+                $mailer->CharSet = 'UTF-8';
+
+                $fromEmail = $smtpConfig['from_email'] ?? $smtpConfig['username'] ?? '';
+                $fromName = $smtpConfig['from_name'] ?? 'Sistem WMS';
+                $mailer->setFrom($fromEmail, $fromName);
+                if (!empty($smtpConfig['reply_to'])) {
+                    $mailer->addReplyTo($smtpConfig['reply_to']);
+                }
+
+                $mailer->addAddress($result['furnizor']['email'], $result['furnizor']['nume'] ?? '');
+                $rawSubject = $emailData['subiect'] ?? 'Test Autocomandă';
+                $cleanSubject = trim(preg_replace('/^[^\pL\d]+/u', '', $rawSubject));
+                $mailer->Subject = $cleanSubject ?: 'Test Autocomandă';
+                $mailer->Body = $emailData['corp'] ?? '';
+                $mailer->AltBody = $emailData['corp'] ?? '';
+                $mailer->isHTML(false);
+                $mailer->send();
+
+                echo json_encode([
+                    'success' => true,
+                    'message' => 'Emailul de test a fost trimis către furnizor.'
+                ]);
+            } catch (Throwable $e) {
+                echo json_encode([
+                    'success' => false,
+                    'message' => 'Trimiterea emailului de test a eșuat: ' . $e->getMessage()
+                ]);
+            }
+            exit;
+
+        case 'execute_auto_order':
+            $result = $autoManager->createAndSendAutoOrder($productId);
+            echo json_encode([
+                'success' => (bool)($result['succes'] ?? false),
+                'message' => $result['mesaj'] ?? 'Rezultatul nu este disponibil.',
+                'order_id' => $result['order_id'] ?? null,
+                'order_number' => $result['order_number'] ?? null
+            ]);
+            exit;
+
+        default:
+            http_response_code(400);
+            echo json_encode([
+                'success' => false,
+                'message' => 'Acțiune necunoscută pentru testarea autocomenzii.'
+            ]);
+            exit;
+    }
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'A apărut o eroare la procesarea cererii.',
+        'error' => $e->getMessage()
+    ]);
+}

--- a/api/auto_orders/dashboard.php
+++ b/api/auto_orders/dashboard.php
@@ -1,0 +1,98 @@
+<?php
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+$config = require BASE_PATH . '/config/config.php';
+$dbFactory = $config['connection_factory'] ?? null;
+
+if (!$dbFactory || !is_callable($dbFactory)) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Database connection factory not configured.'
+    ]);
+    exit;
+}
+
+try {
+    $db = $dbFactory();
+
+    require_once BASE_PATH . '/models/AutoOrderManager.php';
+
+    $autoOrderManager = new AutoOrderManager($db);
+
+    $statistics = $autoOrderManager->getAutoOrderStatistics();
+
+    // Failed auto orders
+    $failedAutoOrders = $autoOrderManager->getFailedAutoOrders();
+    $failedCount = is_array($failedAutoOrders) ? count($failedAutoOrders) : 0;
+
+    // Products below minimum stock with auto order enabled
+    $productsQuery = $db->prepare(
+        "SELECT p.product_id, p.name, p.sku, p.quantity, p.min_stock_level, p.last_auto_order_date,
+                s.supplier_name
+         FROM products p
+         LEFT JOIN sellers s ON p.seller_id = s.id
+         WHERE p.auto_order_enabled = 1
+           AND p.min_stock_level IS NOT NULL
+           AND p.min_stock_level > 0
+           AND p.quantity <= p.min_stock_level
+         ORDER BY p.quantity ASC, p.name ASC
+         LIMIT 15"
+    );
+    $productsQuery->execute();
+    $attentionProducts = $productsQuery->fetchAll(PDO::FETCH_ASSOC);
+
+    $productsAtMinimum = count($attentionProducts);
+
+    // Recent auto orders timeline (last 7 days)
+    $recentOrdersStmt = $db->prepare(
+        "SELECT po.id, po.order_number, po.status, po.total_amount, po.currency, po.created_at,
+                po.email_sent_at, po.notes, s.supplier_name,
+                GROUP_CONCAT(DISTINCT pr.name ORDER BY pr.name SEPARATOR ', ') AS product_names
+         FROM purchase_orders po
+         LEFT JOIN sellers s ON po.seller_id = s.id
+         LEFT JOIN purchase_order_items poi ON poi.purchase_order_id = po.id
+         LEFT JOIN purchasable_products pp ON poi.purchasable_product_id = pp.id
+         LEFT JOIN products pr ON pp.internal_product_id = pr.product_id
+         WHERE (po.notes LIKE 'Autocomandă%' OR po.notes LIKE 'Auto-generată%' OR poi.notes LIKE 'Autocomandă%')
+           AND po.created_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+         GROUP BY po.id
+         ORDER BY po.created_at DESC
+         LIMIT 25"
+    );
+    $recentOrdersStmt->execute();
+    $recentOrders = $recentOrdersStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode([
+        'success' => true,
+        'data' => [
+            'statistics' => [
+                'totalAutoOrders' => $statistics['total_autocomenzi'] ?? 0,
+                'autoOrdersLast30Days' => $statistics['autocomenzi_ultimele_30_zile'] ?? 0,
+                'autoOrdersToday' => $statistics['autocomenzi_azi'] ?? 0,
+                'autoOrdersPending' => $statistics['autocomenzi_nefinalizate'] ?? 0,
+                'failedAutoOrders' => $failedCount,
+                'productsAtMinimum' => $productsAtMinimum
+            ],
+            'recentOrders' => $recentOrders,
+            'attentionProducts' => $attentionProducts,
+            'failedAutoOrders' => $failedAutoOrders
+        ]
+    ]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Unable to load auto order dashboard data.',
+        'error' => $e->getMessage()
+    ]);
+}

--- a/api/auto_orders/history.php
+++ b/api/auto_orders/history.php
@@ -1,0 +1,126 @@
+<?php
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+$config = require BASE_PATH . '/config/config.php';
+$dbFactory = $config['connection_factory'] ?? null;
+
+if (!$dbFactory || !is_callable($dbFactory)) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Database connection factory not configured.'
+    ]);
+    exit;
+}
+
+try {
+    $db = $dbFactory();
+
+    $dateFrom = $_GET['date_from'] ?? date('Y-m-d', strtotime('-30 days'));
+    $dateTo = $_GET['date_to'] ?? date('Y-m-d');
+    $statusFilter = $_GET['status'] ?? '';
+
+    $fromDate = DateTime::createFromFormat('Y-m-d', $dateFrom) ?: new DateTime('-30 days');
+    $toDate = DateTime::createFromFormat('Y-m-d', $dateTo) ?: new DateTime();
+
+    if ($fromDate > $toDate) {
+        [$fromDate, $toDate] = [$toDate, $fromDate];
+    }
+
+    $query = $db->prepare(
+        "SELECT po.id, po.order_number, po.status, po.total_amount, po.currency,
+                po.created_at, po.email_sent_at, po.notes, po.invoiced,
+                s.supplier_name,
+                GROUP_CONCAT(DISTINCT pr.name ORDER BY pr.name SEPARATOR ', ') AS product_names,
+                MAX(poi.quantity) AS max_quantity,
+                SUM(poi.quantity) AS total_quantity
+         FROM purchase_orders po
+         LEFT JOIN sellers s ON po.seller_id = s.id
+         LEFT JOIN purchase_order_items poi ON poi.purchase_order_id = po.id
+         LEFT JOIN purchasable_products pp ON poi.purchasable_product_id = pp.id
+         LEFT JOIN products pr ON pp.internal_product_id = pr.product_id
+         WHERE (po.notes LIKE 'Autocomandă%' OR po.notes LIKE 'Auto-generată%' OR poi.notes LIKE 'Autocomandă%')
+           AND DATE(po.created_at) BETWEEN :date_from AND :date_to
+         GROUP BY po.id
+         ORDER BY po.created_at DESC"
+    );
+
+    $query->bindValue(':date_from', $fromDate->format('Y-m-d'));
+    $query->bindValue(':date_to', $toDate->format('Y-m-d'));
+    $query->execute();
+
+    $orders = $query->fetchAll(PDO::FETCH_ASSOC);
+
+    $normalizeStatus = static function (array $row): string {
+        $notes = mb_strtolower((string)($row['notes'] ?? ''), 'UTF-8');
+        $isAuto = strpos($notes, 'autocomandă') !== false
+            || strpos($notes, 'auto-generată') !== false
+            || strpos($notes, 'autocomanda') !== false;
+
+        if (!$isAuto) {
+            return 'manual';
+        }
+
+        $emailSent = !empty($row['email_sent_at']);
+        $status = $row['status'];
+
+        if ($status === 'cancelled') {
+            return 'failed';
+        }
+
+        if ($emailSent || in_array($status, ['sent', 'confirmed', 'delivered', 'invoiced', 'completed'], true)) {
+            return 'success';
+        }
+
+        if ($status === 'draft') {
+            return 'pending';
+        }
+
+        return 'processing';
+    };
+
+    $history = [];
+    foreach ($orders as $order) {
+        $computedStatus = $normalizeStatus($order);
+        if ($statusFilter && $statusFilter !== $computedStatus) {
+            continue;
+        }
+
+        $history[] = [
+            'id' => (int)$order['id'],
+            'order_number' => $order['order_number'],
+            'created_at' => $order['created_at'],
+            'supplier_name' => $order['supplier_name'],
+            'status' => $order['status'],
+            'auto_order_status' => $computedStatus,
+            'total_amount' => (float)$order['total_amount'],
+            'currency' => $order['currency'],
+            'email_sent_at' => $order['email_sent_at'],
+            'products' => $order['product_names'],
+            'total_quantity' => (float)$order['total_quantity'],
+            'max_quantity' => (float)$order['max_quantity'],
+            'invoiced' => (bool)$order['invoiced']
+        ];
+    }
+
+    echo json_encode([
+        'success' => true,
+        'data' => $history
+    ]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Unable to load auto order history.',
+        'error' => $e->getMessage()
+    ]);
+}

--- a/styles/product-units.css
+++ b/styles/product-units.css
@@ -550,6 +550,104 @@
     max-width: 1200px;
 }
 
+.test-results-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+}
+
+.validation-section,
+.email-preview-section,
+.simulation-section {
+    background: var(--container-background);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.validation-list,
+.simulation-details {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.validation-item {
+    padding: 10px;
+    border-radius: 8px;
+    background: #f5f9ff;
+    font-size: 0.9rem;
+}
+
+.validation-item.validation-success {
+    background: #e8f5e9;
+    color: #1b5e20;
+}
+
+.validation-item.validation-error {
+    background: #ffebee;
+    color: #b71c1c;
+}
+
+.validation-item.validation-warning {
+    background: #fff8e1;
+    color: #bf360c;
+}
+
+.validation-item.validation-info {
+    background: #ede7f6;
+    color: #4527a0;
+}
+
+.email-preview-container {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 0.9rem;
+}
+
+.email-content {
+    padding: 10px;
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.04);
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+.simulation-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 6px 0;
+    border-bottom: 1px dashed rgba(0, 0, 0, 0.1);
+    font-size: 0.9rem;
+}
+
+.simulation-row:last-child {
+    border-bottom: none;
+}
+
+.simulation-label {
+    font-weight: 600;
+}
+
+.simulation-value {
+    color: var(--text-secondary);
+}
+
+.btn.btn-warning {
+    background: #f9a825;
+    color: #fff;
+    border: none;
+}
+
+.btn.btn-warning:hover {
+    background: #f57f17;
+}
+
 .email-template-modal {
     display: flex;
     flex-direction: column;
@@ -1499,4 +1597,134 @@ option {
 .seller-item-details {
     font-size: 0.8rem;
     color: var(--text-secondary);
+}
+
+.stock-row {
+    background: rgba(33, 150, 243, 0.05);
+    border-left: 3px solid rgba(33, 150, 243, 0.7);
+}
+
+.stock-row td {
+    vertical-align: top;
+}
+
+.stock-product-info {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.stock-product-info small {
+    color: var(--text-secondary);
+}
+
+.auto-order-status {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.status-indicator {
+    font-size: 0.75rem;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: #e3f2fd;
+    color: #0d47a1;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.status-indicator.status-enabled {
+    background: #e8f5e9;
+    color: #1b5e20;
+}
+
+.status-indicator.status-disabled {
+    background: #eceff1;
+    color: #37474f;
+}
+
+.status-indicator.status-warning {
+    background: #fff8e1;
+    color: #bf360c;
+}
+
+.status-indicator.status-ready {
+    background: #ede7f6;
+    color: #4527a0;
+}
+
+.status-indicator.status-error {
+    background: #ffebee;
+    color: #b71c1c;
+}
+
+.status-indicator.status-last-order {
+    background: #f5f5f5;
+    color: #424242;
+}
+
+.stock-level-warning {
+    color: #b71c1c;
+    font-weight: 600;
+}
+
+.btn-test-auto-order {
+    background: #2196f3;
+    color: #fff;
+    border: none;
+}
+
+.btn-test-auto-order:hover {
+    background: #1976d2;
+}
+
+.action-group {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.action-group .btn span + span {
+    margin-left: 4px;
+}
+
+[data-theme="dark"] .stock-row {
+    background: rgba(13, 71, 161, 0.2);
+    border-color: rgba(144, 202, 249, 0.4);
+}
+
+[data-theme="dark"] .auto-order-status .status-indicator {
+    background: rgba(144, 202, 249, 0.12);
+    color: #90caf9;
+}
+
+[data-theme="dark"] .status-indicator.status-enabled {
+    background: rgba(102, 187, 106, 0.2);
+    color: #a5d6a7;
+}
+
+[data-theme="dark"] .status-indicator.status-disabled {
+    background: rgba(176, 190, 197, 0.2);
+    color: #cfd8dc;
+}
+
+[data-theme="dark"] .status-indicator.status-warning {
+    background: rgba(255, 183, 77, 0.18);
+    color: #ffcc80;
+}
+
+[data-theme="dark"] .status-indicator.status-ready {
+    background: rgba(206, 147, 216, 0.18);
+    color: #ce93d8;
+}
+
+[data-theme="dark"] .status-indicator.status-error {
+    background: rgba(239, 83, 80, 0.18);
+    color: #ef9a9a;
+}
+
+[data-theme="dark"] .status-indicator.status-last-order {
+    background: rgba(224, 224, 224, 0.08);
+    color: #e0e0e0;
 }

--- a/styles/purchase_orders.css
+++ b/styles/purchase_orders.css
@@ -1510,3 +1510,468 @@ input[type="file"]:hover {
     min-width: 140px;
     max-width: 140px;
 }
+
+.auto-order-row {
+    background-color: rgba(33, 150, 243, 0.08);
+    border-left: 3px solid #2196f3;
+}
+
+.order-number-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.order-number-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.order-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.badge-auto {
+    background-color: #2196f3;
+    color: #fff;
+    font-size: 0.75rem;
+    padding: 4px 10px;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.badge-manual {
+    background-color: #607d8b;
+    color: #fff;
+    font-size: 0.75rem;
+    padding: 4px 10px;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.badge-status {
+    background-color: #e3f2fd;
+    color: #0d47a1;
+    font-size: 0.75rem;
+    padding: 4px 10px;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.badge-status.status-success {
+    background-color: #e8f5e9;
+    color: #1b5e20;
+}
+
+.badge-status.status-failed {
+    background-color: #ffebee;
+    color: #b71c1c;
+}
+
+.badge-status.status-processing {
+    background-color: #fff8e1;
+    color: #bf360c;
+}
+
+.badge-status.status-pending {
+    background-color: #ede7f6;
+    color: #4527a0;
+}
+
+.auto-order-status-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #0d47a1;
+}
+
+.auto-order-status-indicator .status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: currentColor;
+}
+
+.auto-order-status-indicator.status-success {
+    color: #1b5e20;
+}
+
+.auto-order-status-indicator.status-failed {
+    color: #b71c1c;
+}
+
+.auto-order-status-indicator.status-processing {
+    color: #bf360c;
+}
+
+.auto-order-status-indicator.status-pending {
+    color: #4527a0;
+}
+
+.dashboard-row {
+    margin-bottom: 24px;
+}
+
+.auto-order-dashboard {
+    background: var(--bg-secondary);
+    border: 1px solid rgba(33, 150, 243, 0.2);
+    border-radius: 12px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.auto-order-dashboard .widget-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.auto-order-dashboard .widget-header h3 {
+    font-size: 1.2rem;
+    margin: 0;
+}
+
+.auto-order-dashboard .btn-refresh {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 10px;
+    border: 1px solid #2196f3;
+    color: #2196f3;
+    background: transparent;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.auto-order-dashboard .btn-refresh:hover {
+    background-color: rgba(33, 150, 243, 0.08);
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+}
+
+.stat-card {
+    background: #f5f9ff;
+    border-radius: 10px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.stat-card.warning {
+    background: #fff8e1;
+}
+
+.stat-card.error {
+    background: #ffebee;
+}
+
+.stat-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: #0d47a1;
+}
+
+.stat-card.warning .stat-value {
+    color: #bf360c;
+}
+
+.stat-card.error .stat-value {
+    color: #b71c1c;
+}
+
+.stat-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(0, 0, 0, 0.6);
+}
+
+.recent-auto-orders,
+.products-needing-attention {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.recent-auto-orders h4,
+.products-needing-attention h4 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.auto-order-timeline,
+.attention-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.timeline-item {
+    border: 1px solid rgba(33, 150, 243, 0.2);
+    border-radius: 8px;
+    padding: 12px;
+    background: #fff;
+}
+
+.timeline-item .timeline-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 6px;
+}
+
+.timeline-item .order-number {
+    font-weight: 600;
+}
+
+.timeline-item .timeline-status {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #1b5e20;
+}
+
+.timeline-item.status-cancelled .timeline-status {
+    color: #b71c1c;
+}
+
+.timeline-item .timeline-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 0.85rem;
+    color: rgba(0, 0, 0, 0.65);
+}
+
+.timeline-item .timeline-products {
+    margin-top: 6px;
+    font-size: 0.85rem;
+    color: rgba(0, 0, 0, 0.75);
+}
+
+.attention-item {
+    border: 1px dashed rgba(33, 150, 243, 0.4);
+    border-radius: 8px;
+    padding: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    background: #fbfdff;
+}
+
+.attention-details {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.attention-meta {
+    font-size: 0.8rem;
+    color: rgba(0, 0, 0, 0.6);
+}
+
+.attention-stock {
+    font-weight: 600;
+    color: #b71c1c;
+}
+
+.auto-order-history-panel {
+    margin-top: 32px;
+    background: var(--bg-secondary);
+    border: 1px solid rgba(33, 150, 243, 0.2);
+    border-radius: 12px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.auto-order-history-panel .history-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+}
+
+.auto-order-history-panel input[type="date"],
+.auto-order-history-panel select {
+    padding: 8px 12px;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    min-width: 160px;
+}
+
+.history-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.history-item {
+    border: 1px solid rgba(33, 150, 243, 0.2);
+    border-radius: 10px;
+    padding: 14px;
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.history-item-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.history-order {
+    font-weight: 600;
+}
+
+.history-status {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #0d47a1;
+}
+
+.history-item.status-success .history-status {
+    color: #1b5e20;
+}
+
+.history-item.status-failed .history-status {
+    color: #b71c1c;
+}
+
+.history-item.status-processing .history-status,
+.history-item.status-pending .history-status {
+    color: #bf360c;
+}
+
+.history-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 0.85rem;
+    color: rgba(0, 0, 0, 0.6);
+}
+
+.history-products {
+    font-size: 0.85rem;
+    color: rgba(0, 0, 0, 0.75);
+}
+
+.empty-auto-orders,
+.history-empty,
+.history-error {
+    padding: 16px;
+    text-align: center;
+    border-radius: 8px;
+    background: #f5f9ff;
+    color: rgba(0, 0, 0, 0.65);
+}
+
+.history-error {
+    background: #ffebee;
+    color: #b71c1c;
+}
+
+.auto-order-notifications {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    z-index: 2000;
+}
+
+.auto-order-notification {
+    background: #1e88e5;
+    color: #fff;
+    padding: 12px 16px;
+    border-radius: 8px;
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    opacity: 0;
+    transform: translateY(-10px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.auto-order-notification.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.auto-order-notification.success {
+    background: #2e7d32;
+}
+
+.auto-order-notification.warning {
+    background: #f9a825;
+}
+
+.auto-order-notification.error {
+    background: #c62828;
+}
+
+.notification-icon {
+    font-size: 20px;
+}
+
+.notification-text {
+    font-size: 0.9rem;
+}
+
+[data-theme="dark"] .auto-order-dashboard,
+[data-theme="dark"] .auto-order-history-panel {
+    background: rgba(26, 32, 44, 0.95);
+    border-color: rgba(144, 202, 249, 0.25);
+}
+
+[data-theme="dark"] .timeline-item,
+[data-theme="dark"] .attention-item,
+[data-theme="dark"] .history-item {
+    background: rgba(18, 22, 33, 0.95);
+    border-color: rgba(144, 202, 249, 0.2);
+}
+
+[data-theme="dark"] .stat-card {
+    background: rgba(21, 27, 38, 0.9);
+}
+
+[data-theme="dark"] .stat-card.warning {
+    background: rgba(80, 53, 0, 0.4);
+}
+
+[data-theme="dark"] .stat-card.error {
+    background: rgba(74, 21, 24, 0.4);
+}
+
+[data-theme="dark"] .empty-auto-orders,
+[data-theme="dark"] .history-empty {
+    background: rgba(29, 35, 48, 0.9);
+    color: rgba(255, 255, 255, 0.7);
+}
+
+[data-theme="dark"] .history-error {
+    background: rgba(74, 21, 24, 0.6);
+    color: #ffcdd2;
+}


### PR DESCRIPTION
## Summary
- extend the purchase orders page with auto-order filters, dashboard metrics, history timeline, and contextual styling for generated orders
- expose order notes, email status, and sorting in the purchase order summary API together with new dashboard/history endpoints for auto orders
- enhance stock management scripting and styling with richer indicators, Romanian UI strings, auto-order testing modal, and notification utilities

## Testing
- php -l purchase_orders.php
- php -l api/receiving/purchase_order_summary.php
- php -l api/auto_order_test.php
- php -l api/auto_orders/dashboard.php
- php -l api/auto_orders/history.php

------
https://chatgpt.com/codex/tasks/task_e_68ce8d054530832091e71ba30935574b