### PR TITLE
Include picked orders in finalized tab

### DIFF
--- a/api/warehouse/get_orders.php
+++ b/api/warehouse/get_orders.php
@@ -105,7 +105,10 @@ try {
             ), 0) AS remaining_items
         FROM orders o
         WHERE (
-            o.status IN ('Pending', 'Processing', 'assigned', 'pending', 'processing', 'ready_to_ship')
+            o.status IN (
+                'Pending', 'Processing', 'Picked',
+                'assigned', 'pending', 'processing', 'picked', 'ready_to_ship'
+            )
             OR (LOWER(o.status) = 'completed' AND DATE(o.updated_at) = CURDATE())
         )
         ORDER BY

--- a/scripts/warehouse-js/warehouse_orders.js
+++ b/scripts/warehouse-js/warehouse_orders.js
@@ -112,7 +112,7 @@ function applyFilters() {
             return order.status === 'processing' || order.status === 'assigned';
         }
         if (activeStatusFilter === 'completed') {
-            return order.status === 'completed' || order.status === 'ready';
+            return ['completed', 'ready', 'picked'].includes(order.status);
         }
         return !activeStatusFilter || order.status === activeStatusFilter;
     });


### PR DESCRIPTION
## Summary
- include `Picked` orders in the warehouse orders API response so finished picks stay visible
- treat `picked` orders as finalized in the warehouse orders dashboard filter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0f84194188320bb14dcb31b31aaf2