### PR TITLE
Trigger auto ordering when picks reduce inventory

### DIFF
--- a/api/picking/confirm_pick.php
+++ b/api/picking/confirm_pick.php
@@ -17,6 +17,8 @@ if (!defined('BASE_PATH')) {
     define('BASE_PATH', dirname(__DIR__, 2));
 }
 
+require_once BASE_PATH . '/models/Inventory.php';
+
 if (!file_exists(BASE_PATH . '/config/config.php')) {
     http_response_code(500);
     echo json_encode(['status' => 'error', 'message' => 'Config file missing.']);
@@ -38,6 +40,8 @@ try {
     if (session_status() === PHP_SESSION_NONE) {
         session_start();
     }
+
+    $inventoryModel = new Inventory($db);
 
     // Get JSON input
     $input = json_decode(file_get_contents('php://input'), true);
@@ -125,24 +129,36 @@ try {
         ':order_item_id' => $orderItemId
     ]);
 
-    // If inventory_id is provided, reduce inventory
+    // If inventory_id is provided, reduce inventory using the Inventory model so auto-order checks run
+    $locationId = null;
     if ($inventoryId) {
-        $updateInventoryQuery = "
-            UPDATE inventory 
-            SET quantity = quantity - :quantity_picked,
-                updated_at = NOW()
-            WHERE id = :inventory_id AND quantity >= :quantity_picked
-        ";
+        $inventoryStmt = $db->prepare('SELECT product_id, location_id FROM inventory WHERE id = :inventory_id');
+        $inventoryStmt->execute([':inventory_id' => $inventoryId]);
+        $inventoryRow = $inventoryStmt->fetch(PDO::FETCH_ASSOC);
 
-        $updateInventoryStmt = $db->prepare($updateInventoryQuery);
-        $updateInventoryStmt->execute([
-            ':quantity_picked' => $quantityPicked,
-            ':inventory_id' => $inventoryId
-        ]);
+        if (!$inventoryRow) {
+            $db->rollback();
+            http_response_code(404);
+            echo json_encode([
+                'status' => 'error',
+                'message' => 'Inventory record not found.'
+            ]);
+            exit;
+        }
 
-        // Check if inventory was actually updated
-        if ($updateInventoryStmt->rowCount() === 0) {
-            // Inventory update failed - not enough stock
+        if ((int)$inventoryRow['product_id'] !== (int)$item['product_id']) {
+            $db->rollback();
+            http_response_code(400);
+            echo json_encode([
+                'status' => 'error',
+                'message' => 'Inventory record does not match the requested product.'
+            ]);
+            exit;
+        }
+
+        $locationId = $inventoryRow['location_id'] !== null ? (int)$inventoryRow['location_id'] : null;
+
+        if (!$inventoryModel->removeStock((int)$item['product_id'], $quantityPicked, $locationId, false)) {
             $db->rollback();
             echo json_encode([
                 'status' => 'error',

--- a/api/picking/update_pick.php
+++ b/api/picking/update_pick.php
@@ -33,59 +33,8 @@ try {
         session_start();
     }
 
-    // Include inventory model for stock operations
     require_once BASE_PATH . '/models/Inventory.php';
-
-    /**
-     * Remove stock without managing its own transaction. Returns false if
-     * insufficient stock is available.
-     */
-    function removeStockForPick(PDO $db, int $productId, int $quantity, ?int $locationId = null): bool {
-        $query = "SELECT id, quantity FROM inventory WHERE product_id = :pid AND quantity > 0";
-        $params = [':pid' => $productId];
-        if ($locationId !== null) {
-            $query .= " AND location_id = :lid";
-            $params[':lid'] = $locationId;
-        }
-        $query .= " ORDER BY received_at ASC, id ASC";
-
-        $stmt = $db->prepare($query);
-        $stmt->execute($params);
-        $records = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-        if (empty($records)) {
-            return false;
-        }
-
-        $totalAvailable = array_sum(array_column($records, 'quantity'));
-        if ($totalAvailable < $quantity) {
-            return false;
-        }
-
-        $remaining = $quantity;
-        foreach ($records as $rec) {
-            if ($remaining <= 0) break;
-
-            if ($rec['quantity'] <= $remaining) {
-                $del = $db->prepare('DELETE FROM inventory WHERE id = :id');
-                $del->execute([':id' => $rec['id']]);
-                $remaining -= $rec['quantity'];
-            } else {
-                $newQty = $rec['quantity'] - $remaining;
-                $upd = $db->prepare('UPDATE inventory SET quantity = :q WHERE id = :id');
-                $upd->execute([':q' => $newQty, ':id' => $rec['id']]);
-                $remaining = 0;
-            }
-        }
-
-        // Update product total quantity
-        $update = $db->prepare(
-            "UPDATE products p SET quantity = (SELECT COALESCE(SUM(i.quantity),0) FROM inventory i WHERE i.product_id = p.product_id) WHERE p.product_id = :pid"
-        );
-        $update->execute([':pid' => $productId]);
-
-        return true;
-    }
+    $inventoryModel = new Inventory($db);
 
     // Only allow POST requests
     if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
@@ -165,8 +114,8 @@ try {
             throw new Exception("Cannot pick more than ordered quantity. Ordered: {$totalOrdered}, Already picked: {$currentPicked}, Trying to pick: {$quantityPicked}");
         }
 
-        // Deduct stock from inventory using FIFO
-        if (!removeStockForPick($db, (int)$orderItem['product_id'], $quantityPicked, $locationId)) {
+        // Deduct stock from inventory using FIFO managed by the Inventory model
+        if (!$inventoryModel->removeStock((int)$orderItem['product_id'], $quantityPicked, $locationId, false)) {
             if ($locationId !== null) {
                 throw new Exception('Insufficient stock at specified location.');
             }


### PR DESCRIPTION
## Summary
- use the Inventory model in `api/picking/update_pick.php` so stock deductions rely on the inventory table and auto-order checks run
- update `api/picking/confirm_pick.php` to validate the targeted inventory row and remove stock through the Inventory model for consistent auto-order behaviour

## Testing
- php -l api/picking/update_pick.php
- php -l api/picking/confirm_pick.php

------
https://chatgpt.com/codex/tasks/task_e_68d4f3c1089c8320959364a82c7ea2ea