### PR TITLE
Add bulk management tools to product units table

### DIFF
--- a/product-units.php
+++ b/product-units.php
@@ -232,11 +232,63 @@ $currentPage = 'product-units';
                                     </button>
                                 </div>
                             </div>
-                            
+
+                            <!-- Bulk Actions Bar -->
+                            <div class="bulk-actions-bar" id="unitBulkActionsBar" style="display: none;">
+                                <div class="bulk-actions-content">
+                                    <span class="bulk-selection-count">
+                                        <span id="selectedUnitsCount">0</span> configurări selectate
+                                    </span>
+                                    <div class="bulk-actions">
+                                        <button type="button" class="btn btn-sm btn-success" onclick="ProductUnitsApp.performBulkUnitAction('activate')">
+                                            <span class="material-symbols-outlined">check_circle</span>
+                                            Activează
+                                        </button>
+                                        <button type="button" class="btn btn-sm btn-warning" onclick="ProductUnitsApp.performBulkUnitAction('deactivate')">
+                                            <span class="material-symbols-outlined">block</span>
+                                            Dezactivează
+                                        </button>
+                                        <button type="button" class="btn btn-sm btn-danger" onclick="ProductUnitsApp.performBulkUnitAction('delete')">
+                                            <span class="material-symbols-outlined">delete</span>
+                                            Șterge
+                                        </button>
+                                        <div class="bulk-divider"></div>
+                                        <select id="bulkPropertySelect" class="form-control">
+                                            <option value="">Setează proprietate</option>
+                                            <option value="fragile:true">Marchează Fragil</option>
+                                            <option value="fragile:false">Elimină Fragil</option>
+                                            <option value="hazardous:true">Marchează Periculos</option>
+                                            <option value="hazardous:false">Elimină Periculos</option>
+                                            <option value="temperature_controlled:true">Control Temperatura: Da</option>
+                                            <option value="temperature_controlled:false">Control Temperatura: Nu</option>
+                                        </select>
+                                        <button type="button" id="applyBulkPropertyBtn" class="btn btn-sm btn-primary">
+                                            Aplică
+                                        </button>
+                                        <div class="bulk-divider"></div>
+                                        <div class="bulk-input-group" style="display:flex; gap:6px; align-items:center;">
+                                            <input type="number" id="bulkMaxValue" class="form-control" placeholder="Max/Colet" min="0">
+                                            <button type="button" id="applyBulkMaxBtn" class="btn btn-sm btn-info">
+                                                Setează
+                                            </button>
+                                        </div>
+                                        <div class="bulk-input-group" style="display:flex; gap:6px; align-items:center;">
+                                            <input type="number" step="0.001" id="bulkWeightValue" class="form-control" placeholder="Greutate (kg)" min="0">
+                                            <button type="button" id="applyBulkWeightBtn" class="btn btn-sm btn-info">
+                                                Actualizează
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
                             <div class="table-wrapper">
                                 <table class="data-table" id="productUnitsTable">
                                     <thead>
                                         <tr>
+                                            <th class="select-column">
+                                                <input type="checkbox" id="selectAllUnits">
+                                            </th>
                                             <th>Produs</th>
                                             <th>Cod Produs</th>
                                             <th>Unitate</th>
@@ -251,7 +303,7 @@ $currentPage = 'product-units';
                                     <tbody id="productUnitsBody">
                                         <!-- Table rows will be loaded via JavaScript -->
                                         <tr class="loading-row">
-                                            <td colspan="9" class="text-center">
+                                            <td colspan="10" class="text-center">
                                                 <div class="loading-spinner">
                                                     <span class="material-symbols-outlined spinning">progress_activity</span>
                                                     Încărcare date...

--- a/styles/product-units.css
+++ b/styles/product-units.css
@@ -232,6 +232,75 @@
 }
 
 /* ===== TABLE STYLES ===== */
+.bulk-actions-bar {
+    background: linear-gradient(135deg, var(--surface-background) 0%, var(--container-background) 100%);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    padding: 0.75rem 1rem;
+    margin: 0 0 1rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    position: sticky;
+    top: 80px;
+    z-index: 100;
+}
+
+.bulk-actions-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.bulk-selection-count {
+    font-weight: 600;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+}
+
+.bulk-selection-count::before {
+    content: "✓";
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    background-color: var(--primary-color);
+    color: #fff;
+    border-radius: 50%;
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.bulk-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.bulk-divider {
+    width: 1px;
+    background: var(--border-color);
+    align-self: stretch;
+    margin: 0 0.5rem;
+}
+
+.select-column {
+    width: 48px;
+    text-align: center;
+}
+
+.select-column input[type="checkbox"],
+.unit-checkbox {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--primary-color);
+}
+
 .table-container {
     background: var(--container-background);
     border: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary
- add a bulk actions toolbar and row selection to the product units table so multiple configurations can be managed at once
- extend the product units page script with selection state, bulk update helpers, and new actions for status, properties, weight, and max-per-parcel
- support bulk update/delete on the product units API and style the new controls in the product units stylesheet

## Testing
- php -l product-units.php
- php -l api/product_units.php

------
https://chatgpt.com/codex/tasks/task_e_68d3c76a0f5c8320ad16b32b05bf499e