### PR TITLE
Include SKU on production labels

### DIFF
--- a/api/receiving/record_production_receipt.php
+++ b/api/receiving/record_production_receipt.php
@@ -24,6 +24,14 @@ function addRotatedQRAndTextToPDF($pdf, string $sku, string $productName, int $q
     // Add text content at bottom edge location
     $currentY = $textY;
     
+    // SKU
+    if ($sku) {
+        $pdf->SetFont('Arial', 'B', 8);
+        $pdf->SetXY($textX, $currentY);
+        $pdf->Cell(0, 5, "SKU: " . $sku, 0, 1, 'L');
+        $currentY += 6;
+    }
+
     // Batch
     if ($batch) {
         $pdf->SetFont('Arial', 'B', 8);
@@ -570,6 +578,14 @@ function addTextContentToPDF($pdf, string $sku, string $productName, int $qty, s
     $pdf->SetTextColor(0, 0, 0);
     $currentY = $textY;
     
+    // SKU
+    if ($sku) {
+        $pdf->SetFont('Arial', 'B', 8);
+        $pdf->SetXY($textX, $currentY);
+        $pdf->Cell(0, 5, "SKU: " . $sku, 0, 1, 'L');
+        $currentY += 4;
+    }
+
     // Batch
     if ($batch) {
         $pdf->SetFont('Arial', 'B', 8);
@@ -601,6 +617,14 @@ function addRotatedTextContentToPDF($pdf, string $sku, string $productName, int 
     
     $currentY = $textY;
     
+    // SKU
+    if ($sku) {
+        $pdf->SetFont('Arial', 'B', 8);
+        $pdf->SetXY($textX, $currentY);
+        $pdf->Cell(0, 5, "SKU: " . $sku, 0, 1, 'L');
+        $currentY -= 4;  // Move up for rotation
+    }
+
     // Batch
     if ($batch) {
         $pdf->SetFont('Arial', 'B', 8);


### PR DESCRIPTION
## Summary
- display the SKU alongside lot, quantity, and date when printing production labels
- ensure both rotated and standard label layouts include the SKU text block

## Testing
- php -l api/receiving/record_production_receipt.php

------
https://chatgpt.com/codex/tasks/task_e_68d123493a348320bb10673196da57ea