### PR TITLE
Allow assigning sellers from stock configuration

### DIFF
--- a/api/inventory_settings.php
+++ b/api/inventory_settings.php
@@ -41,7 +41,7 @@ try {
 
         $where = $conditions ? 'WHERE ' . implode(' AND ', $conditions) : '';
 
-        $query = "SELECT p.product_id, p.sku, p.name, p.category,
+        $query = "SELECT p.product_id, p.sku, p.name, p.category, p.seller_id,
                          COALESCE(inv.current_stock, 0) AS current_stock,
                          p.min_stock_level, p.min_order_quantity,
                          p.auto_order_enabled, p.last_auto_order_date,
@@ -85,6 +85,7 @@ try {
                 'min_order_quantity' => (int)($r['min_order_quantity'] ?? 1),
                 'auto_order_enabled' => (bool)$r['auto_order_enabled'],
                 'last_auto_order_date' => $r['last_auto_order_date'],
+                'seller_id' => isset($r['seller_id']) ? (int)$r['seller_id'] : null,
                 'supplier_name' => $r['supplier_name']
             ];
         }, $rows);
@@ -110,18 +111,28 @@ try {
         $minStock = max(0, (int)($input['min_stock_level'] ?? 0));
         $minOrder = max(1, (int)($input['min_order_quantity'] ?? 1));
         $autoOrder = !empty($input['auto_order_enabled']) ? 1 : 0;
+        $sellerId = null;
+        if (array_key_exists('seller_id', $input) && $input['seller_id'] !== null && $input['seller_id'] !== '') {
+            $sellerId = (int)$input['seller_id'];
+        }
+
         $query = "UPDATE products
                   SET min_stock_level = :min_stock,
                       min_order_quantity = :min_order,
-                      auto_order_enabled = :auto_order
+                      auto_order_enabled = :auto_order,
+                      seller_id = :seller_id
                   WHERE product_id = :id";
         $stmt = $db->prepare($query);
-        $success = $stmt->execute([
-            ':min_stock' => $minStock,
-            ':min_order' => $minOrder,
-            ':auto_order' => $autoOrder,
-            ':id' => $productId
-        ]);
+        $stmt->bindValue(':min_stock', $minStock, PDO::PARAM_INT);
+        $stmt->bindValue(':min_order', $minOrder, PDO::PARAM_INT);
+        $stmt->bindValue(':auto_order', $autoOrder, PDO::PARAM_INT);
+        if ($sellerId === null) {
+            $stmt->bindValue(':seller_id', null, PDO::PARAM_NULL);
+        } else {
+            $stmt->bindValue(':seller_id', $sellerId, PDO::PARAM_INT);
+        }
+        $stmt->bindValue(':id', $productId, PDO::PARAM_INT);
+        $success = $stmt->execute();
         if ($success) {
             echo json_encode(['success' => true]);
         } else {

--- a/product-units.php
+++ b/product-units.php
@@ -1195,8 +1195,24 @@ $currentPage = 'product-units';
                         </div>
                     </div>
                     <div class="form-group">
-                        <label>Furnizor Asignat</label>
-                        <div id="assignedSupplier" class="form-info">-</div>
+                        <label for="stockSellerSearch">Furnizor Asignat</label>
+                        <div class="seller-search-container">
+                            <input type="hidden" id="stockSellerId" name="seller_id" value="">
+                            <input type="text"
+                                   id="stockSellerSearch"
+                                   class="seller-search-input"
+                                   placeholder="Caută furnizor..."
+                                   autocomplete="off">
+                            <div class="seller-search-results" id="stockSellerResults"></div>
+                        </div>
+                        <div class="selected-seller-info unassigned" id="selectedSellerInfo">
+                            <span class="material-symbols-outlined">store</span>
+                            <span id="assignedSupplier" class="selected-seller-name">Neasignat</span>
+                            <button type="button" class="btn btn-sm btn-ghost" id="clearStockSeller" style="display:none;">
+                                <span class="material-symbols-outlined">close</span>
+                                Elimină
+                            </button>
+                        </div>
                     </div>
                     <div class="form-group">
                         <label>Stoc Curent</label>

--- a/styles/product-units.css
+++ b/styles/product-units.css
@@ -1868,6 +1868,33 @@ option {
     color: var(--text-secondary);
 }
 
+.selected-seller-info {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+    padding: 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    background-color: var(--surface-background);
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.selected-seller-info.unassigned {
+    border-style: dashed;
+    color: var(--text-secondary);
+    opacity: 0.85;
+}
+
+.selected-seller-info .material-symbols-outlined {
+    font-size: 1.25rem;
+    color: inherit;
+}
+
+.selected-seller-info .btn {
+    margin-left: auto;
+}
+
 .stock-row {
     background: rgba(33, 150, 243, 0.05);
     border-left: 3px solid rgba(33, 150, 243, 0.7);


### PR DESCRIPTION
## Summary
- add seller search inputs to the stock configuration modal and show the selected supplier
- implement seller lookup/selection logic in the product units script and wire it to auto-order warnings
- persist seller assignments via the inventory settings API and adjust styling for the new UI elements

## Testing
- php -l product-units.php
- php -l api/inventory_settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d4df13e5608320bd2f085c99b288a7