### PR TITLE
Refactor purchase order modal product selection

### DIFF
--- a/purchase_orders.php
+++ b/purchase_orders.php
@@ -993,32 +993,27 @@ require_once __DIR__ . '/includes/header.php';
                                     <div class="row">
                                         <div class="form-group">
                                             <label>Selectează Produs Existent</label>
-                                            <select class="form-control existing-product-select" onchange="selectExistingProduct(0, this)">
-                                                <option value="">Sau creează produs nou...</option>
-                                            <?php foreach ($purchasableProducts as $product): ?>
-                                                    <option value="<?= $product['id'] ?>"
-                                                            data-name="<?= htmlspecialchars($product['supplier_product_name']) ?>"
-                                                            data-code="<?= htmlspecialchars($product['supplier_product_code']) ?>"
-                                                            data-price="<?= $product['last_purchase_price'] ?>"
-                                                            data-internal-id="<?= $product['internal_product_id'] ?>">
-                                                        <?= htmlspecialchars($product['supplier_product_name']) ?>
-                                                        <?= $product['supplier_product_code'] ? ' (' . htmlspecialchars($product['supplier_product_code']) . ')' : '' ?>
-                                                    </option>
-                                            <?php endforeach; ?>
-                                            </select>
+                                            <div class="product-search-container">
+                                                <input type="text"
+                                                       class="form-control product-search-input existing-product-search"
+                                                       placeholder="Caută produs furnizor..."
+                                                       autocomplete="off">
+                                                <div class="product-search-results existing-product-results"></div>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="row">
                                         <div class="form-group">
                                             <label>Produs Intern *</label>
-                                            <select class="form-control internal-product-select" name="items[0][internal_product_id]" required>
-                                                <option value="">-- Produs intern --</option>
-                                                <?php foreach ($allProducts as $prod): ?>
-                                                    <option value="<?= $prod['product_id'] ?>">
-                                                        <?= htmlspecialchars($prod['name']) ?> (<?= htmlspecialchars($prod['sku']) ?>)
-                                                    </option>
-                                                <?php endforeach; ?>
-                                            </select>
+                                            <div class="product-search-container">
+                                                <input type="hidden" name="items[0][internal_product_id]" class="internal-product-id">
+                                                <input type="text"
+                                                       class="form-control product-search-input internal-product-search"
+                                                       placeholder="Caută produs intern..."
+                                                       autocomplete="off"
+                                                       required>
+                                                <div class="product-search-results internal-product-results"></div>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="row">

--- a/styles/purchase_orders.css
+++ b/styles/purchase_orders.css
@@ -341,6 +341,69 @@
     color: var(--text-muted);
 }
 
+/* ===== SEARCHABLE INPUTS ===== */
+.product-search-container {
+    position: relative;
+}
+
+.product-search-input {
+    position: relative;
+    z-index: 1;
+}
+
+.product-search-results {
+    position: absolute;
+    top: calc(100% + 2px);
+    left: 0;
+    right: 0;
+    background-color: var(--container-background);
+    border: 1px solid var(--border-color);
+    border-radius: 0 0 var(--border-radius) var(--border-radius);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    max-height: 220px;
+    overflow-y: auto;
+    display: none;
+    z-index: 1200;
+}
+
+.product-search-results.show {
+    display: block;
+}
+
+.search-result-item {
+    padding: 0.6rem 0.75rem;
+    cursor: pointer;
+    border-bottom: 1px solid var(--border-color);
+    transition: background-color 0.2s ease;
+}
+
+.search-result-item:last-child {
+    border-bottom: none;
+}
+
+.search-result-item:hover {
+    background-color: var(--button-hover);
+}
+
+.search-result-item.no-results {
+    cursor: default;
+    font-style: italic;
+    color: var(--text-secondary);
+}
+
+.search-result-item .product-name {
+    display: block;
+    font-weight: 600;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+}
+
+.search-result-item .product-details {
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    margin-top: 0.2rem;
+}
+
 /* ===== FILTERS CONTAINER ===== */
 .filters-container {
     background-color: var(--container-background);


### PR DESCRIPTION
## Summary
- replace the existing product and internal product dropdowns in the purchase order modal with searchable inputs
- add client-side search logic that filters purchasable and internal products, auto-fills fields, and enforces selection of a valid internal product
- introduce styles for the new search suggestion lists to match the purchase order modal visuals