### PR TITLE
Add return receiving workflow with automated restock logging

### DIFF
--- a/api/warehouse/process_return_restock.php
+++ b/api/warehouse/process_return_restock.php
@@ -1,0 +1,152 @@
+<?php
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Unauthorized']);
+    exit;
+}
+
+$csrfToken = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+if (function_exists('apache_request_headers')) {
+    $headers = array_change_key_case(apache_request_headers(), CASE_UPPER);
+    $csrfToken = $csrfToken ?: ($headers['X-CSRF-TOKEN'] ?? '');
+}
+
+if (!validateCsrfToken($csrfToken)) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Method not allowed']);
+    exit;
+}
+
+try {
+    $config = require BASE_PATH . '/config/config.php';
+    $dbFactory = $config['connection_factory'] ?? null;
+    if (!$dbFactory || !is_callable($dbFactory)) {
+        throw new RuntimeException('Database connection not available');
+    }
+    $db = $dbFactory();
+
+    $input = json_decode(file_get_contents('php://input'), true);
+    if (!is_array($input)) {
+        throw new InvalidArgumentException('Invalid JSON payload');
+    }
+
+    $orderId = isset($input['order_id']) ? (int)$input['order_id'] : 0;
+    $items = isset($input['items']) && is_array($input['items']) ? $input['items'] : [];
+
+    if ($orderId <= 0 || empty($items)) {
+        throw new InvalidArgumentException('Order ID și lista de produse sunt obligatorii.');
+    }
+
+    require_once BASE_PATH . '/models/Inventory.php';
+
+    $orderStmt = $db->prepare('SELECT id, order_number, customer_name, status FROM orders WHERE id = :id');
+    $orderStmt->execute([':id' => $orderId]);
+    $order = $orderStmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$order) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'message' => 'Comanda nu a fost găsită.']);
+        exit;
+    }
+
+    $inventoryModel = new Inventory($db);
+    $userId = (int)($_SESSION['user_id'] ?? 0);
+    $orderNumber = $order['order_number'] ?? ('#' . $orderId);
+
+    $processedCount = 0;
+    $totalQuantity = 0;
+
+    foreach ($items as $item) {
+        $productId = isset($item['product_id']) ? (int)$item['product_id'] : 0;
+        $restockQty = isset($item['restock_quantity']) ? (int)$item['restock_quantity'] : 0;
+        $locationId = isset($item['location_id']) ? (int)$item['location_id'] : 0;
+        $inventoryId = isset($item['inventory_id']) ? (int)$item['inventory_id'] : 0;
+        $shelfLevel = $item['shelf_level'] ?? null;
+        $subdivisionNumber = isset($item['subdivision_number']) ? (int)$item['subdivision_number'] : null;
+
+        if ($productId <= 0 || $restockQty <= 0 || $locationId <= 0) {
+            throw new InvalidArgumentException('Informațiile despre produs și locație sunt incomplete.');
+        }
+
+        $metadata = [
+            'transaction_type' => 'return',
+            'reason' => 'Restocare retur',
+            'reference_type' => 'return',
+            'reference_id' => $orderId,
+            'notes' => 'Return din comanda ' . $orderNumber,
+            'user_id' => $userId,
+            'shelf_level' => $shelfLevel,
+            'subdivision_number' => $subdivisionNumber
+        ];
+
+        $success = false;
+        if ($inventoryId > 0) {
+            $success = $inventoryModel->increaseInventoryQuantity($inventoryId, $restockQty, $metadata);
+        } else {
+            $addData = [
+                'product_id' => $productId,
+                'location_id' => $locationId,
+                'quantity' => $restockQty,
+                'received_at' => date('Y-m-d H:i:s'),
+                'transaction_type' => 'return',
+                'reason' => 'Restocare retur',
+                'reference_type' => 'return',
+                'reference_id' => $orderId,
+                'notes' => 'Return din comanda ' . $orderNumber,
+                'user_id' => $userId
+            ];
+
+            if ($shelfLevel !== null) {
+                $addData['shelf_level'] = $shelfLevel;
+            }
+            if ($subdivisionNumber !== null) {
+                $addData['subdivision_number'] = $subdivisionNumber;
+            }
+            if (!empty($item['batch_number'])) {
+                $addData['batch_number'] = $item['batch_number'];
+            }
+            if (!empty($item['lot_number'])) {
+                $addData['lot_number'] = $item['lot_number'];
+            }
+
+            $success = (bool)$inventoryModel->addStock($addData);
+        }
+
+        if (!$success) {
+            throw new RuntimeException('Nu am putut readăuga produsul ' . $productId . ' în stoc.');
+        }
+
+        $processedCount++;
+        $totalQuantity += $restockQty;
+    }
+
+    if ($processedCount === 0) {
+        throw new RuntimeException('Niciun produs nu a fost readăugat în stoc.');
+    }
+
+    echo json_encode([
+        'success' => true,
+        'message' => sprintf('Au fost readăugate %d produse în stoc (%d bucăți).', $processedCount, $totalQuantity)
+    ]);
+} catch (InvalidArgumentException $e) {
+    http_response_code(422);
+    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+} catch (Throwable $e) {
+    error_log('process_return_restock error: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'A apărut o eroare la procesarea returului.']);
+}

--- a/api/warehouse/return_order_details.php
+++ b/api/warehouse/return_order_details.php
@@ -1,0 +1,191 @@
+<?php
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Unauthorized']);
+    exit;
+}
+
+try {
+    $config = require BASE_PATH . '/config/config.php';
+    $dbFactory = $config['connection_factory'] ?? null;
+    if (!$dbFactory || !is_callable($dbFactory)) {
+        throw new RuntimeException('Database connection not available');
+    }
+
+    $db = $dbFactory();
+
+    $orderId = isset($_GET['order_id']) ? (int)$_GET['order_id'] : 0;
+    if ($orderId <= 0) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'message' => 'Order ID invalid']);
+        exit;
+    }
+
+    $orderStmt = $db->prepare(
+        'SELECT id, order_number, customer_name, status, order_date, updated_at, total_value
+         FROM orders
+         WHERE id = :id'
+    );
+    $orderStmt->execute([':id' => $orderId]);
+    $order = $orderStmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$order) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'message' => 'Comanda nu a fost găsită.']);
+        exit;
+    }
+
+    $status = strtolower((string)($order['status'] ?? ''));
+    $allowedStatuses = ['picked', 'ready_to_ship', 'processing'];
+    if ($status && !in_array($status, $allowedStatuses, true)) {
+        http_response_code(409);
+        echo json_encode([
+            'success' => false,
+            'message' => 'Comanda nu este în stadiu de retur. Status curent: ' . ($order['status'] ?? 'necunoscut')
+        ]);
+        exit;
+    }
+
+    $itemsStmt = $db->prepare(
+        'SELECT
+            oi.id AS order_item_id,
+            oi.product_id,
+            oi.quantity AS quantity_ordered,
+            COALESCE(oi.picked_quantity, oi.quantity) AS picked_quantity,
+            p.name AS product_name,
+            p.sku,
+            p.barcode
+         FROM order_items oi
+         JOIN products p ON oi.product_id = p.product_id
+         WHERE oi.order_id = :order_id
+         ORDER BY oi.id'
+    );
+    $itemsStmt->execute([':order_id' => $orderId]);
+    $items = $itemsStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $responseItems = [];
+    $missingLocations = [];
+    $totalRestockQty = 0;
+
+    foreach ($items as $item) {
+        $productId = (int)$item['product_id'];
+        $pickedQty = (int)($item['picked_quantity'] ?? 0);
+        $orderedQty = (int)($item['quantity_ordered'] ?? 0);
+        $restockQty = $pickedQty > 0 ? $pickedQty : $orderedQty;
+        if ($restockQty < 0) {
+            $restockQty = 0;
+        }
+
+        $locationInfo = findProductReturnLocation($db, $productId);
+        if (!$locationInfo) {
+            $missingLocations[] = [
+                'product_id' => $productId,
+                'product_name' => $item['product_name'],
+                'sku' => $item['sku']
+            ];
+        }
+
+        $responseItems[] = [
+            'order_item_id' => (int)$item['order_item_id'],
+            'product_id' => $productId,
+            'product_name' => $item['product_name'],
+            'sku' => $item['sku'],
+            'quantity_ordered' => $orderedQty,
+            'picked_quantity' => $pickedQty,
+            'restock_quantity' => $restockQty,
+            'location_id' => $locationInfo['location_id'] ?? null,
+            'location_code' => $locationInfo['location_code'] ?? null,
+            'inventory_id' => $locationInfo['inventory_id'] ?? null,
+            'shelf_level' => $locationInfo['shelf_level'] ?? null,
+            'subdivision_number' => $locationInfo['subdivision_number'] ?? null
+        ];
+
+        $totalRestockQty += $restockQty;
+    }
+
+    $latestActivity = $order['updated_at'] ?: $order['order_date'];
+
+    echo json_encode([
+        'success' => true,
+        'order' => [
+            'id' => (int)$order['id'],
+            'order_number' => $order['order_number'],
+            'customer_name' => $order['customer_name'],
+            'status' => $order['status'],
+            'status_label' => translateOrderStatus($order['status']),
+            'latest_activity' => $latestActivity,
+            'total_items' => count($responseItems),
+            'total_value' => isset($order['total_value']) ? (float)$order['total_value'] : null
+        ],
+        'items' => $responseItems,
+        'missing_locations' => $missingLocations,
+        'totals' => [
+            'items' => count($responseItems),
+            'restock_quantity' => $totalRestockQty,
+            'missing_locations' => count($missingLocations)
+        ]
+    ]);
+} catch (Throwable $e) {
+    error_log('return_order_details error: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'A apărut o eroare internă.']);
+}
+
+function findProductReturnLocation(PDO $db, int $productId): ?array
+{
+    $stmt = $db->prepare(
+        "SELECT i.id AS inventory_id,
+                i.location_id,
+                l.location_code,
+                i.shelf_level,
+                i.subdivision_number,
+                i.quantity,
+                i.received_at
+         FROM inventory i
+         JOIN locations l ON i.location_id = l.id
+         WHERE i.product_id = :product_id AND i.quantity >= 0
+         ORDER BY i.quantity DESC, i.received_at ASC
+         LIMIT 1"
+    );
+    $stmt->execute([':product_id' => $productId]);
+    $location = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$location) {
+        return null;
+    }
+
+    return [
+        'inventory_id' => (int)$location['inventory_id'],
+        'location_id' => (int)$location['location_id'],
+        'location_code' => $location['location_code'],
+        'shelf_level' => $location['shelf_level'],
+        'subdivision_number' => $location['subdivision_number'] !== null ? (int)$location['subdivision_number'] : null
+    ];
+}
+
+function translateOrderStatus(?string $status): string
+{
+    if ($status === null) {
+        return 'Necunoscut';
+    }
+
+    $map = [
+        'picked' => 'Pregătită',
+        'ready_to_ship' => 'Gata de expediere',
+        'completed' => 'Finalizată',
+        'processing' => 'În procesare',
+        'pending' => 'În așteptare',
+        'assigned' => 'Alocată'
+    ];
+
+    $normalized = strtolower($status);
+    return $map[$normalized] ?? $status;
+}

--- a/models/Inventory.php
+++ b/models/Inventory.php
@@ -355,6 +355,7 @@ class Inventory {
                     $data['location_id'],
                     $data['quantity'],
                     [
+                        'transaction_type' => $data['transaction_type'] ?? 'receive',
                         'batch_number' => $data['batch_number'] ?? null,
                         'lot_number' => $data['lot_number'] ?? null,
                         'expiry_date' => $data['expiry_date'] ?? null,
@@ -466,6 +467,7 @@ class Inventory {
                         (int)$record['location_id'],
                         $quantity,
                         [
+                            'transaction_type' => $options['transaction_type'] ?? 'receive',
                             'batch_number' => $options['batch_number'] ?? $record['batch_number'] ?? null,
                             'lot_number' => $options['lot_number'] ?? $record['lot_number'] ?? null,
                             'expiry_date' => $options['expiry_date'] ?? $record['expiry_date'] ?? null,

--- a/styles/warehouse-css/warehouse_receiving.css
+++ b/styles/warehouse-css/warehouse_receiving.css
@@ -166,8 +166,26 @@ body {
   margin: 0;
 }
 
-.return-orders-results {
+.returns-panel-content {
   margin-top: 2rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: 1.75rem;
+}
+
+@media (max-width: 1200px) {
+  .returns-panel-content {
+    grid-template-columns: 1fr;
+  }
+}
+
+.return-orders-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.return-orders-results {
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -212,6 +230,18 @@ body {
   flex-direction: column;
   gap: 1rem;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.return-order-card:hover {
+  border-color: rgba(127, 189, 255, 0.4);
+  transform: translateY(-1px);
+}
+
+.return-order-card.selected {
+  border-color: rgba(127, 189, 255, 0.65);
+  box-shadow: 0 12px 28px rgba(79, 142, 255, 0.25);
 }
 
 .return-order-card-header {
@@ -273,6 +303,147 @@ body {
   text-align: center;
 }
 
+.return-details-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.return-order-details {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-height: 320px;
+}
+
+.return-order-details .empty-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem 1rem;
+  color: var(--light-gray);
+  gap: 0.75rem;
+}
+
+.return-order-details .empty-state .material-symbols-outlined {
+  font-size: 2.4rem;
+  color: var(--white);
+}
+
+.return-order-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+}
+
+.return-order-summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.return-order-summary-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--light-gray);
+}
+
+.return-order-summary-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--white);
+}
+
+.return-items-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.return-item {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.return-item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.return-item-name {
+  font-weight: 600;
+  color: var(--white);
+}
+
+.return-item-sku {
+  font-size: 0.85rem;
+  color: var(--light-gray);
+}
+
+.return-item-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  color: var(--light-gray);
+}
+
+.return-item-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.return-item-location-missing {
+  color: #ffbaba;
+  font-weight: 600;
+}
+
+.return-restock-hint {
+  display: none;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+}
+
+.return-restock-hint.warning {
+  display: flex;
+  background: rgba(255, 193, 7, 0.12);
+  border: 1px solid rgba(255, 193, 7, 0.35);
+  color: #ffe082;
+}
+
+.return-restock-hint.success {
+  display: flex;
+  background: rgba(76, 175, 80, 0.12);
+  border: 1px solid rgba(76, 175, 80, 0.35);
+  color: #c8e6c9;
+}
+
+.return-restock-hint .material-symbols-outlined {
+  font-size: 1.2rem;
+}
+
 /* ===== LOADING OVERLAY ===== */
 .loading-overlay {
   position: fixed;
@@ -306,6 +477,11 @@ body {
 @keyframes spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
+}
+
+.material-symbols-outlined.spin {
+  animation: spin 1s linear infinite;
+  margin-right: 0.35rem;
 }
 
 /* ===== ALERT MESSAGES ===== */

--- a/warehouse_receiving.php
+++ b/warehouse_receiving.php
@@ -362,10 +362,27 @@ $currentPage = 'warehouse_receiving';
                                 </div>
                                 <p class="returns-hint">Rezultatele afișează comenzile deja ridicate, cele mai recente apar primele.</p>
                             </div>
-                            <div id="return-orders-results" class="return-orders-results">
-                                <div class="empty-state">
-                                    <span class="material-symbols-outlined">travel_explore</span>
-                                    <p>Introduceți numele unei companii pentru a vedea comenzile pregătite pentru retur.</p>
+                            <div class="returns-panel-content">
+                                <div class="return-orders-column">
+                                    <div id="return-orders-results" class="return-orders-results">
+                                        <div class="empty-state">
+                                            <span class="material-symbols-outlined">travel_explore</span>
+                                            <p>Introduceți numele unei companii pentru a vedea comenzile pregătite pentru retur.</p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="return-details-column">
+                                    <div id="return-order-details" class="return-order-details">
+                                        <div class="empty-state">
+                                            <span class="material-symbols-outlined">playlist_add_check</span>
+                                            <p>Selectați o comandă pentru a vedea produsele returnate și locațiile propuse.</p>
+                                        </div>
+                                    </div>
+                                    <div id="return-restock-hint" class="return-restock-hint" style="display:none;"></div>
+                                    <button type="button" class="btn btn-success" id="return-restock-btn" disabled>
+                                        <span class="material-symbols-outlined">inventory_2</span>
+                                        Adaugă în stoc
+                                    </button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- enhance the return tab in the receiving interface so orders can be selected, their items inspected, and restocked directly into inventory locations
- add dedicated warehouse API endpoints to fetch picked order details and to push returned stock back with transaction history marked as return operations
- allow inventory logging to override the transaction type so stock movements entered from returns surface as "Retur" in the stock movement history and polish the related styles/UI feedback

## Testing
- `php -l api/warehouse/return_order_details.php`
- `php -l api/warehouse/process_return_restock.php`
- `vendor/bin/phpunit` *(fails: command not found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d525efb79c832086fa1d6ea793bc51