### PR TITLE
Add EUR price field and make order pricing optional

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -567,6 +567,7 @@ class ProductionWMSAPI {
             'name' => $input['name'],
             'unit_of_measure' => $input['unit_of_measure'] ?? 'buc',
             'price' => floatval($input['price'] ?? 0),
+            'price_eur' => floatval($input['price_eur'] ?? 0),
             'category' => $input['category'] ?? 'General'
         ];
         

--- a/database/migrations/2025_09_25_000000_add_price_eur_to_products_table.php
+++ b/database/migrations/2025_09_25_000000_add_price_eur_to_products_table.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Migration: add_price_eur_to_products_table
+ * Created: 2025-09-25
+ * Purpose: Add a dedicated EUR price column for products while keeping the existing RON price.
+ */
+
+class AddPriceEurToProductsTableMigration {
+    public function up(PDO $pdo) {
+        echo "➕ Adding price_eur column to products table...\n";
+
+        $pdo->exec("ALTER TABLE products ADD COLUMN price_eur DECIMAL(10,2) NULL AFTER price");
+
+        echo "✅ price_eur column added successfully!\n";
+    }
+
+    public function down(PDO $pdo) {
+        echo "➖ Removing price_eur column from products table...\n";
+
+        $pdo->exec("ALTER TABLE products DROP COLUMN price_eur");
+
+        echo "✅ price_eur column removed successfully.\n";
+    }
+}
+
+return new AddPriceEurToProductsTableMigration();

--- a/models/Product.php
+++ b/models/Product.php
@@ -8,7 +8,7 @@ class Product {
     
     private $defaultFields = [
         'product_id', 'sku', 'name', 'description', 'category', 'unit_of_measure', 'quantity',
-        'min_stock_level', 'price', 'weight', 'dimensions', 'barcode',
+        'min_stock_level', 'price', 'price_eur', 'weight', 'dimensions', 'barcode',
         'image_url', 'status', 'seller_id', 'created_at', 'updated_at', 'smartbill_product_id'
     ];
     
@@ -214,8 +214,8 @@ class Product {
         }
         
         $query = "INSERT INTO {$this->table} (
-                    sku, name, description, category, unit_of_measure, quantity, price, seller_id
-                  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+                    sku, name, description, category, unit_of_measure, quantity, price, price_eur, seller_id
+                  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
         
         try {
             $stmt = $this->conn->prepare($query);
@@ -227,6 +227,7 @@ class Product {
                 $productData['unit_of_measure'] ?? 'pcs',
                 intval($productData['quantity'] ?? 0),
                 floatval($productData['price'] ?? 0),
+                floatval($productData['price_eur'] ?? 0),
                 !empty($productData['seller_id']) ? intval($productData['seller_id']) : null
             ];
             
@@ -290,6 +291,7 @@ class Product {
             'unit_of_measure' => ':unit_of_measure',
             'quantity' => ':quantity',
             'price' => ':price',
+            'price_eur' => ':price_eur',
             'min_stock_level' => ':min_stock_level',
             'seller_id' => ':seller_id'
         ];
@@ -302,7 +304,7 @@ class Product {
                 // Handle different data types
                 if (in_array($field, ['quantity', 'min_stock_level', 'seller_id'])) {
                     $params[$param] = $productData[$field] !== null ? intval($productData[$field]) : null;
-                } elseif ($field === 'price') {
+                } elseif (in_array($field, ['price', 'price_eur'], true)) {
                     $params[$param] = floatval($productData[$field]);
                 } else {
                     $params[$param] = $productData[$field];
@@ -863,7 +865,8 @@ class Product {
             'category' => 'Category',
             'quantity' => 'Base Quantity',
             'min_stock_level' => 'Min Stock Level',
-            'price' => 'Price',
+            'price' => 'Price (RON)',
+            'price_eur' => 'Price (EUR)',
             'created_at' => 'Created Date'
         ];
     }
@@ -887,7 +890,8 @@ class Product {
             'unit_of_measure' => 'unit_of_measure',
             'quantity' => 'quantity',
             'min_stock_level' => 'min_stock_level',
-            'price' => 'price'
+            'price' => 'price',
+            'price_eur' => 'price_eur'
         ];
         
         foreach ($directMappings as $newField => $existingField) {

--- a/orders.php
+++ b/orders.php
@@ -68,11 +68,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $items = [];
                 if (!empty($_POST['items'])) {
                     foreach ($_POST['items'] as $item) {
-                        if (!empty($item['product_id']) && !empty($item['quantity']) && isset($item['unit_price'])) {
+                        if (!empty($item['product_id']) && !empty($item['quantity'])) {
+                            $unitPrice = 0.0;
+                            if (isset($item['unit_price']) && $item['unit_price'] !== '') {
+                                $unitPrice = floatval($item['unit_price']);
+                            }
+
                             $items[] = [
                                 'product_id' => intval($item['product_id']),
                                 'quantity' => intval($item['quantity']),
-                                'unit_price' => floatval($item['unit_price'])
+                                'unit_price' => $unitPrice
                             ];
                         }
                     }
@@ -522,8 +527,8 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                                         <input type="number" name="items[0][quantity]" class="form-control" min="1" required>
                                     </div>
                                     <div class="form-group">
-                                        <label class="form-label">Preț Unitar</label>
-                                        <input type="number" name="items[0][unit_price]" class="form-control" step="0.01" min="0" required>
+                                        <label class="form-label">Preț Unitar (opțional)</label>
+                                        <input type="number" name="items[0][unit_price]" class="form-control" step="0.01" min="0">
                                     </div>
                                     <div class="form-group">
                                         <label class="form-label">&nbsp;</label>

--- a/products.php
+++ b/products.php
@@ -40,6 +40,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 'description' => trim($_POST['description'] ?? ''),
                 'sku' => trim($_POST['sku'] ?? ''),
                 'price' => floatval($_POST['price'] ?? 0),
+                'price_eur' => floatval($_POST['price_eur'] ?? 0),
                 'category' => trim($_POST['category'] ?? ''),
                 'unit_of_measure' => trim($_POST['unit_of_measure'] ?? 'pcs'),
                 'status' => isset($_POST['status']) ? 'active' : 'inactive',
@@ -79,6 +80,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'description' => trim($_POST['description'] ?? ''),
                     'sku' => trim($_POST['sku'] ?? ''),
                     'price' => floatval($_POST['price'] ?? 0),
+                    'price_eur' => floatval($_POST['price_eur'] ?? 0),
                     'category' => trim($_POST['category'] ?? ''),
                     'unit_of_measure' => trim($_POST['unit_of_measure'] ?? 'pcs'),
                     'status' => isset($_POST['status']) ? 'active' : 'inactive',
@@ -645,6 +647,10 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                             <input type="number" id="create-price" name="price" class="form-control" step="0.01" min="0">
                         </div>
                         <div class="form-group">
+                            <label for="create-price-eur">Preț (EUR)</label>
+                            <input type="number" id="create-price-eur" name="price_eur" class="form-control" step="0.01" min="0">
+                        </div>
+                        <div class="form-group">
                             <label for="create-category">Categorie</label>
                             <input type="text" id="create-category" name="category" class="form-control">
                         </div>
@@ -737,6 +743,10 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                         <div class="form-group">
                             <label for="edit-price">Preț (RON)</label>
                             <input type="number" id="edit-price" name="price" class="form-control" step="0.01" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="edit-price-eur">Preț (EUR)</label>
+                            <input type="number" id="edit-price-eur" name="price_eur" class="form-control" step="0.01" min="0">
                         </div>
                         <div class="form-group">
                             <label for="edit-category">Categorie</label>

--- a/purchase_orders.php
+++ b/purchase_orders.php
@@ -461,12 +461,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     }
 
                     $quantity = floatval($item['quantity']);
-                    $unitPrice = floatval($item['unit_price']);
+                    $unitPrice = max(0, floatval($item['unit_price'] ?? 0));
 
-                    if ($quantity <= 0 || $unitPrice <= 0) {
-                        throw new Exception('Cantitatea și prețul trebuie să fie mai mari decât 0.');
+                    if ($quantity <= 0) {
+                        throw new Exception('Cantitatea trebuie să fie mai mare decât 0.');
                     }
-                    
+
                     $totalPrice = $quantity * $unitPrice;
                     
                     $processedItems[] = [
@@ -993,9 +993,9 @@ require_once __DIR__ . '/includes/header.php';
                                                    step="0.001" min="0.001" required onchange="calculateItemTotal(0)">
                                         </div>
                                         <div class="form-group">
-                                            <label>Preț Unitar (RON) *</label>
-                                            <input type="number" name="items[0][unit_price]" class="form-control unit-price" 
-                                                   step="0.01" min="0.01" required onchange="calculateItemTotal(0)">
+                                            <label>Preț Unitar (RON) (opțional)</label>
+                                            <input type="number" name="items[0][unit_price]" class="form-control unit-price"
+                                                   step="0.01" min="0" onchange="calculateItemTotal(0)">
                                         </div>
                                         <div class="form-group">
                                             <label>Total</label>

--- a/scripts/orders.js
+++ b/scripts/orders.js
@@ -772,7 +772,7 @@ function addOrderItem() {
                 <input type="number" name="items[${itemCounter}][quantity]" class="form-control item-quantity" placeholder="Cant." min="1" required>
             </div>
             <div class="form-group">
-                <input type="number" name="items[${itemCounter}][unit_price]" class="form-control item-price" placeholder="Preț" step="0.01" min="0" required>
+                <input type="number" name="items[${itemCounter}][unit_price]" class="form-control item-price" placeholder="Preț (opțional)" step="0.01" min="0">
             </div>
             <div class="form-group form-group-sm">
                 <button type="button" class="btn btn-danger btn-sm" onclick="removeOrderItem(this)" title="Șterge produs">

--- a/scripts/products.js
+++ b/scripts/products.js
@@ -267,6 +267,7 @@ function populateEditForm(productData) {
         document.getElementById('edit-sku').value = product.sku || '';
         document.getElementById('edit-description').value = product.description || '';
         document.getElementById('edit-price').value = product.price || '';
+        document.getElementById('edit-price-eur').value = product.price_eur || '';
         document.getElementById('edit-category').value = product.category || '';
         document.getElementById('edit-unit').value = product.unit_of_measure || 'pcs';
         document.getElementById('edit-status').checked = (product.status == undefined ? 1 : product.status) == 1;
@@ -1894,6 +1895,7 @@ function populateEditForm(productData) {
         document.getElementById('edit-sku').value = product.sku || '';
         document.getElementById('edit-description').value = product.description || '';
         document.getElementById('edit-price').value = product.price || '';
+        document.getElementById('edit-price-eur').value = product.price_eur || '';
         document.getElementById('edit-category').value = product.category || '';
         document.getElementById('edit-unit').value = product.unit_of_measure || 'pcs';
         document.getElementById('edit-status').checked = (product.status == undefined ? 1 : product.status) == 1;

--- a/scripts/purchase_orders.js
+++ b/scripts/purchase_orders.js
@@ -711,9 +711,9 @@ function createProductItem(index) {
                            step="0.001" min="0.001" required onchange="calculateItemTotal(${index})">
                 </div>
                 <div class="form-group">
-                    <label>Preț Unitar (RON) *</label>
-                    <input type="number" name="items[${index}][unit_price]" class="form-control unit-price" 
-                           step="0.01" min="0.01" required onchange="calculateItemTotal(${index})">
+                    <label>Preț Unitar (RON) (opțional)</label>
+                    <input type="number" name="items[${index}][unit_price]" class="form-control unit-price"
+                           step="0.01" min="0" onchange="calculateItemTotal(${index})">
                 </div>
                 <div class="form-group">
                     <label>Total</label>
@@ -901,7 +901,7 @@ function validateStockPurchaseForm() {
 
         console.log('✅ Fixed validation check:', { productName, quantity, unitPrice }); // Debug log
 
-        if (productName && quantity > 0 && unitPrice > 0) {
+        if (productName && quantity > 0) {
             if (!internalProductHidden || !internalProductHidden.value) {
                 alert('Te rog selectează produsul intern din lista de sugestii.');
                 if (internalProductSearch) {
@@ -914,7 +914,7 @@ function validateStockPurchaseForm() {
     }
 
     if (!hasValidItems) {
-        alert('Te rog adaugă cel puțin un produs valid cu cantitate și preț.');
+        alert('Te rog adaugă cel puțin un produs valid cu cantitate.');
         return false;
     }
     


### PR DESCRIPTION
## Summary
- add a dedicated `price_eur` column for products and surface it in the product create/edit modals alongside the existing RON price
- extend the product model and API to persist the optional EUR price while keeping backward-compatible mappings
- relax manual and auto purchase order flows so unit price inputs are optional on both the UI and server-side validation

## Testing
- php -l database/migrations/2025_09_25_000000_add_price_eur_to_products_table.php
- php -l models/Product.php
- php -l products.php
- php -l orders.php
- php -l purchase_orders.php
- php -l api/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d4d9697ab08320be913bb5d905947d