### PR TITLE
Add price fields to stock configuration modal

### DIFF
--- a/product-units.php
+++ b/product-units.php
@@ -1226,6 +1226,14 @@ $currentPage = 'product-units';
                         <label for="minOrderQty">Cantitate Min. Comandă</label>
                         <input type="number" id="minOrderQty" name="min_order_quantity" min="1" value="1">
                     </div>
+                    <div class="form-group">
+                        <label for="stockPriceRon">Preț (RON)</label>
+                        <input type="number" id="stockPriceRon" name="price" step="0.01" min="0">
+                    </div>
+                    <div class="form-group">
+                        <label for="stockPriceEur">Preț (EUR)</label>
+                        <input type="number" id="stockPriceEur" name="price_eur" step="0.01" min="0">
+                    </div>
                     <div class="form-group checkbox-group">
                         <label class="checkbox-label">
                             <input type="checkbox" id="autoOrderEnabled" name="auto_order_enabled">


### PR DESCRIPTION
## Summary
- add RON and EUR price inputs to the stock management configuration modal
- update the product units front-end logic to track, validate, and submit the new price fields
- extend the inventory settings API to persist and return price information for stock configurations

## Testing
- php -l product-units.php
- php -l api/inventory_settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d4fb28ac1083209b02804f0e59080b