### PR TITLE
Enable auto-order price fallback and purchasable auto-creation

### DIFF
--- a/models/AutoOrderManager.php
+++ b/models/AutoOrderManager.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/PurchaseOrder.php';
 require_once __DIR__ . '/Setting.php';
+require_once __DIR__ . '/PurchasableProduct.php';
 
 class AutoOrderManager
 {
@@ -18,6 +19,7 @@ class AutoOrderManager
     private PDO $conn;
     private PurchaseOrder $purchaseOrder;
     private Setting $settingModel;
+    private PurchasableProduct $purchasableProductModel;
     private array $emailConfig = [];
     private string $productsTable = 'products';
     private string $purchaseOrdersTable = 'purchase_orders';
@@ -32,6 +34,7 @@ class AutoOrderManager
         $this->conn = $conn;
         $this->purchaseOrder = new PurchaseOrder($conn);
         $this->settingModel = new Setting($conn);
+        $this->purchasableProductModel = new PurchasableProduct($conn);
         $this->emailConfig = $this->incarcaConfiguratieEmail();
     }
 
@@ -271,18 +274,35 @@ class AutoOrderManager
                         'cod' => $row['supplier_product_code'] ?? null,
                         'pret' => $pretCalculat,
                         'currency' => $monedaCalculata,
-                        'price_source' => $pretAchizitie > 0 ? 'purchasable_product' : ($pretCalculat > 0 ? 'product_price' : 'unknown')
+                        'price_source' => $pretAchizitie > 0 ? 'purchasable_product' : ($pretCalculat > 0 ? 'product_price' : 'unknown'),
+                        'needs_auto_creation' => false,
+                        'internal_product_id' => (int)$primaLinie['product_id']
                     ];
                     $scorSelectat = $scor;
                 }
+            }
+
+            if ($articolSelectat === null && $pretFallback > 0) {
+                $articolSelectat = [
+                    'id' => null,
+                    'nume' => $primaLinie['supplier_product_name'] ?? $primaLinie['name'] ?? '',
+                    'cod' => $primaLinie['supplier_product_code'] ?? $primaLinie['sku'] ?? null,
+                    'pret' => $pretFallback,
+                    'currency' => $monedaFallback ?: 'RON',
+                    'price_source' => 'product_price',
+                    'needs_auto_creation' => true,
+                    'internal_product_id' => (int)$primaLinie['product_id']
+                ];
             }
 
             if ($articolSelectat) {
                 $detalii['validari'][] = [
                     'conditie' => 'Articol achiziționabil asociat',
                     'rezultat' => 'ok',
-                    'tip' => 'critic',
-                    'detalii' => 'A fost identificat un articol valid pentru comandă.'
+                    'tip' => !empty($articolSelectat['needs_auto_creation']) ? 'informativ' : 'critic',
+                    'detalii' => !empty($articolSelectat['needs_auto_creation'])
+                        ? 'Nu există încă un articol achiziționabil salvat. Sistemul va crea automat unul folosind datele produsului.'
+                        : 'A fost identificat un articol valid pentru comandă.'
                 ];
             } else {
                 $detalii['validari'][] = [
@@ -353,7 +373,9 @@ class AutoOrderManager
                         'purchasable_product_id' => $articolSelectat['id'],
                         'quantity' => $cantitateComandata,
                         'unit_price' => $pretUnitar,
-                        'notes' => 'Autocomandă generată automat de sistemul WMS.'
+                        'notes' => 'Autocomandă generată automat de sistemul WMS.',
+                        'needs_auto_creation' => !empty($articolSelectat['needs_auto_creation']),
+                        'internal_product_id' => (int)$primaLinie['product_id']
                     ]]
                 ];
             }
@@ -397,6 +419,17 @@ class AutoOrderManager
         $productId = (int)($context['produs']['id'] ?? 0);
 
         try {
+            $pregatire = $this->ensurePurchasableItems($context);
+            if (!$pregatire['success']) {
+                $mesaj = $pregatire['message'] ?? 'Articolul necesar nu a putut fi pregătit pentru autocomandă.';
+                $this->log($mesaj, 'error');
+                return [
+                    'succes' => false,
+                    'mesaj' => $mesaj
+                ];
+            }
+            $context = $pregatire['context'];
+
             $orderId = $this->purchaseOrder->createPurchaseOrder($context['payload']);
             if (!$orderId) {
                 $mesaj = sprintf('Autocomanda pentru produsul #%d a eșuat: comanda de achiziție nu a putut fi creată.', $productId);
@@ -469,6 +502,67 @@ class AutoOrderManager
                 'mesaj' => $mesaj
             ];
         }
+    }
+
+    /**
+     * Asigură existența produselor achiziționabile necesare pentru payload.
+     */
+    private function ensurePurchasableItems(array $context): array
+    {
+        if (empty($context['payload']['items'])) {
+            return ['success' => true, 'context' => $context];
+        }
+
+        foreach ($context['payload']['items'] as $index => $item) {
+            $purchasableId = (int)($item['purchasable_product_id'] ?? 0);
+            if ($purchasableId > 0) {
+                continue;
+            }
+
+            $internalProductId = (int)($item['internal_product_id'] ?? $context['produs']['id'] ?? 0);
+            $sellerId = (int)($context['furnizor']['id'] ?? 0);
+            $unitPrice = (float)($item['unit_price'] ?? 0);
+            $currency = $context['articol']['currency'] ?? ($context['comanda']['currency'] ?? 'RON');
+
+            if ($internalProductId <= 0 || $sellerId <= 0 || $unitPrice <= 0) {
+                return [
+                    'success' => false,
+                    'message' => 'Produsul nu are asociat un articol achiziționabil și nu s-a putut genera unul automat.'
+                ];
+            }
+
+            $productName = $context['articol']['nume'] ?? $context['produs']['nume'] ?? ('Produs #' . $internalProductId);
+            $productCode = $context['articol']['cod'] ?? $context['produs']['sku'] ?? null;
+
+            $creationData = [
+                'supplier_product_name' => $productName,
+                'supplier_product_code' => $productCode,
+                'description' => 'Articol creat automat pentru autocomandă.',
+                'unit_measure' => 'buc',
+                'last_purchase_price' => $unitPrice,
+                'currency' => $currency,
+                'internal_product_id' => $internalProductId,
+                'preferred_seller_id' => $sellerId,
+                'notes' => 'Generat automat de modulul de autocomandă.',
+                'status' => 'active'
+            ];
+
+            $newId = $this->purchasableProductModel->createProduct($creationData);
+            if (!$newId) {
+                $mesaj = $this->purchasableProductModel->getLastError() ?? 'Nu s-a putut crea produsul achiziționabil necesar.';
+                return [
+                    'success' => false,
+                    'message' => $mesaj
+                ];
+            }
+
+            $context['payload']['items'][$index]['purchasable_product_id'] = $newId;
+            unset($context['payload']['items'][$index]['needs_auto_creation']);
+            $context['articol']['id'] = $newId;
+            $context['articol']['needs_auto_creation'] = false;
+        }
+
+        return ['success' => true, 'context' => $context];
     }
 
     /**

--- a/models/Inventory.php
+++ b/models/Inventory.php
@@ -1677,21 +1677,40 @@ public function getCriticalStockAlerts(int $limit = 10): array {
                         'supplier_product_code' => $row['supplier_product_code'] ?? null,
                         'pret' => $pretCalculat,
                         'currency' => $monedaCalculata,
-                        'price_source' => $pretAchizitie > 0 ? 'purchasable_product' : ($pretCalculat > 0 ? 'product_price' : 'unknown')
+                        'price_source' => $pretAchizitie > 0 ? 'purchasable_product' : ($pretCalculat > 0 ? 'product_price' : 'unknown'),
+                        'requires_auto_creation' => false
                     ];
                     $scorSelectat = $scor;
                 }
             }
 
+            if ($piesaSelectata === null && $pretFallback > 0) {
+                $piesaSelectata = [
+                    'purchasable_product_id' => null,
+                    'supplier_product_name' => $primaLinie['supplier_product_name'] ?? $primaLinie['name'] ?? null,
+                    'supplier_product_code' => $primaLinie['supplier_product_code'] ?? $primaLinie['sku'] ?? null,
+                    'pret' => $pretFallback,
+                    'currency' => $monedaFallback ?: 'RON',
+                    'price_source' => 'product_price',
+                    'requires_auto_creation' => true
+                ];
+            }
+
             if ($piesaSelectata) {
                 $detalii['articol'] = [
-                    'id' => $piesaSelectata['purchasable_product_id'],
+                    'id' => $piesaSelectata['purchasable_product_id'] !== null
+                        ? (int)$piesaSelectata['purchasable_product_id']
+                        : null,
                     'nume' => $piesaSelectata['supplier_product_name'] ?? null,
                     'cod' => $piesaSelectata['supplier_product_code'] ?? null,
                     'pret' => (float)($piesaSelectata['pret'] ?? 0),
                     'currency' => $piesaSelectata['currency'] ?? ($monedaFallback ?: 'RON'),
-                    'price_source' => $piesaSelectata['price_source'] ?? null
+                    'price_source' => $piesaSelectata['price_source'] ?? null,
+                    'needs_auto_creation' => !empty($piesaSelectata['requires_auto_creation']),
+                    'internal_product_id' => (int)$primaLinie['product_id']
                 ];
+            } else {
+                $detalii['articol'] = null;
             }
 
             $pretValid = $detalii['articol'] && (float)$detalii['articol']['pret'] > 0;
@@ -1700,7 +1719,14 @@ public function getCriticalStockAlerts(int $limit = 10): array {
                 $sursaPret = $detalii['articol']['price_source'] ?? null;
                 $monedaArticol = $detalii['articol']['currency'] ?? 'RON';
                 if ($sursaPret === 'product_price') {
-                    $detaliuPret = sprintf('Se va folosi prețul configurat în fișa produsului (%s).', $monedaArticol);
+                    if (!empty($detalii['articol']['needs_auto_creation'])) {
+                        $detaliuPret = sprintf(
+                            'Se va folosi prețul configurat în fișa produsului (%s). La trimiterea comenzii va fi creat automat un articol achiziționabil.',
+                            $monedaArticol
+                        );
+                    } else {
+                        $detaliuPret = sprintf('Se va folosi prețul configurat în fișa produsului (%s).', $monedaArticol);
+                    }
                 } elseif ($sursaPret === 'purchasable_product') {
                     $detaliuPret = 'Se va folosi ultimul preț de achiziție salvat pentru furnizor.';
                 } else {
@@ -1713,6 +1739,15 @@ public function getCriticalStockAlerts(int $limit = 10): array {
                 'tip' => 'critic',
                 'detalii' => $detaliuPret
             ];
+
+            if ($detalii['articol'] && empty($detalii['articol']['id'])) {
+                $detalii['validari'][] = [
+                    'conditie' => 'Articol achiziționabil asociat',
+                    'rezultat' => 'ok',
+                    'tip' => 'informativ',
+                    'detalii' => 'Produsul nu are articol achiziționabil salvat; sistemul va crea unul automat folosind datele produsului.'
+                ];
+            }
 
             $intervalRespectat = true;
             if ($ultimaAutocomanda) {
@@ -1783,7 +1818,9 @@ public function getCriticalStockAlerts(int $limit = 10): array {
                         'purchasable_product_id' => $detalii['articol']['id'],
                         'quantity' => $cantitateComandata,
                         'unit_price' => $detalii['articol']['pret'],
-                        'notes' => 'Autocomandă generată automat de sistemul WMS.'
+                        'notes' => 'Autocomandă generată automat de sistemul WMS.',
+                        'needs_auto_creation' => !empty($detalii['articol']['needs_auto_creation']),
+                        'internal_product_id' => (int)$primaLinie['product_id']
                     ]]
                 ];
             }


### PR DESCRIPTION
## Summary
- allow auto-order simulations to fall back to the product price when no last purchase price exists and log an informational message
- automatically create purchasable product records for auto-orders that rely on product prices, ensuring the actual order can be generated
- include metadata in auto-order payloads so the creation flow can generate the missing purchasable items on demand

## Testing
- php -l models/Inventory.php
- php -l models/AutoOrderManager.php

------
https://chatgpt.com/codex/tasks/task_e_68d4e165204c832099e1bf7226c4f7df