### PR TITLE
Enable horizontal scrolling for products table

### DIFF
--- a/styles/products.css
+++ b/styles/products.css
@@ -205,10 +205,14 @@
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
     overflow: hidden;
+    overflow-x: auto;
+    width: 100%;
+    -webkit-overflow-scrolling: touch;
 }
 
 .table {
     width: 100%;
+    min-width: 900px;
     border-collapse: collapse;
     margin: 0;
     font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- allow the products table container to scroll horizontally when the viewport is too narrow
- enforce a minimum width for the products table to preserve the column layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3822e710483209c0a22c31960f1db