### PR TITLE
Force IPv4 for Cargus requests to avoid connection timeouts

### DIFF
--- a/models/CargusService.php
+++ b/models/CargusService.php
@@ -1200,6 +1200,8 @@ if ($envelopeTypeCount !== $awbData['Envelopes']) {
         CURLOPT_URL => $url,
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_TIMEOUT => 30,
+        CURLOPT_CONNECTTIMEOUT => 10,
+        CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
         CURLOPT_CUSTOMREQUEST => $method,
         CURLOPT_HTTPHEADER => $headers,
         CURLOPT_SSL_VERIFYPEER => false,


### PR DESCRIPTION
## Summary
- force Cargus API curl requests to use IPv4 resolution and a dedicated connect timeout

## Testing
- php -l models/CargusService.php


------
https://chatgpt.com/codex/tasks/task_e_68d0f89d25f88320a4114fdbab7c2b4e