### PR TITLE
Improve auto-order email configurator UX and PDF test output

### DIFF
--- a/product-units.php
+++ b/product-units.php
@@ -861,6 +861,15 @@ $currentPage = 'product-units';
                                required>
                         <small class="field-error" id="emailSubjectError">Subiectul emailului este obligatoriu.</small>
                     </div>
+                    <div class="form-group">
+                        <label for="autoOrderTestRecipient">Email furnizor pentru test</label>
+                        <input type="email"
+                               id="autoOrderTestRecipient"
+                               name="auto_order_test_recipient"
+                               placeholder="ex: furnizor@example.com"
+                               autocomplete="off">
+                        <small class="form-text">Adresa folosită la trimiterea emailului de test. Dacă este lăsată goală se va folosi configurația sistemului.</small>
+                    </div>
                     <div class="form-group form-group-textarea">
                         <label for="autoOrderEmailBody">Conținut Email <span class="required">*</span></label>
                         <textarea id="autoOrderEmailBody"

--- a/styles/product-units.css
+++ b/styles/product-units.css
@@ -546,8 +546,8 @@
 }
 
 .modal.modal-large .modal-content {
-    width: 80%;
-    max-width: 1200px;
+    width: min(96vw, 1400px);
+    max-width: none;
 }
 
 .test-results-container {
@@ -656,6 +656,8 @@
 
 .email-template-body {
     display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
     gap: 1.5rem;
     padding: var(--base-padding);
     background: var(--surface-background);
@@ -664,8 +666,13 @@
     border-bottom-right-radius: var(--border-radius-large);
 }
 
+.email-template-body > * {
+    flex-grow: 1;
+}
+
 .template-editor {
-    flex: 0 1 60%;
+    flex: 1 1 55%;
+    min-width: 460px;
     display: flex;
     flex-direction: column;
     gap: 1.25rem;
@@ -757,7 +764,8 @@
 }
 
 .variables-panel {
-    flex: 0 1 40%;
+    flex: 1 1 28%;
+    min-width: 340px;
     background: var(--container-background);
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
@@ -767,6 +775,192 @@
     gap: 1rem;
     max-height: calc(90vh - 4rem);
     overflow-y: auto;
+}
+
+.template-history-panel {
+    flex: 0 1 260px;
+    min-width: 260px;
+    max-height: calc(90vh - 4rem);
+    overflow-y: auto;
+    background: var(--container-background);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.template-history-panel h3 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.history-empty {
+    padding: 0.75rem;
+    border: 1px dashed var(--border-color);
+    border-radius: var(--border-radius);
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    text-align: center;
+}
+
+.history-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.history-list li {
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    padding: 0.75rem;
+    cursor: pointer;
+    transition: var(--transition);
+    background: var(--surface-background);
+}
+
+.history-list li:hover,
+.history-list li:focus {
+    border-color: var(--product-units-accent);
+    box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.12);
+}
+
+.history-name {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.history-meta {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.template-metadata {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 0.5rem;
+    padding: 0.75rem;
+    background: var(--surface-background);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    margin-bottom: 1rem;
+}
+
+.metadata-item {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.char-count {
+    margin-top: 0.35rem;
+    text-align: right;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.unsaved-indicator {
+    margin-left: auto;
+    background: rgba(255, 193, 7, 0.12);
+    color: var(--warning-color);
+    border: 1px solid rgba(255, 193, 7, 0.4);
+    border-radius: 999px;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.autosave-status {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    min-width: 140px;
+}
+
+.template-dropdown-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.template-dropdown {
+    flex: 1 1 auto;
+    min-width: 220px;
+    padding: 0.65rem;
+    border: 1px solid var(--input-border);
+    border-radius: var(--border-radius);
+    background: var(--input-background);
+    color: var(--text-primary);
+    font-size: 0.9rem;
+}
+
+.template-validation {
+    border-top: 1px solid var(--border-color);
+    padding-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.validation-header {
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+}
+
+.validation-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.validation-list li {
+    padding: 0.6rem 0.75rem;
+    border-radius: var(--border-radius);
+    font-size: 0.85rem;
+}
+
+.validation-list .validation-error {
+    background: rgba(220, 53, 69, 0.12);
+    color: var(--danger-color);
+}
+
+.validation-list .validation-warning {
+    background: rgba(255, 193, 7, 0.15);
+    color: var(--warning-color);
+}
+
+.validation-list .validation-success {
+    background: rgba(25, 135, 84, 0.12);
+    color: var(--success-color);
+}
+
+.preview-missing {
+    font-size: 0.85rem;
+    color: var(--warning-color);
+    margin-top: 0.5rem;
+}
+
+.missing-variable {
+    font-weight: 600;
+}
+
+.template-variable.variable-used {
+    border-color: var(--success-color);
+    box-shadow: 0 0 0 3px rgba(25, 135, 84, 0.12);
+}
+
+.template-variable.variable-unused {
+    opacity: 0.85;
 }
 
 .variables-header {
@@ -886,11 +1080,17 @@
     }
 
     .template-editor,
-    .variables-panel {
+    .variables-panel,
+    .template-history-panel {
         flex: 1 1 auto;
+        min-width: 100%;
     }
 
     .variables-panel {
+        max-height: none;
+    }
+
+    .template-history-panel {
         max-height: none;
     }
 }


### PR DESCRIPTION
## Summary
- add a supplier test email input to the auto-order email configurator and populate it from sample data
- normalize sample data usage, validate the test recipient, and keep the live preview/error states in sync
- refresh the configurator layout styles, including history and validation panels, with better responsive behavior
- generate a lightweight purchase order PDF for email tests and attach it to the outgoing message