### PR TITLE
Defer auto-order evaluation until after stock transactions

### DIFF
--- a/api/picking/update_pick.php
+++ b/api/picking/update_pick.php
@@ -33,59 +33,8 @@ try {
         session_start();
     }
 
-    // Include inventory model for stock operations
     require_once BASE_PATH . '/models/Inventory.php';
-
-    /**
-     * Remove stock without managing its own transaction. Returns false if
-     * insufficient stock is available.
-     */
-    function removeStockForPick(PDO $db, int $productId, int $quantity, ?int $locationId = null): bool {
-        $query = "SELECT id, quantity FROM inventory WHERE product_id = :pid AND quantity > 0";
-        $params = [':pid' => $productId];
-        if ($locationId !== null) {
-            $query .= " AND location_id = :lid";
-            $params[':lid'] = $locationId;
-        }
-        $query .= " ORDER BY received_at ASC, id ASC";
-
-        $stmt = $db->prepare($query);
-        $stmt->execute($params);
-        $records = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-        if (empty($records)) {
-            return false;
-        }
-
-        $totalAvailable = array_sum(array_column($records, 'quantity'));
-        if ($totalAvailable < $quantity) {
-            return false;
-        }
-
-        $remaining = $quantity;
-        foreach ($records as $rec) {
-            if ($remaining <= 0) break;
-
-            if ($rec['quantity'] <= $remaining) {
-                $del = $db->prepare('DELETE FROM inventory WHERE id = :id');
-                $del->execute([':id' => $rec['id']]);
-                $remaining -= $rec['quantity'];
-            } else {
-                $newQty = $rec['quantity'] - $remaining;
-                $upd = $db->prepare('UPDATE inventory SET quantity = :q WHERE id = :id');
-                $upd->execute([':q' => $newQty, ':id' => $rec['id']]);
-                $remaining = 0;
-            }
-        }
-
-        // Update product total quantity
-        $update = $db->prepare(
-            "UPDATE products p SET quantity = (SELECT COALESCE(SUM(i.quantity),0) FROM inventory i WHERE i.product_id = p.product_id) WHERE p.product_id = :pid"
-        );
-        $update->execute([':pid' => $productId]);
-
-        return true;
-    }
+    $inventoryModel = new Inventory($db);
 
     // Only allow POST requests
     if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
@@ -129,6 +78,8 @@ try {
     // Begin transaction
     $db->beginTransaction();
 
+    $autoOrderProductId = null;
+
     try {
         // Get current order item details
         $itemQuery = "
@@ -156,6 +107,8 @@ try {
             throw new Exception('Order item not found.');
         }
 
+        $autoOrderProductId = (int)$orderItem['product_id'];
+
         $currentPicked = (int)($orderItem['picked_quantity'] ?? 0);
         $totalOrdered = (int)$orderItem['quantity'];
         $newTotalPicked = $currentPicked + $quantityPicked;
@@ -165,8 +118,8 @@ try {
             throw new Exception("Cannot pick more than ordered quantity. Ordered: {$totalOrdered}, Already picked: {$currentPicked}, Trying to pick: {$quantityPicked}");
         }
 
-        // Deduct stock from inventory using FIFO
-        if (!removeStockForPick($db, (int)$orderItem['product_id'], $quantityPicked, $locationId)) {
+        // Deduct stock from inventory using FIFO managed by the Inventory model
+        if (!$inventoryModel->removeStock((int)$orderItem['product_id'], $quantityPicked, $locationId, false)) {
             if ($locationId !== null) {
                 throw new Exception('Insufficient stock at specified location.');
             }
@@ -225,6 +178,8 @@ try {
         // Commit transaction
         $db->commit();
 
+        $inventoryModel->processDeferredAutoOrders();
+
         $userId = $_SESSION['user_id'] ?? 0;
         logActivity(
             $userId,
@@ -256,7 +211,12 @@ try {
         ]);
 
     } catch (Exception $e) {
-        $db->rollback();
+        if ($db->inTransaction()) {
+            $db->rollback();
+        }
+        if ($autoOrderProductId !== null) {
+            $inventoryModel->discardDeferredAutoOrder($autoOrderProductId);
+        }
         throw $e;
     }
 


### PR DESCRIPTION
## Summary
- add deferred auto-order scheduling to the Inventory model so evaluations run after open transactions commit
- process or discard deferred auto-orders within add, remove, and move stock flows and expose helpers for callers
- update the picking APIs to flush or cancel deferred auto-orders once their database work finishes

## Testing
- php -l models/Inventory.php
- php -l api/picking/update_pick.php
- php -l api/picking/confirm_pick.php

------
https://chatgpt.com/codex/tasks/task_e_68d4f3c1089c8320959364a82c7ea2ea