### PR TITLE
Fix stock category filter initialization

### DIFF
--- a/scripts/product-units.js
+++ b/scripts/product-units.js
@@ -2069,20 +2069,7 @@ const ProductUnitsApp = {
         if (!this.elements.stockCategoryFilter) return;
         const select = this.elements.stockCategoryFilter;
         const categories = [...new Set(this.state.products.map(p => p.category).filter(Boolean))].sort();
-        select.innerHTML = '<option value="">Toate categoriile</option>';
-        categories.forEach(cat => {
-            const opt = document.createElement('option');
-            opt.value = cat;
-            opt.textContent = cat;
-            select.appendChild(opt);
-        });
-    },
 
-    populateStockCategoryFilter() {
-        if (!this.elements.stockCategoryFilter) return;
-        const select = this.elements.stockCategoryFilter;
-        const categories = [...new Set(this.state.products.map(p => p.category).filter(Boolean))].sort();
-        
         // Start with the "All categories" option
         select.innerHTML = '<option value="">Toate categoriile</option>';
         
@@ -2098,7 +2085,7 @@ const ProductUnitsApp = {
         if (categories.includes('Marfa')) {
             select.value = 'Marfa';
             this.state.stockCategory = 'Marfa'; // Update the state
-            
+
             // Trigger the filtering to show only Marfa products
             this.applyStockFilters();
         }
@@ -3705,6 +3692,15 @@ async deletePackagingRule(id, ruleName) {
     },
 
     // ===== STOCK MANAGEMENT FUNCTIONS =====
+    applyStockFilters() {
+        if (this.elements.stockCategoryFilter) {
+            this.elements.stockCategoryFilter.value = this.state.stockCategory || '';
+        }
+
+        this.state.stockPagination.offset = 0;
+        return this.loadStockSettings();
+    },
+
     async loadStockSettings() {
         if (!this.elements.stockSettingsBody) return;
         this.elements.stockSettingsBody.innerHTML = `


### PR DESCRIPTION
## Summary
- remove the duplicate stock category filter helper and keep the version that preselects "Marfa"
- add an `applyStockFilters` helper so the stock settings reload when the default category is applied

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4dac6bb8883209bf1e01c32377812