### PR TITLE
Handle missing inventory transaction service

### DIFF
--- a/models/Inventory.php
+++ b/models/Inventory.php
@@ -20,7 +20,7 @@ class Inventory {
     }
 
     // init transaction servie
-    private function getTransactionService(): InventoryTransactionService {
+    private function getTransactionService(): ?InventoryTransactionService {
         if ($this->transactionService === null) {
             if (file_exists(BASE_PATH . '/services/InventoryTransactionService.php')) {
                 require_once BASE_PATH . '/services/InventoryTransactionService.php';


### PR DESCRIPTION
## Summary
- allow `Inventory::getTransactionService` to return null when the transaction service file is absent
- prevent fatal errors when transaction logging is unavailable by updating the return type hint

## Testing
- php -l models/Inventory.php

------
https://chatgpt.com/codex/tasks/task_e_68d106ffd0208320a86115a2c939298c