### PR TITLE
Add comprehensive incident reporting system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,12 +12,15 @@ node_modules/
 /src
 
 /storage
+!storage/incidents/
+storage/incidents/*
+!storage/incidents/.gitignore
 
 # Ignore OS system files
-.DS_StoreThumbs.db
+.DS_Store
+Thumbs.db
 # Ignore database backups
 database/backups/*.sql
 vendor/
 \.phpunit.result.cache
 storage/invoice_pdfs/
-storage

--- a/api/incidents/create.php
+++ b/api/incidents/create.php
@@ -1,0 +1,175 @@
+<?php
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Autentificare necesară.']);
+    exit;
+}
+
+$allowedRoles = ['admin', 'warehouse', 'worker'];
+if (!in_array($_SESSION['role'] ?? '', $allowedRoles, true)) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Nu aveți permisiunea să raportați incidente.']);
+    exit;
+}
+
+$csrfToken = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? ($_POST['csrf_token'] ?? '');
+if (!validateCsrfToken($csrfToken)) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Token CSRF invalid.']);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Metoda trebuie să fie POST.']);
+    exit;
+}
+
+try {
+    $config = require BASE_PATH . '/config/config.php';
+    $dbFactory = $config['connection_factory'] ?? null;
+    if (!$dbFactory || !is_callable($dbFactory)) {
+        throw new RuntimeException('Configurația bazei de date este invalidă.');
+    }
+
+    $db = $dbFactory();
+    require_once BASE_PATH . '/models/Incident.php';
+
+    $incidentModel = new Incident($db);
+
+    $incidentType = $_POST['incident_type'] ?? '';
+    $title = trim($_POST['title'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $severity = $_POST['severity'] ?? 'medium';
+    $occurredRaw = $_POST['occurred_at'] ?? '';
+    $locationId = isset($_POST['location_id']) && $_POST['location_id'] !== '' ? (int)$_POST['location_id'] : null;
+    $locationDescription = trim($_POST['location_description'] ?? '');
+    $estimatedCost = $_POST['estimated_cost'] ?? null;
+
+    $validTypes = ['product_loss','equipment_loss','equipment_damage','safety_issue','quality_issue','process_violation','other'];
+    $validSeverities = ['low','medium','high','critical'];
+
+    if (!in_array($incidentType, $validTypes, true)) {
+        throw new InvalidArgumentException('Tipul incidentului este invalid.');
+    }
+
+    if (empty($title) || empty($description)) {
+        throw new InvalidArgumentException('Titlul și descrierea sunt obligatorii.');
+    }
+
+    if (!in_array($severity, $validSeverities, true)) {
+        throw new InvalidArgumentException('Severitatea selectată nu este validă.');
+    }
+
+    $occurredAt = DateTime::createFromFormat('Y-m-d\TH:i', $occurredRaw) ?: DateTime::createFromFormat('Y-m-d H:i:s', $occurredRaw);
+    if (!$occurredAt) {
+        throw new InvalidArgumentException('Data incidentului este invalidă.');
+    }
+
+    $costValue = null;
+    if ($estimatedCost !== null && $estimatedCost !== '') {
+        $costFloat = (float)$estimatedCost;
+        if ($costFloat < 0) {
+            throw new InvalidArgumentException('Costul estimativ nu poate fi negativ.');
+        }
+        $costValue = number_format($costFloat, 2, '.', '');
+    }
+
+    $incidentNumber = $incidentModel->generateIncidentNumber();
+    $storageDir = BASE_PATH . '/storage/incidents/' . $incidentNumber;
+    if (!is_dir($storageDir) && !mkdir($storageDir, 0775, true) && !is_dir($storageDir)) {
+        throw new RuntimeException('Nu se poate crea directorul pentru fotografii.');
+    }
+
+    $photoRecords = [];
+    if (!empty($_FILES['photos']) && is_array($_FILES['photos']['name'])) {
+        $fileCount = count($_FILES['photos']['name']);
+        for ($i = 0; $i < $fileCount; $i++) {
+            $error = $_FILES['photos']['error'][$i];
+            if ($error === UPLOAD_ERR_NO_FILE) {
+                continue;
+            }
+            if ($error !== UPLOAD_ERR_OK) {
+                throw new RuntimeException('Încărcarea fotografiei a eșuat.');
+            }
+
+            $tmpName = $_FILES['photos']['tmp_name'][$i];
+            $originalName = $_FILES['photos']['name'][$i];
+            $size = (int)$_FILES['photos']['size'][$i];
+            $mime = mime_content_type($tmpName);
+
+            if ($size > 5 * 1024 * 1024) {
+                throw new InvalidArgumentException('Fotografiile trebuie să fie mai mici de 5MB.');
+            }
+
+            $allowedMime = ['image/jpeg' => 'jpg', 'image/png' => 'png', 'image/webp' => 'webp'];
+            if (!isset($allowedMime[$mime])) {
+                throw new InvalidArgumentException('Doar imaginile JPEG, PNG sau WebP sunt permise.');
+            }
+
+            $uniqueName = sprintf('%s_%s.%s', time(), bin2hex(random_bytes(4)), $allowedMime[$mime]);
+            $targetPath = $storageDir . '/' . $uniqueName;
+            if (!move_uploaded_file($tmpName, $targetPath)) {
+                throw new RuntimeException('Nu s-a putut salva fișierul încărcat.');
+            }
+
+            $photoRecords[] = [
+                'file_path' => 'storage/incidents/' . $incidentNumber . '/' . $uniqueName,
+                'original_filename' => $originalName,
+                'file_size' => $size,
+                'mime_type' => $mime,
+            ];
+        }
+    }
+
+    $incidentData = [
+        'incident_number' => $incidentNumber,
+        'reporter_id' => (int)$_SESSION['user_id'],
+        'incident_type' => $incidentType,
+        'title' => $title,
+        'description' => $description,
+        'location_id' => $locationId,
+        'location_description' => $locationDescription ?: null,
+        'severity' => $severity,
+        'status' => 'reported',
+        'occurred_at' => $occurredAt->format('Y-m-d H:i:s'),
+        'estimated_cost' => $costValue,
+        'follow_up_required' => in_array($severity, ['high','critical'], true),
+    ];
+
+    $result = $incidentModel->createIncident($incidentData, $photoRecords);
+
+    logActivity(
+        (int)$_SESSION['user_id'],
+        'create',
+        'incident',
+        $result['id'],
+        'Incident raportat: ' . $incidentNumber,
+        null,
+        $incidentData
+    );
+
+    echo json_encode([
+        'success' => true,
+        'message' => 'Incident raportat cu succes.',
+        'data' => [
+            'incident_id' => $result['id'],
+            'incident_number' => $incidentNumber
+        ]
+    ]);
+} catch (InvalidArgumentException $e) {
+    http_response_code(422);
+    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+} catch (Throwable $e) {
+    error_log('Incident create error: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'A apărut o eroare la raportarea incidentului.']);
+}

--- a/api/incidents/update-status.php
+++ b/api/incidents/update-status.php
@@ -1,0 +1,103 @@
+<?php
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'admin') {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Doar administratorii pot actualiza incidente.']);
+    exit;
+}
+
+$csrfToken = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+if (!validateCsrfToken($csrfToken)) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Token CSRF invalid.']);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Metoda trebuie să fie POST.']);
+    exit;
+}
+
+$payload = json_decode(file_get_contents('php://input'), true);
+if (!is_array($payload)) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Payload JSON invalid.']);
+    exit;
+}
+
+try {
+    $incidentId = isset($payload['incident_id']) ? (int)$payload['incident_id'] : 0;
+    $status = $payload['status'] ?? '';
+    $adminNotes = $payload['admin_notes'] ?? null;
+    $resolutionNotes = $payload['resolution_notes'] ?? null;
+    $followUp = !empty($payload['follow_up_required']);
+
+    if ($incidentId <= 0) {
+        throw new InvalidArgumentException('Incidentul specificat nu există.');
+    }
+
+    $validStatuses = ['reported','under_review','investigating','resolved','rejected'];
+    if (!in_array($status, $validStatuses, true)) {
+        throw new InvalidArgumentException('Statusul selectat este invalid.');
+    }
+
+    $config = require BASE_PATH . '/config/config.php';
+    $dbFactory = $config['connection_factory'] ?? null;
+    if (!$dbFactory || !is_callable($dbFactory)) {
+        throw new RuntimeException('Configurația bazei de date este invalidă.');
+    }
+
+    $db = $dbFactory();
+    require_once BASE_PATH . '/models/Incident.php';
+
+    $incidentModel = new Incident($db);
+    $updateSuccess = $incidentModel->updateStatus($incidentId, [
+        'status' => $status,
+        'admin_notes' => $adminNotes,
+        'resolution_notes' => $resolutionNotes,
+        'follow_up_required' => $followUp,
+        'assigned_admin_id' => (int)$_SESSION['user_id'],
+    ]);
+
+    if (!$updateSuccess) {
+        throw new RuntimeException('Actualizarea statusului nu a fost posibilă.');
+    }
+
+    $incident = $incidentModel->getIncidentById($incidentId);
+
+    logActivity(
+        (int)$_SESSION['user_id'],
+        'update',
+        'incident',
+        $incidentId,
+        'Actualizare status incident la ' . $status,
+        null,
+        [
+            'status' => $status,
+            'admin_notes' => $adminNotes,
+            'resolution_notes' => $resolutionNotes,
+            'follow_up_required' => $followUp,
+        ]
+    );
+
+    echo json_encode([
+        'success' => true,
+        'message' => 'Status actualizat cu succes.',
+        'data' => $incident,
+    ]);
+} catch (InvalidArgumentException $e) {
+    http_response_code(422);
+    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+} catch (Throwable $e) {
+    error_log('Incident update error: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'A apărut o eroare la actualizarea incidentului.']);
+}

--- a/database/migrations/2025_09_30_120000_create_incidents_tables.php
+++ b/database/migrations/2025_09_30_120000_create_incidents_tables.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Migration: create_incidents_tables
+ * Created: 2025-09-30
+ * Purpose: Incident reporting system tables
+ */
+
+class CreateIncidentsTablesMigration {
+    public function up(PDO $pdo) {
+        echo "🚨 Creating incident reporting tables...\n";
+
+        $pdo->exec("CREATE TABLE IF NOT EXISTS incidents (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            incident_number VARCHAR(20) UNIQUE NOT NULL,
+            reporter_id INT NOT NULL,
+            incident_type ENUM('product_loss','equipment_loss','equipment_damage','safety_issue','quality_issue','process_violation','other') NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            description TEXT NOT NULL,
+            location_id INT NULL,
+            location_description VARCHAR(255) NULL,
+            severity ENUM('low','medium','high','critical') NOT NULL DEFAULT 'medium',
+            status ENUM('reported','under_review','investigating','resolved','rejected') NOT NULL DEFAULT 'reported',
+            assigned_admin_id INT NULL,
+            admin_notes TEXT NULL,
+            resolution_notes TEXT NULL,
+            occurred_at DATETIME NOT NULL,
+            reported_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            reviewed_at TIMESTAMP NULL,
+            resolved_at TIMESTAMP NULL,
+            estimated_cost DECIMAL(10,2) NULL,
+            follow_up_required BOOLEAN NOT NULL DEFAULT FALSE,
+            INDEX idx_incident_status (status),
+            INDEX idx_incident_severity (severity),
+            INDEX idx_incident_type (incident_type),
+            INDEX idx_reporter (reporter_id),
+            INDEX idx_assigned_admin (assigned_admin_id),
+            FOREIGN KEY (reporter_id) REFERENCES users(id) ON DELETE RESTRICT,
+            FOREIGN KEY (location_id) REFERENCES locations(id) ON DELETE SET NULL,
+            FOREIGN KEY (assigned_admin_id) REFERENCES users(id) ON DELETE SET NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+
+        $pdo->exec("CREATE TABLE IF NOT EXISTS incident_photos (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            incident_id INT NOT NULL,
+            file_path VARCHAR(500) NOT NULL,
+            original_filename VARCHAR(255) NOT NULL,
+            file_size INT NOT NULL,
+            mime_type VARCHAR(100) NOT NULL,
+            uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            INDEX idx_incident_photo_incident (incident_id),
+            FOREIGN KEY (incident_id) REFERENCES incidents(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+
+        echo "✅ Incident tables created successfully.\n";
+    }
+
+    public function down(PDO $pdo) {
+        echo "🗑️ Dropping incident reporting tables...\n";
+        $pdo->exec("DROP TABLE IF EXISTS incident_photos");
+        $pdo->exec("DROP TABLE IF EXISTS incidents");
+        echo "✅ Incident tables dropped.\n";
+    }
+}
+
+return new CreateIncidentsTablesMigration();

--- a/docs/incident_reporting_setup.md
+++ b/docs/incident_reporting_setup.md
@@ -1,0 +1,48 @@
+# Sistem Raportare Incidente - Instrucțiuni Integrare
+
+## 1. Migrare Bază de Date
+1. Rulează utilitarul de migrare existent:
+   ```bash
+   php migrate.php
+   ```
+2. Verifică faptul că tabelele `incidents` și `incident_photos` au fost create.
+
+## 2. Permisiuni și Stocare Fișiere
+- Asigură-te că directorul `storage/incidents` există și are permisiuni de scriere pentru utilizatorul PHP:
+  ```bash
+  mkdir -p storage/incidents
+  chmod 775 storage/incidents
+  ```
+- Fișierele sunt organizate pe fiecare incident (`storage/incidents/INCYYYYMMDD###`).
+
+## 3. Integrare Interfață Worker
+- Componenta pentru raportare este încărcată automat pe toate paginile worker prin `includes/warehouse_footer.php`.
+- Pentru paginile personalizate warehouse, confirmă că folosesc footer-ul standard.
+- Butonul flotant „Raportează Incident” se afișează doar pentru rolurile `warehouse`, `worker` și `admin`.
+
+## 4. Interfață Administrator
+- Accesibilă doar pentru utilizatorii cu rol `admin` la `incidents-admin.php`.
+- Include filtre pentru tip, severitate și status, plus actualizare workflow.
+- Fotografii se pot deschide în tab nou pentru audit.
+
+## 5. API-uri Noi
+- `POST /api/incidents/create.php`
+  - Acceptă formular multipart cu câmpurile din formularul worker.
+  - Necesită antet `X-CSRF-TOKEN` și sesiune validă.
+- `POST /api/incidents/update-status.php`
+  - Acceptă payload JSON cu `incident_id`, `status`, `admin_notes`, `resolution_notes`, `follow_up_required`.
+  - Doar rol `admin`.
+
+## 6. Reguli de Securitate
+- CSRF obligatoriu pentru ambele endpoint-uri.
+- Upload-urile sunt limitate la 5 MB/fisier și JPEG/PNG/WebP.
+- Toate operațiile folosesc PDO cu prepared statements.
+
+## 7. Activitate și Audit
+- Fiecare raportare și actualizare înregistrează evenimente în sistemul existent `logActivity`.
+- Numerele de incident sunt generate ca `INCYYYYMMDD###` și garantat unice.
+
+## 8. Personalizare Ulterioară
+- Pentru includerea altor câmpuri se poate extinde modelul `Incident`.
+- Stilurile se află în `styles/incident-report.css` și `styles/incidents-admin.css`.
+- Logica front-end este în `js/incident-report-worker.js` și `js/incidents-admin.js`.

--- a/incident-report-worker.php
+++ b/incident-report-worker.php
@@ -1,0 +1,159 @@
+<?php
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', __DIR__);
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$allowedRoles = ['admin', 'warehouse', 'worker'];
+if (!isset($_SESSION['role']) || !in_array($_SESSION['role'], $allowedRoles, true)) {
+    return;
+}
+
+if (defined('INCIDENT_REPORT_WIDGET_RENDERED')) {
+    return;
+}
+
+define('INCIDENT_REPORT_WIDGET_RENDERED', true);
+
+$config = $config ?? require BASE_PATH . '/config/config.php';
+$dbFactory = $config['connection_factory'] ?? null;
+$locations = [];
+
+if ($dbFactory && is_callable($dbFactory)) {
+    try {
+        $db = $dbFactory();
+        $stmt = $db->prepare("SELECT id, location_code FROM locations ORDER BY location_code ASC LIMIT 300");
+        $stmt->execute();
+        $locations = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    } catch (Throwable $e) {
+        error_log('Incident widget could not load locations: ' . $e->getMessage());
+    }
+}
+
+$assetBase = rtrim(BASE_URL, '/') . '/';
+$cssPath = BASE_PATH . '/styles/incident-report.css';
+$cssHref = $assetBase . 'styles/incident-report.css';
+$jsPath = BASE_PATH . '/js/incident-report-worker.js';
+$jsSrc = $assetBase . 'js/incident-report-worker.js';
+
+if (file_exists($cssPath)) {
+    $cssHref .= '?v=' . filemtime($cssPath);
+}
+
+if (file_exists($jsPath)) {
+    $jsSrc .= '?v=' . filemtime($jsPath);
+}
+
+$createEndpoint = $assetBase . 'api/incidents/create.php';
+$csrfToken = getCsrfToken();
+?>
+<link rel="stylesheet" href="<?= htmlspecialchars($cssHref) ?>">
+<div id="incident-report-widget"
+     class="incident-widget"
+     data-create-endpoint="<?= htmlspecialchars($createEndpoint) ?>"
+     data-csrf="<?= htmlspecialchars($csrfToken) ?>"
+     data-max-photos="5">
+    <button type="button" class="incident-fab" id="incident-fab">
+        <span class="material-symbols-outlined">report</span>
+        <span class="fab-label">Raportează Incident</span>
+    </button>
+
+    <div class="incident-modal" id="incident-modal" aria-hidden="true">
+        <div class="incident-modal-overlay" data-close="modal"></div>
+        <div class="incident-modal-content" role="dialog" aria-modal="true" aria-labelledby="incident-modal-title">
+            <header class="incident-modal-header">
+                <h2 id="incident-modal-title">Raportare Incident Operațional</h2>
+                <button type="button" class="incident-modal-close" data-close="modal" aria-label="Închide">
+                    <span class="material-symbols-outlined">close</span>
+                </button>
+            </header>
+
+            <form id="incident-form" class="incident-form" enctype="multipart/form-data">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                <div class="incident-form-grid">
+                    <div class="incident-field">
+                        <label for="incident_type">Tip Incident</label>
+                        <select id="incident_type" name="incident_type" required>
+                            <option value="">Selectează...</option>
+                            <option value="product_loss">Pierdere Produs</option>
+                            <option value="equipment_loss">Pierdere Echipament</option>
+                            <option value="equipment_damage">Deteriorare Echipament</option>
+                            <option value="safety_issue">Problemă Siguranță</option>
+                            <option value="quality_issue">Problemă Calitate</option>
+                            <option value="process_violation">Încălcare Procedură</option>
+                            <option value="other">Altele</option>
+                        </select>
+                    </div>
+
+                    <div class="incident-field">
+                        <label for="incident_title">Titlu Scurt</label>
+                        <input type="text" id="incident_title" name="title" maxlength="255" required placeholder="Descriere rapidă">
+                    </div>
+
+                    <div class="incident-field incident-field-span">
+                        <label for="incident_description">Descriere Detaliată</label>
+                        <textarea id="incident_description" name="description" rows="4" required placeholder="Explică pe scurt ce s-a întâmplat, cauze, impact"></textarea>
+                    </div>
+
+                    <div class="incident-field">
+                        <label for="incident_location">Locația</label>
+                        <select id="incident_location" name="location_id">
+                            <option value="">Alege locația</option>
+                            <?php foreach ($locations as $location): ?>
+                                <option value="<?= (int)$location['id'] ?>"><?= htmlspecialchars($location['location_code']) ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+
+                    <div class="incident-field">
+                        <label for="location_description">Descriere locație suplimentară</label>
+                        <input type="text" id="location_description" name="location_description" maxlength="255" placeholder="Zona, echipament sau context">
+                    </div>
+
+                    <div class="incident-field">
+                        <label for="incident_severity">Severitate</label>
+                        <select id="incident_severity" name="severity" required>
+                            <option value="low">Scăzută</option>
+                            <option value="medium" selected>Medie</option>
+                            <option value="high">Ridicată</option>
+                            <option value="critical">Critică</option>
+                        </select>
+                    </div>
+
+                    <div class="incident-field">
+                        <label for="occurred_at">Când s-a întâmplat?</label>
+                        <input type="datetime-local" id="occurred_at" name="occurred_at" required>
+                    </div>
+
+                    <div class="incident-field">
+                        <label for="estimated_cost">Cost Estimativ (RON)</label>
+                        <input type="number" id="estimated_cost" name="estimated_cost" step="0.01" min="0" placeholder="0.00">
+                    </div>
+
+                    <div class="incident-field incident-field-span">
+                        <label for="incident_photos">Fotografii (max. 5MB/buc)</label>
+                        <input type="file" id="incident_photos" name="photos[]" accept="image/jpeg,image/png,image/webp" multiple>
+                        <small class="incident-help">Poți atașa mai multe poze pentru documentare.</small>
+                        <div class="incident-photo-preview" id="incident-photo-preview"></div>
+                    </div>
+                </div>
+
+                <footer class="incident-modal-footer">
+                    <button type="button" class="btn-secondary" data-close="modal">Renunță</button>
+                    <button type="submit" class="btn-primary" id="incident-submit">
+                        <span class="material-symbols-outlined">send</span>
+                        Trimite Raportul
+                    </button>
+                </footer>
+            </form>
+        </div>
+    </div>
+
+    <div class="incident-toast-container" id="incident-toast"></div>
+</div>
+<script src="<?= htmlspecialchars($jsSrc) ?>" defer></script>

--- a/incidents-admin.php
+++ b/incidents-admin.php
@@ -1,0 +1,320 @@
+<?php
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', __DIR__);
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? null) !== 'admin') {
+    header('Location: ' . getNavUrl('login.php'));
+    exit;
+}
+
+$config = require BASE_PATH . '/config/config.php';
+$dbFactory = $config['connection_factory'] ?? null;
+
+if (!$dbFactory || !is_callable($dbFactory)) {
+    die('Conexiunea la baza de date nu este configurată corect.');
+}
+
+$db = $dbFactory();
+
+require_once BASE_PATH . '/models/Incident.php';
+
+$incidentModel = new Incident($db);
+
+$statusMap = [
+    'reported' => 'Raportat',
+    'under_review' => 'În Revizuire',
+    'investigating' => 'În Investigare',
+    'resolved' => 'Rezolvat',
+    'rejected' => 'Respins',
+];
+
+$typeMap = [
+    'product_loss' => 'Pierdere Produs',
+    'equipment_loss' => 'Pierdere Echipament',
+    'equipment_damage' => 'Deteriorare Echipament',
+    'safety_issue' => 'Problemă Siguranță',
+    'quality_issue' => 'Problemă Calitate',
+    'process_violation' => 'Încălcare Procedură',
+    'other' => 'Altele',
+];
+
+$severityMap = [
+    'low' => 'Scăzută',
+    'medium' => 'Medie',
+    'high' => 'Ridicată',
+    'critical' => 'Critică',
+];
+
+$filters = [
+    'status' => isset($_GET['status']) && array_key_exists($_GET['status'], $statusMap) ? $_GET['status'] : '',
+    'incident_type' => isset($_GET['incident_type']) && array_key_exists($_GET['incident_type'], $typeMap) ? $_GET['incident_type'] : '',
+    'severity' => isset($_GET['severity']) && array_key_exists($_GET['severity'], $severityMap) ? $_GET['severity'] : '',
+    'search' => trim($_GET['search'] ?? ''),
+];
+
+$incidents = $incidentModel->getAllIncidents($filters);
+$incidentIds = array_column($incidents, 'id');
+$photosByIncident = [];
+
+if ($incidentIds) {
+    $placeholders = implode(',', array_fill(0, count($incidentIds), '?'));
+    $photoStmt = $db->prepare("SELECT * FROM incident_photos WHERE incident_id IN ($placeholders) ORDER BY uploaded_at ASC");
+    $photoStmt->execute($incidentIds);
+    while ($photo = $photoStmt->fetch(PDO::FETCH_ASSOC)) {
+        $photosByIncident[$photo['incident_id']][] = $photo;
+    }
+}
+
+$incidentsForView = [];
+foreach ($incidents as $incident) {
+    $incidentId = (int)$incident['id'];
+    $incident['status_label'] = $statusMap[$incident['status']] ?? $incident['status'];
+    $incident['type_label'] = $typeMap[$incident['incident_type']] ?? $incident['incident_type'];
+    $incident['severity_label'] = $severityMap[$incident['severity']] ?? $incident['severity'];
+    $incident['photos'] = $photosByIncident[$incidentId] ?? [];
+    $incident['reported_at_display'] = date('d.m.Y H:i', strtotime($incident['reported_at']));
+    $incident['occurred_at_display'] = date('d.m.Y H:i', strtotime($incident['occurred_at']));
+    $incident['estimated_cost_display'] = $incident['estimated_cost'] !== null
+        ? number_format((float)$incident['estimated_cost'], 2, ',', ' ')
+        : 'N/A';
+    $incidentsForView[] = $incident;
+}
+
+$unresolvedCounts = $incidentModel->getUnresolvedCounts();
+$unresolvedTotal = $incidentModel->getUnresolvedTotal();
+
+$currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
+$cssPath = BASE_PATH . '/styles/incidents-admin.css';
+$cssUrl = rtrim(BASE_URL, '/') . '/styles/incidents-admin.css' . (file_exists($cssPath) ? '?v=' . filemtime($cssPath) : '');
+$scriptPath = BASE_PATH . '/js/incidents-admin.js';
+$scriptUrl = file_exists($scriptPath) ? rtrim(BASE_URL, '/') . '/js/incidents-admin.js?v=' . filemtime($scriptPath) : '';
+
+?>
+<!DOCTYPE html>
+<html lang="ro">
+<head>
+    <?php require_once __DIR__ . '/includes/header.php'; ?>
+    <link rel="stylesheet" href="<?= htmlspecialchars($cssUrl) ?>">
+    <title>Administrare Incidente</title>
+</head>
+<body>
+    <div class="app">
+        <?php require_once __DIR__ . '/includes/navbar.php'; ?>
+        <div class="main-content">
+            <div class="page-container incidents-admin">
+                <header class="page-header">
+                    <div class="page-header-content">
+                        <h1 class="page-title">
+                            <span class="material-symbols-outlined">emergency</span>
+                            Administrare Incidente
+                        </h1>
+                    </div>
+                </header>
+
+                <section class="incident-badges">
+                    <div class="badge-card total">
+                        <span class="badge-label">Incidente nerezolvate</span>
+                        <strong class="badge-value"><?= (int)$unresolvedTotal ?></strong>
+                    </div>
+                    <div class="badge-grid">
+                        <?php foreach ($severityMap as $key => $label): ?>
+                            <div class="badge-card severity-<?= htmlspecialchars($key) ?>">
+                                <span class="badge-label"><?= htmlspecialchars($label) ?></span>
+                                <strong class="badge-value"><?= (int)($unresolvedCounts[$key] ?? 0) ?></strong>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </section>
+
+                <section class="filters-card">
+                    <form class="filters-form" method="GET">
+                        <div class="filter-group">
+                            <label for="filter-status">Status</label>
+                            <select name="status" id="filter-status">
+                                <option value="">Toate Statusurile</option>
+                                <?php foreach ($statusMap as $value => $label): ?>
+                                    <option value="<?= htmlspecialchars($value) ?>" <?= $filters['status'] === $value ? 'selected' : '' ?>><?= htmlspecialchars($label) ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="filter-group">
+                            <label for="filter-type">Tip</label>
+                            <select name="incident_type" id="filter-type">
+                                <option value="">Toate Tipurile</option>
+                                <?php foreach ($typeMap as $value => $label): ?>
+                                    <option value="<?= htmlspecialchars($value) ?>" <?= $filters['incident_type'] === $value ? 'selected' : '' ?>><?= htmlspecialchars($label) ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="filter-group">
+                            <label for="filter-severity">Severitate</label>
+                            <select name="severity" id="filter-severity">
+                                <option value="">Toate Severitățile</option>
+                                <?php foreach ($severityMap as $value => $label): ?>
+                                    <option value="<?= htmlspecialchars($value) ?>" <?= $filters['severity'] === $value ? 'selected' : '' ?>><?= htmlspecialchars($label) ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="filter-group search">
+                            <label for="filter-search">Căutare</label>
+                            <input type="search" id="filter-search" name="search" value="<?= htmlspecialchars($filters['search']) ?>" placeholder="Număr, titlu sau raportant">
+                        </div>
+                        <div class="filter-actions">
+                            <button type="submit" class="btn-primary">
+                                <span class="material-symbols-outlined">filter_alt</span>
+                                Filtrează
+                            </button>
+                            <a class="btn-secondary" href="<?= htmlspecialchars($_SERVER['PHP_SELF']) ?>">
+                                <span class="material-symbols-outlined">refresh</span>
+                                Resetează
+                            </a>
+                        </div>
+                    </form>
+                </section>
+
+                <section class="incidents-table-card">
+                    <div class="card-header">
+                        <h2>Incidente Raportate</h2>
+                        <span class="count-pill"><?= count($incidentsForView) ?> rezultate</span>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table incidents-table">
+                            <thead>
+                                <tr>
+                                    <th>Număr Incident</th>
+                                    <th>Tip</th>
+                                    <th>Titlu</th>
+                                    <th>Raportant</th>
+                                    <th>Severitate</th>
+                                    <th>Status</th>
+                                    <th>Data Raportării</th>
+                                    <th>Acțiuni</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php if (empty($incidentsForView)): ?>
+                                    <tr>
+                                        <td colspan="8" class="empty-state">Nu există incidente pentru filtrele selectate.</td>
+                                    </tr>
+                                <?php else: ?>
+                                    <?php foreach ($incidentsForView as $incident):
+                                        $incidentJson = htmlspecialchars(json_encode($incident, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR), ENT_QUOTES, 'UTF-8');
+                                    ?>
+                                        <tr data-incident-id="<?= (int)$incident['id'] ?>">
+                                            <td><span class="mono"><?= htmlspecialchars($incident['incident_number']) ?></span></td>
+                                            <td><?= htmlspecialchars($incident['type_label']) ?></td>
+                                            <td><?= htmlspecialchars($incident['title']) ?></td>
+                                            <td><?= htmlspecialchars($incident['reporter_name']) ?></td>
+                                            <td>
+                                                <span class="badge severity <?= htmlspecialchars($incident['severity']) ?>">
+                                                    <?= htmlspecialchars($incident['severity_label']) ?>
+                                                </span>
+                                            </td>
+                                            <td>
+                                                <span class="badge status <?= htmlspecialchars($incident['status']) ?>">
+                                                    <?= htmlspecialchars($incident['status_label']) ?>
+                                                </span>
+                                            </td>
+                                            <td><?= htmlspecialchars($incident['reported_at_display']) ?></td>
+                                            <td>
+                                                <div class="action-group">
+                                                    <button type="button" class="btn-icon view-incident" data-incident='<?= $incidentJson ?>'>
+                                                        <span class="material-symbols-outlined">visibility</span>
+                                                        Vezi Detalii
+                                                    </button>
+                                                    <button type="button" class="btn-icon update-incident" data-incident='<?= $incidentJson ?>'>
+                                                        <span class="material-symbols-outlined">playlist_add_check</span>
+                                                        Actualizează Status
+                                                    </button>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                <?php endif; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal incident-modal" id="incidentDetailModal" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <header class="modal-header">
+                    <h2 class="modal-title">Detalii Incident</h2>
+                    <button type="button" class="modal-close" data-modal-close>
+                        <span class="material-symbols-outlined">close</span>
+                    </button>
+                </header>
+                <div class="modal-body" id="incident-detail-body"></div>
+                <footer class="modal-footer">
+                    <button type="button" class="btn-secondary" data-modal-close>Închide</button>
+                </footer>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal incident-modal" id="incidentStatusModal" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <header class="modal-header">
+                    <h2 class="modal-title">Actualizează Status Incident</h2>
+                    <button type="button" class="modal-close" data-modal-close>
+                        <span class="material-symbols-outlined">close</span>
+                    </button>
+                </header>
+                <form class="modal-body" id="incident-status-form">
+                    <input type="hidden" name="incident_id" id="status-incident-id">
+                    <div class="form-group">
+                        <label for="status-select">Status</label>
+                        <select name="status" id="status-select" required>
+                            <?php foreach ($statusMap as $value => $label): ?>
+                                <option value="<?= htmlspecialchars($value) ?>"><?= htmlspecialchars($label) ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="status-admin-notes">Note Administrator</label>
+                        <textarea id="status-admin-notes" name="admin_notes" rows="3" placeholder="Observații interne"></textarea>
+                    </div>
+                    <div class="form-group">
+                        <label for="status-resolution-notes">Note Rezolvare</label>
+                        <textarea id="status-resolution-notes" name="resolution_notes" rows="3" placeholder="Rezumatul rezolvării"></textarea>
+                    </div>
+                    <div class="form-check">
+                        <input type="checkbox" id="status-follow-up" name="follow_up_required" value="1">
+                        <label for="status-follow-up">Necesită acțiuni suplimentare</label>
+                    </div>
+                </form>
+                <footer class="modal-footer">
+                    <button type="button" class="btn-secondary" data-modal-close>Anulează</button>
+                    <button type="button" class="btn-primary" id="status-save-btn">
+                        <span class="material-symbols-outlined">save</span>
+                        Salvează
+                    </button>
+                </footer>
+            </div>
+        </div>
+    </div>
+
+    <div id="incident-data" data-update-endpoint="<?= htmlspecialchars(rtrim(BASE_URL, '/') . '/api/incidents/update-status.php') ?>" data-csrf="<?= htmlspecialchars(getCsrfToken()) ?>"></div>
+
+    <?php if ($scriptUrl): ?>
+        <script src="<?= htmlspecialchars($scriptUrl) ?>" defer></script>
+    <?php endif; ?>
+    <?php require_once __DIR__ . '/includes/footer.php'; ?>
+</body>
+</html>

--- a/includes/warehouse_footer.php
+++ b/includes/warehouse_footer.php
@@ -83,6 +83,12 @@ if (in_array($currentPage, $timingCompatiblePages)) {
     echo 'window.TIMING_ENABLED = true;';
     echo '</script>';
 }
+
+// Attach the incident reporting widget for all warehouse pages
+$incidentWidgetPath = BASE_PATH . '/incident-report-worker.php';
+if (file_exists($incidentWidgetPath)) {
+    include $incidentWidgetPath;
+}
 ?>
 </body>
 </html>

--- a/js/incident-report-worker.js
+++ b/js/incident-report-worker.js
@@ -1,0 +1,218 @@
+(function () {
+    const widget = document.getElementById('incident-report-widget');
+    if (!widget) {
+        return;
+    }
+
+    const modal = document.getElementById('incident-modal');
+    const fab = document.getElementById('incident-fab');
+    const form = document.getElementById('incident-form');
+    const toastContainer = document.getElementById('incident-toast');
+    const submitButton = document.getElementById('incident-submit');
+    const photoInput = document.getElementById('incident_photos');
+    const previewContainer = document.getElementById('incident-photo-preview');
+    const occurredInput = document.getElementById('occurred_at');
+
+    const createEndpoint = widget.dataset.createEndpoint;
+    const csrfToken = widget.dataset.csrf;
+    const maxPhotos = parseInt(widget.dataset.maxPhotos || '5', 10);
+    const maxFileSize = 5 * 1024 * 1024; // 5MB
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+
+    let fileBuffer = [];
+
+    const setDefaultDate = () => {
+        if (!occurredInput) {
+            return;
+        }
+        const now = new Date();
+        const offset = now.getTimezoneOffset();
+        const localDate = new Date(now.getTime() - offset * 60000);
+        occurredInput.value = localDate.toISOString().slice(0, 16);
+    };
+
+    const toggleModal = (show) => {
+        if (!modal) return;
+        modal.setAttribute('aria-hidden', show ? 'false' : 'true');
+        if (show) {
+            document.body.classList.add('incident-modal-open');
+        } else {
+            document.body.classList.remove('incident-modal-open');
+        }
+    };
+
+    const createToast = (message, type = 'success') => {
+        if (!toastContainer) return;
+        const toast = document.createElement('div');
+        toast.className = `incident-toast ${type}`;
+        toast.innerHTML = `
+            <span class="material-symbols-outlined">${type === 'success' ? 'task_alt' : 'error'}</span>
+            <span>${message}</span>
+        `;
+        toastContainer.appendChild(toast);
+        setTimeout(() => {
+            toast.classList.add('hide');
+            toast.addEventListener('transitionend', () => toast.remove(), { once: true });
+            toast.style.opacity = '0';
+        }, 4000);
+    };
+
+    const syncInputFiles = () => {
+        if (!photoInput) return;
+        const dataTransfer = new DataTransfer();
+        fileBuffer.forEach((file) => dataTransfer.items.add(file));
+        photoInput.files = dataTransfer.files;
+    };
+
+    const renderPreview = () => {
+        if (!previewContainer) return;
+        previewContainer.innerHTML = '';
+        fileBuffer.forEach((file, index) => {
+            const chip = document.createElement('div');
+            chip.className = 'incident-photo-chip';
+            chip.innerHTML = `
+                <span class="material-symbols-outlined">image</span>
+                <span>${file.name}</span>
+                <button type="button" data-remove="${index}" aria-label="Șterge imaginea">
+                    <span class="material-symbols-outlined">close</span>
+                </button>
+            `;
+            previewContainer.appendChild(chip);
+        });
+    };
+
+    const clearForm = () => {
+        form.reset();
+        fileBuffer = [];
+        syncInputFiles();
+        renderPreview();
+        setDefaultDate();
+    };
+
+    const handleFileSelection = (event) => {
+        const inputFiles = Array.from(event.target.files || []);
+        let added = false;
+
+        inputFiles.forEach((file) => {
+            if (!allowedTypes.includes(file.type)) {
+                createToast('Formatul imaginii nu este acceptat (JPEG/PNG/WebP).', 'error');
+                return;
+            }
+            if (file.size > maxFileSize) {
+                createToast(`Fișierul ${file.name} depășește 5MB.`, 'error');
+                return;
+            }
+            if (fileBuffer.length >= maxPhotos) {
+                createToast('Ai atins limita maximă de fotografii.', 'error');
+                return;
+            }
+            fileBuffer.push(file);
+            added = true;
+        });
+
+        if (added) {
+            syncInputFiles();
+            renderPreview();
+        }
+
+        photoInput.value = '';
+    };
+
+    const handleRemovePhoto = (event) => {
+        const target = event.target.closest('button[data-remove]');
+        if (!target) return;
+        const index = parseInt(target.dataset.remove || '-1', 10);
+        if (Number.isNaN(index)) return;
+        fileBuffer.splice(index, 1);
+        syncInputFiles();
+        renderPreview();
+    };
+
+    const buildFormData = () => {
+        const formData = new FormData(form);
+        formData.delete('photos[]');
+        fileBuffer.forEach((file) => formData.append('photos[]', file));
+        return formData;
+    };
+
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        if (!createEndpoint) {
+            createToast('Endpoint-ul de raportare nu este configurat.', 'error');
+            return;
+        }
+
+        const formData = buildFormData();
+        if (!formData.get('occurred_at')) {
+            createToast('Completează data și ora incidentului.', 'error');
+            return;
+        }
+
+        submitButton.disabled = true;
+        submitButton.classList.add('loading');
+        submitButton.querySelector('.material-symbols-outlined').textContent = 'hourglass_bottom';
+
+        try {
+            const response = await fetch(createEndpoint, {
+                method: 'POST',
+                body: formData,
+                headers: {
+                    'X-CSRF-TOKEN': csrfToken || ''
+                }
+            });
+
+            const result = await response.json();
+            if (!response.ok || result.success === false) {
+                throw new Error(result.message || 'Eroare la raportarea incidentului');
+            }
+
+            createToast(result.message || 'Incident raportat cu succes.', 'success');
+            clearForm();
+            toggleModal(false);
+        } catch (error) {
+            console.error('Incident report error:', error);
+            createToast(error.message || 'Eroare la raportarea incidentului.', 'error');
+        } finally {
+            submitButton.disabled = false;
+            submitButton.classList.remove('loading');
+            submitButton.querySelector('.material-symbols-outlined').textContent = 'send';
+        }
+    };
+
+    const handleCloseClick = (event) => {
+        if (event.target.matches('[data-close="modal"]')) {
+            toggleModal(false);
+        }
+    };
+
+    const handleKeyDown = (event) => {
+        if (event.key === 'Escape') {
+            toggleModal(false);
+        }
+    };
+
+    if (fab) {
+        fab.addEventListener('click', () => {
+            toggleModal(true);
+        });
+    }
+
+    if (modal) {
+        modal.addEventListener('click', handleCloseClick);
+    }
+
+    if (form) {
+        form.addEventListener('submit', handleSubmit);
+    }
+
+    if (photoInput) {
+        photoInput.addEventListener('change', handleFileSelection);
+    }
+
+    if (previewContainer) {
+        previewContainer.addEventListener('click', handleRemovePhoto);
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    setDefaultDate();
+})();

--- a/js/incidents-admin.js
+++ b/js/incidents-admin.js
@@ -1,0 +1,271 @@
+(function () {
+    const detailModal = document.getElementById('incidentDetailModal');
+    const statusModal = document.getElementById('incidentStatusModal');
+    const detailBody = document.getElementById('incident-detail-body');
+    const statusForm = document.getElementById('incident-status-form');
+    const statusSaveBtn = document.getElementById('status-save-btn');
+    const incidentDataEl = document.getElementById('incident-data');
+    const toastContainer = (() => {
+        const container = document.createElement('div');
+        container.className = 'admin-toast-container';
+        document.body.appendChild(container);
+        return container;
+    })();
+
+    const updateEndpoint = incidentDataEl?.dataset.updateEndpoint || '';
+    const csrfToken = incidentDataEl?.dataset.csrf || '';
+    const statusLabels = {
+        reported: 'Raportat',
+        under_review: 'În Revizuire',
+        investigating: 'În Investigare',
+        resolved: 'Rezolvat',
+        rejected: 'Respins'
+    };
+
+    const baseUrl = window.APP_CONFIG?.baseUrl || (window.BASE_URL || '/');
+
+    const openModal = (modal) => {
+        if (!modal) return;
+        modal.setAttribute('aria-hidden', 'false');
+        document.body.classList.add('modal-open');
+    };
+
+    const closeModal = (modal) => {
+        if (!modal) return;
+        modal.setAttribute('aria-hidden', 'true');
+        if (!document.querySelector('.modal[aria-hidden="false"]')) {
+            document.body.classList.remove('modal-open');
+        }
+    };
+
+    const showToast = (message, type = 'success') => {
+        const toast = document.createElement('div');
+        toast.className = `admin-toast ${type}`;
+        toast.innerHTML = `
+            <span class="material-symbols-outlined">${type === 'success' ? 'task_alt' : 'error'}</span>
+            <span>${message}</span>
+        `;
+        toastContainer.appendChild(toast);
+        setTimeout(() => {
+            toast.classList.add('hide');
+            toast.addEventListener('transitionend', () => toast.remove(), { once: true });
+        }, 4000);
+    };
+
+    const formatValue = (value) => {
+        if (value === null || value === undefined || value === '') {
+            return '<span class="text-muted">N/A</span>';
+        }
+        return value;
+    };
+
+    const renderDetailModal = (incident) => {
+        if (!detailBody) return;
+        const locationInfo = [incident.location_code, incident.location_description]
+            .filter(Boolean)
+            .join(' - ');
+        const photos = Array.isArray(incident.photos) ? incident.photos : [];
+        const photoHtml = photos.length
+            ? `<div class="photo-gallery">${photos.map((photo) => {
+                    const url = `${baseUrl.replace(/\/$/, '')}/${photo.file_path}`;
+                    return `<a href="${url}" target="_blank" rel="noopener noreferrer">
+                                <img src="${url}" alt="${photo.original_filename}">
+                            </a>`;
+                }).join('')}</div>`
+            : '<p class="text-muted">Nu există fotografii atașate.</p>';
+
+        detailBody.innerHTML = `
+            <div class="detail-grid">
+                <div class="detail-card">
+                    <span class="label">Număr incident</span>
+                    <span class="value mono">${incident.incident_number}</span>
+                </div>
+                <div class="detail-card">
+                    <span class="label">Tip</span>
+                    <span class="value">${incident.type_label}</span>
+                </div>
+                <div class="detail-card">
+                    <span class="label">Severitate</span>
+                    <span class="value">${incident.severity_label}</span>
+                </div>
+                <div class="detail-card">
+                    <span class="label">Status</span>
+                    <span class="value">${incident.status_label}</span>
+                </div>
+                <div class="detail-card">
+                    <span class="label">Raportant</span>
+                    <span class="value">${incident.reporter_name} (${incident.reporter_email})</span>
+                </div>
+                <div class="detail-card">
+                    <span class="label">Data producerii</span>
+                    <span class="value">${incident.occurred_at_display}</span>
+                </div>
+                <div class="detail-card">
+                    <span class="label">Data raportării</span>
+                    <span class="value">${incident.reported_at_display}</span>
+                </div>
+                <div class="detail-card">
+                    <span class="label">Cost estimativ</span>
+                    <span class="value">${incident.estimated_cost_display}</span>
+                </div>
+                <div class="detail-card">
+                    <span class="label">Locație</span>
+                    <span class="value">${locationInfo || '<span class="text-muted">Nespecificat</span>'}</span>
+                </div>
+            </div>
+            <div class="detail-card">
+                <span class="label">Descriere</span>
+                <p>${formatValue(incident.description)}</p>
+            </div>
+            <div class="detail-card">
+                <span class="label">Note administrator</span>
+                <p>${formatValue(incident.admin_notes)}</p>
+            </div>
+            <div class="detail-card">
+                <span class="label">Note rezolvare</span>
+                <p>${formatValue(incident.resolution_notes)}</p>
+            </div>
+            <div class="detail-card">
+                <span class="label">Documentare foto</span>
+                ${photoHtml}
+            </div>
+        `;
+    };
+
+    const parseIncident = (element) => {
+        const dataset = element.dataset.incident;
+        if (!dataset) return null;
+        try {
+            return JSON.parse(dataset);
+        } catch (error) {
+            console.error('Nu se poate parsa incidentul:', error);
+            return null;
+        }
+    };
+
+    const updateIncidentDataAttributes = (row, incident) => {
+        if (!row) return;
+        const incidentJson = JSON.stringify(incident);
+        row.querySelectorAll('[data-incident]').forEach((btn) => {
+            btn.dataset.incident = incidentJson;
+        });
+    };
+
+    document.addEventListener('click', (event) => {
+        const viewButton = event.target.closest('.view-incident');
+        if (viewButton) {
+            const incident = parseIncident(viewButton);
+            if (incident) {
+                renderDetailModal(incident);
+                openModal(detailModal);
+            }
+            return;
+        }
+
+        const updateButton = event.target.closest('.update-incident');
+        if (updateButton) {
+            const incident = parseIncident(updateButton);
+            if (incident) {
+                statusForm.reset();
+                statusForm.querySelector('#status-incident-id').value = incident.id;
+                statusForm.querySelector('#status-select').value = incident.status;
+                statusForm.querySelector('#status-admin-notes').value = incident.admin_notes || '';
+                statusForm.querySelector('#status-resolution-notes').value = incident.resolution_notes || '';
+                statusForm.querySelector('#status-follow-up').checked = incident.follow_up_required === '1' || incident.follow_up_required === 1;
+                statusForm.dataset.rowSelector = `tr[data-incident-id="${incident.id}"]`;
+                openModal(statusModal);
+            }
+            return;
+        }
+
+        if (event.target.matches('[data-modal-close]')) {
+            const modal = event.target.closest('.modal');
+            closeModal(modal);
+        }
+    });
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+            document.querySelectorAll('.modal[aria-hidden="false"]').forEach((modal) => closeModal(modal));
+        }
+    });
+
+    const updateTableRow = (row, incident) => {
+        if (!row) return;
+        const statusBadge = row.querySelector('.badge.status');
+        if (statusBadge) {
+            statusBadge.textContent = statusLabels[incident.status] || incident.status;
+            statusBadge.className = `badge status ${incident.status}`;
+        }
+        updateIncidentDataAttributes(row, incident);
+    };
+
+    const handleStatusSave = async () => {
+        if (!statusForm || !updateEndpoint) {
+            showToast('Endpoint-ul de actualizare nu este configurat.', 'error');
+            return;
+        }
+
+        const incidentId = statusForm.querySelector('#status-incident-id').value;
+        const statusValue = statusForm.querySelector('#status-select').value;
+        const adminNotes = statusForm.querySelector('#status-admin-notes').value.trim();
+        const resolutionNotes = statusForm.querySelector('#status-resolution-notes').value.trim();
+        const followUp = statusForm.querySelector('#status-follow-up').checked ? 1 : 0;
+
+        if (!incidentId || !statusValue) {
+            showToast('Completează toate câmpurile obligatorii.', 'error');
+            return;
+        }
+
+        statusSaveBtn.disabled = true;
+        statusSaveBtn.querySelector('.material-symbols-outlined').textContent = 'hourglass_bottom';
+
+        try {
+            const response = await fetch(updateEndpoint, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': csrfToken
+                },
+                body: JSON.stringify({
+                    incident_id: incidentId,
+                    status: statusValue,
+                    admin_notes: adminNotes,
+                    resolution_notes: resolutionNotes,
+                    follow_up_required: followUp
+                })
+            });
+
+            const result = await response.json();
+            if (!response.ok || result.success === false) {
+                throw new Error(result.message || 'Actualizarea statusului a eșuat.');
+            }
+
+            const row = document.querySelector(statusForm.dataset.rowSelector || '');
+            if (row) {
+                const incident = parseIncident(row.querySelector('.view-incident'));
+                if (incident) {
+                    incident.status = statusValue;
+                    incident.status_label = statusLabels[statusValue] || statusValue;
+                    incident.admin_notes = adminNotes;
+                    incident.resolution_notes = resolutionNotes;
+                    incident.follow_up_required = followUp;
+                    updateTableRow(row, incident);
+                }
+            }
+
+            showToast(result.message || 'Status actualizat cu succes.');
+            closeModal(statusModal);
+        } catch (error) {
+            console.error('Status update error:', error);
+            showToast(error.message || 'A apărut o eroare la actualizarea statusului.', 'error');
+        } finally {
+            statusSaveBtn.disabled = false;
+            statusSaveBtn.querySelector('.material-symbols-outlined').textContent = 'save';
+        }
+    };
+
+    if (statusSaveBtn) {
+        statusSaveBtn.addEventListener('click', handleStatusSave);
+    }
+})();

--- a/models/Incident.php
+++ b/models/Incident.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * Incident Model
+ * File: models/Incident.php
+ *
+ * Handles CRUD operations for the incident reporting system.
+ */
+
+class Incident {
+    private PDO $db;
+
+    public function __construct(PDO $db) {
+        $this->db = $db;
+    }
+
+    /**
+     * Generate a unique incident number formatted as INCYYYYMMDD###
+     */
+    public function generateIncidentNumber(): string {
+        $prefix = 'INC' . date('Ymd');
+        $stmt = $this->db->prepare("SELECT incident_number FROM incidents WHERE incident_number LIKE :prefix ORDER BY incident_number DESC LIMIT 1");
+        $stmt->execute([':prefix' => $prefix . '%']);
+        $lastNumber = $stmt->fetchColumn();
+
+        if ($lastNumber) {
+            $sequence = (int)substr($lastNumber, -3) + 1;
+        } else {
+            $sequence = 1;
+        }
+
+        return sprintf('%s%03d', $prefix, $sequence);
+    }
+
+    /**
+     * Create an incident and optionally attach photos
+     *
+     * @param array $data
+     * @param array $photos
+     * @return array{id:int,incident_number:string}
+     */
+    public function createIncident(array $data, array $photos = []): array {
+        $incidentNumber = $data['incident_number'] ?? $this->generateIncidentNumber();
+
+        try {
+            $this->db->beginTransaction();
+
+            $stmt = $this->db->prepare("
+                INSERT INTO incidents (
+                    incident_number, reporter_id, incident_type, title, description,
+                    location_id, location_description, severity, status, assigned_admin_id,
+                    admin_notes, resolution_notes, occurred_at, estimated_cost, follow_up_required
+                ) VALUES (
+                    :incident_number, :reporter_id, :incident_type, :title, :description,
+                    :location_id, :location_description, :severity, :status, :assigned_admin_id,
+                    :admin_notes, :resolution_notes, :occurred_at, :estimated_cost, :follow_up_required
+                )
+            ");
+
+            $stmt->execute([
+                ':incident_number' => $incidentNumber,
+                ':reporter_id' => (int)$data['reporter_id'],
+                ':incident_type' => $data['incident_type'],
+                ':title' => $data['title'],
+                ':description' => $data['description'],
+                ':location_id' => $data['location_id'] ?? null,
+                ':location_description' => $data['location_description'] ?? null,
+                ':severity' => $data['severity'] ?? 'medium',
+                ':status' => $data['status'] ?? 'reported',
+                ':assigned_admin_id' => $data['assigned_admin_id'] ?? null,
+                ':admin_notes' => $data['admin_notes'] ?? null,
+                ':resolution_notes' => $data['resolution_notes'] ?? null,
+                ':occurred_at' => $data['occurred_at'],
+                ':estimated_cost' => $data['estimated_cost'] ?? null,
+                ':follow_up_required' => !empty($data['follow_up_required']) ? 1 : 0,
+            ]);
+
+            $incidentId = (int)$this->db->lastInsertId();
+
+            foreach ($photos as $photo) {
+                $this->addPhoto($incidentId, $photo);
+            }
+
+            $this->db->commit();
+
+            return [
+                'id' => $incidentId,
+                'incident_number' => $incidentNumber,
+            ];
+        } catch (Throwable $e) {
+            $this->db->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Fetch all incidents with optional filters
+     */
+    public function getAllIncidents(array $filters = []): array {
+        $sql = "
+            SELECT
+                i.*, 
+                reporter.username AS reporter_name,
+                reporter.email AS reporter_email,
+                assigned.username AS assigned_admin_name,
+                l.location_code AS location_code
+            FROM incidents i
+            INNER JOIN users reporter ON i.reporter_id = reporter.id
+            LEFT JOIN users assigned ON i.assigned_admin_id = assigned.id
+            LEFT JOIN locations l ON i.location_id = l.id
+            WHERE 1=1
+        ";
+
+        $params = [];
+
+        if (!empty($filters['status'])) {
+            $sql .= " AND i.status = :status";
+            $params[':status'] = $filters['status'];
+        }
+
+        if (!empty($filters['incident_type'])) {
+            $sql .= " AND i.incident_type = :incident_type";
+            $params[':incident_type'] = $filters['incident_type'];
+        }
+
+        if (!empty($filters['severity'])) {
+            $sql .= " AND i.severity = :severity";
+            $params[':severity'] = $filters['severity'];
+        }
+
+        if (!empty($filters['search'])) {
+            $sql .= " AND (i.incident_number LIKE :search OR i.title LIKE :search OR reporter.username LIKE :search)";
+            $params[':search'] = '%' . $filters['search'] . '%';
+        }
+
+        $sql .= " ORDER BY i.reported_at DESC";
+
+        $stmt = $this->db->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue($key, $value);
+        }
+        $stmt->execute();
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Update incident status and administrative data
+     */
+    public function updateStatus(int $incidentId, array $payload): bool {
+        $fields = [];
+        $params = [':id' => $incidentId];
+
+        if (!empty($payload['status'])) {
+            $fields[] = 'status = :status';
+            $params[':status'] = $payload['status'];
+        }
+
+        if (array_key_exists('admin_notes', $payload)) {
+            $fields[] = 'admin_notes = :admin_notes';
+            $params[':admin_notes'] = $payload['admin_notes'];
+        }
+
+        if (array_key_exists('resolution_notes', $payload)) {
+            $fields[] = 'resolution_notes = :resolution_notes';
+            $params[':resolution_notes'] = $payload['resolution_notes'];
+        }
+
+        if (array_key_exists('assigned_admin_id', $payload)) {
+            $fields[] = 'assigned_admin_id = :assigned_admin_id';
+            $params[':assigned_admin_id'] = $payload['assigned_admin_id'] ?: null;
+        }
+
+        if (array_key_exists('follow_up_required', $payload)) {
+            $fields[] = 'follow_up_required = :follow_up_required';
+            $params[':follow_up_required'] = !empty($payload['follow_up_required']) ? 1 : 0;
+        }
+
+        $timestamps = [];
+        if (!empty($payload['status'])) {
+            if (in_array($payload['status'], ['under_review', 'investigating'], true)) {
+                $timestamps[] = 'reviewed_at = COALESCE(reviewed_at, NOW())';
+            }
+            if (in_array($payload['status'], ['resolved', 'rejected'], true)) {
+                $timestamps[] = 'resolved_at = NOW()';
+            }
+        }
+
+        if (empty($fields) && empty($timestamps)) {
+            return false;
+        }
+
+        $sql = 'UPDATE incidents SET ' . implode(', ', array_merge($fields, $timestamps)) . ' WHERE id = :id';
+
+        $stmt = $this->db->prepare($sql);
+        return $stmt->execute($params);
+    }
+
+    /**
+     * Attach a photo record to an incident
+     */
+    public function addPhoto(int $incidentId, array $photoData): int {
+        $stmt = $this->db->prepare("
+            INSERT INTO incident_photos (incident_id, file_path, original_filename, file_size, mime_type)
+            VALUES (:incident_id, :file_path, :original_filename, :file_size, :mime_type)
+        ");
+
+        $stmt->execute([
+            ':incident_id' => $incidentId,
+            ':file_path' => $photoData['file_path'],
+            ':original_filename' => $photoData['original_filename'],
+            ':file_size' => $photoData['file_size'],
+            ':mime_type' => $photoData['mime_type'],
+        ]);
+
+        return (int)$this->db->lastInsertId();
+    }
+
+    /**
+     * Retrieve a single incident with photos
+     */
+    public function getIncidentById(int $incidentId): ?array {
+        $stmt = $this->db->prepare("
+            SELECT
+                i.*, reporter.username AS reporter_name, reporter.email AS reporter_email,
+                assigned.username AS assigned_admin_name,
+                l.location_code
+            FROM incidents i
+            INNER JOIN users reporter ON i.reporter_id = reporter.id
+            LEFT JOIN users assigned ON i.assigned_admin_id = assigned.id
+            LEFT JOIN locations l ON i.location_id = l.id
+            WHERE i.id = :id
+        ");
+        $stmt->execute([':id' => $incidentId]);
+        $incident = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$incident) {
+            return null;
+        }
+
+        $photosStmt = $this->db->prepare('SELECT * FROM incident_photos WHERE incident_id = :id ORDER BY uploaded_at ASC');
+        $photosStmt->execute([':id' => $incidentId]);
+        $incident['photos'] = $photosStmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return $incident;
+    }
+
+    /**
+     * Get counts for unresolved incidents grouped by severity
+     */
+    public function getUnresolvedCounts(): array {
+        $stmt = $this->db->query("
+            SELECT severity, COUNT(*) AS total
+            FROM incidents
+            WHERE status NOT IN ('resolved', 'rejected')
+            GROUP BY severity
+        ");
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $counts = ['low' => 0, 'medium' => 0, 'high' => 0, 'critical' => 0];
+        foreach ($rows as $row) {
+            $counts[$row['severity']] = (int)$row['total'];
+        }
+        return $counts;
+    }
+
+    /**
+     * Get total unresolved incidents
+     */
+    public function getUnresolvedTotal(): int {
+        $stmt = $this->db->query("SELECT COUNT(*) FROM incidents WHERE status NOT IN ('resolved', 'rejected')");
+        return (int)$stmt->fetchColumn();
+    }
+}

--- a/styles/incident-report.css
+++ b/styles/incident-report.css
@@ -1,0 +1,286 @@
+/* Incident Reporting Widget Styles */
+:root {
+    --incident-fab-size: 62px;
+}
+
+.incident-widget {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    z-index: 1090;
+    font-family: 'Poppins', sans-serif;
+}
+
+body.incident-modal-open {
+    overflow: hidden;
+}
+
+.incident-fab {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background: var(--attention-color, #ff7b00);
+    color: var(--white, #ffffff);
+    border: none;
+    border-radius: var(--incident-fab-size);
+    padding: 0 22px;
+    height: var(--incident-fab-size);
+    box-shadow: var(--card-shadow, 0 10px 30px rgba(0, 0, 0, 0.35));
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.incident-fab .material-symbols-outlined {
+    font-size: 28px;
+}
+
+.incident-fab:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 12px 34px rgba(0, 0, 0, 0.45);
+}
+
+.incident-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+}
+
+.incident-modal[aria-hidden="false"] {
+    display: flex;
+}
+
+.incident-modal-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 16, 19, 0.7);
+    backdrop-filter: blur(4px);
+}
+
+.incident-modal-content {
+    position: relative;
+    background: var(--surface-background, #1b1d23);
+    color: var(--text-primary, #ffffff);
+    border-radius: 18px;
+    box-shadow: var(--card-shadow, 0 25px 70px rgba(0, 0, 0, 0.45));
+    width: min(760px, 100%);
+    max-height: calc(100vh - 80px);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.incident-modal-header {
+    padding: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--border-color, rgba(255,255,255,0.08));
+}
+
+.incident-modal-header h2 {
+    font-size: 1.4rem;
+    margin: 0;
+    font-weight: 600;
+}
+
+.incident-modal-close {
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 6px;
+    border-radius: 50%;
+    transition: background 0.2s ease;
+}
+
+.incident-modal-close:hover {
+    background: rgba(255,255,255,0.08);
+}
+
+.incident-form {
+    padding: 0 24px 24px;
+    overflow-y: auto;
+}
+
+.incident-form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+}
+
+.incident-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.incident-field label {
+    font-weight: 500;
+    color: var(--text-secondary, #a0a7b5);
+}
+
+.incident-field input,
+.incident-field select,
+.incident-field textarea {
+    background: var(--input-background, rgba(255,255,255,0.04));
+    border: 1px solid var(--input-border, rgba(255,255,255,0.1));
+    border-radius: 12px;
+    padding: 12px 14px;
+    color: var(--text-primary, #ffffff);
+    font-size: 0.95rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.incident-field textarea {
+    resize: vertical;
+    min-height: 110px;
+}
+
+.incident-field input:focus,
+.incident-field select:focus,
+.incident-field textarea:focus {
+    outline: none;
+    border-color: var(--input-focus, rgba(255,255,255,0.35));
+    box-shadow: 0 0 0 2px rgba(255,255,255,0.08);
+}
+
+.incident-field-span {
+    grid-column: 1 / -1;
+}
+
+.incident-help {
+    font-size: 0.8rem;
+    color: var(--text-muted, #7f8698);
+}
+
+.incident-photo-preview {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.incident-photo-chip {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(255,255,255,0.06);
+    border-radius: 12px;
+    padding: 8px 12px;
+    font-size: 0.85rem;
+}
+
+.incident-photo-chip button {
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+}
+
+.incident-modal-footer {
+    margin-top: 24px;
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+}
+
+.btn-secondary,
+.btn-primary {
+    border: none;
+    border-radius: 12px;
+    padding: 12px 20px;
+    font-weight: 600;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-secondary {
+    background: rgba(255,255,255,0.08);
+    color: var(--text-primary, #ffffff);
+}
+
+.btn-secondary:hover {
+    transform: translateY(-1px);
+}
+
+.btn-primary {
+    background: var(--primary-color, #0d6efd);
+    color: #ffffff;
+    box-shadow: 0 10px 30px rgba(13,110,253,0.35);
+}
+
+.btn-primary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 34px rgba(13,110,253,0.45);
+}
+
+.incident-toast-container {
+    position: fixed;
+    bottom: 110px;
+    right: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    pointer-events: none;
+}
+
+.incident-toast {
+    background: rgba(18, 18, 22, 0.95);
+    color: #ffffff;
+    padding: 14px 18px;
+    border-radius: 14px;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.95rem;
+    pointer-events: all;
+    border-left: 4px solid;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.incident-toast.success {
+    border-color: var(--success-color, #198754);
+}
+
+.incident-toast.error {
+    border-color: var(--danger-color, #dc3545);
+}
+
+.incident-toast .material-symbols-outlined {
+    font-size: 22px;
+}
+
+.incident-toast.hide {
+    opacity: 0;
+    transform: translateY(8px);
+}
+
+@media (max-width: 768px) {
+    .incident-widget {
+        right: 16px;
+        bottom: 16px;
+    }
+
+    .incident-fab {
+        padding: 0 18px;
+    }
+
+    .incident-modal-content {
+        width: 100%;
+        max-height: 100vh;
+        border-radius: 0;
+    }
+
+    .incident-modal {
+        padding: 0;
+    }
+}

--- a/styles/incidents-admin.css
+++ b/styles/incidents-admin.css
@@ -1,0 +1,441 @@
+.incidents-admin {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.incident-badges {
+    display: grid;
+    gap: 20px;
+}
+
+.incident-badges .badge-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 16px;
+}
+
+.badge-card {
+    background: var(--surface-background, #1b1d23);
+    border-radius: 16px;
+    padding: 20px;
+    box-shadow: var(--card-shadow, 0 18px 40px rgba(0,0,0,0.25));
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.text-muted {
+    color: var(--text-muted, #9ca3b5);
+    font-style: italic;
+}
+
+.badge-card.total {
+    background: linear-gradient(135deg, #ff7b00, #ff3d71);
+    color: #fff;
+}
+
+.badge-label {
+    font-size: 0.85rem;
+    color: var(--text-muted, #9ca3b5);
+}
+
+.badge-card.total .badge-label {
+    color: rgba(255, 255, 255, 0.8);
+}
+
+.badge-value {
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.badge-card.severity-low {
+    border: 1px solid rgba(40, 199, 111, 0.35);
+}
+
+.badge-card.severity-medium {
+    border: 1px solid rgba(255, 193, 7, 0.35);
+}
+
+.badge-card.severity-high {
+    border: 1px solid rgba(255, 107, 53, 0.35);
+}
+
+.badge-card.severity-critical {
+    border: 1px solid rgba(220, 53, 69, 0.5);
+}
+
+.filters-card {
+    background: var(--surface-background, #1b1d23);
+    border-radius: 18px;
+    padding: 24px;
+    box-shadow: var(--card-shadow, 0 18px 38px rgba(0,0,0,0.2));
+}
+
+.filters-form {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+    align-items: end;
+}
+
+.filter-group {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.filter-group label {
+    font-size: 0.85rem;
+    color: var(--text-secondary, #a0a7b5);
+}
+
+.filter-group select,
+.filter-group input[type="search"] {
+    background: var(--input-background, rgba(255,255,255,0.04));
+    border: 1px solid var(--input-border, rgba(255,255,255,0.12));
+    border-radius: 12px;
+    padding: 12px;
+    color: var(--text-primary, #fff);
+}
+
+.filter-group input[type="search"]::placeholder {
+    color: rgba(255,255,255,0.45);
+}
+
+.filter-actions {
+    display: flex;
+    gap: 12px;
+}
+
+.filter-actions .btn-primary,
+.filter-actions .btn-secondary {
+    height: 48px;
+}
+
+.incidents-table-card {
+    background: var(--surface-background, #1b1d23);
+    border-radius: 18px;
+    padding: 24px;
+    box-shadow: var(--card-shadow, 0 18px 40px rgba(0,0,0,0.25));
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.card-header h2 {
+    font-size: 1.2rem;
+    margin: 0;
+}
+
+.count-pill {
+    background: rgba(255,255,255,0.08);
+    padding: 8px 16px;
+    border-radius: 999px;
+    font-weight: 600;
+    color: var(--text-primary, #fff);
+}
+
+.table.incidents-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.table.incidents-table thead tr {
+    text-align: left;
+    color: var(--text-secondary, #a0a7b5);
+    font-size: 0.85rem;
+}
+
+.table.incidents-table th,
+.table.incidents-table td {
+    padding: 14px 16px;
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+
+.table.incidents-table tbody tr:hover {
+    background: rgba(255,255,255,0.03);
+}
+
+.badge.severity,
+.badge.status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border-radius: 999px;
+    padding: 6px 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.badge.severity.low {
+    background: rgba(40, 199, 111, 0.18);
+    color: #28c76f;
+}
+
+.badge.severity.medium {
+    background: rgba(255, 193, 7, 0.18);
+    color: #ffc107;
+}
+
+.badge.severity.high {
+    background: rgba(255, 107, 53, 0.18);
+    color: #ff6b35;
+}
+
+.badge.severity.critical {
+    background: rgba(220, 53, 69, 0.18);
+    color: #dc3545;
+}
+
+.badge.status.reported { background: rgba(13,110,253,0.2); color: #0d6efd; }
+.badge.status.under_review { background: rgba(102,16,242,0.2); color: #6610f2; }
+.badge.status.investigating { background: rgba(255, 193, 7, 0.2); color: #ffc107; }
+.badge.status.resolved { background: rgba(40, 199, 111, 0.2); color: #28c76f; }
+.badge.status.rejected { background: rgba(220, 53, 69, 0.2); color: #dc3545; }
+
+.action-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.btn-icon {
+    background: rgba(255,255,255,0.06);
+    border: 1px solid transparent;
+    color: var(--text-primary, #fff);
+    border-radius: 12px;
+    padding: 10px 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.btn-icon:hover {
+    background: rgba(255,255,255,0.12);
+    border-color: rgba(255,255,255,0.18);
+}
+
+.empty-state {
+    text-align: center;
+    padding: 40px;
+    color: var(--text-muted, #a0a7b5);
+}
+
+.mono {
+    font-family: 'Fira Code', 'Source Code Pro', monospace;
+    font-size: 0.9rem;
+}
+
+.modal.incident-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(10, 10, 15, 0.65);
+    backdrop-filter: blur(3px);
+    z-index: 2000;
+    padding: 24px;
+}
+
+.modal.incident-modal[aria-hidden="false"] {
+    display: flex;
+}
+
+.modal-dialog {
+    background: var(--surface-background, #1b1d23);
+    border-radius: 18px;
+    width: min(720px, 100%);
+    max-height: 85vh;
+    overflow: hidden;
+    box-shadow: var(--card-shadow, 0 28px 60px rgba(0,0,0,0.4));
+    display: flex;
+    flex-direction: column;
+}
+
+.modal-header,
+.modal-footer {
+    padding: 20px 24px;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+
+.modal-footer {
+    border-bottom: none;
+    border-top: 1px solid rgba(255,255,255,0.08);
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+}
+
+.modal-title {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.modal-close {
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 6px;
+    border-radius: 50%;
+}
+
+.modal-close:hover {
+    background: rgba(255,255,255,0.08);
+}
+
+.modal-body {
+    padding: 24px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.modal-body .detail-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+}
+
+.modal-body .detail-card {
+    background: rgba(255,255,255,0.04);
+    border-radius: 14px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.detail-card .label {
+    font-size: 0.8rem;
+    color: var(--text-muted, #9098aa);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.detail-card .value {
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.photo-gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+}
+
+.photo-gallery a {
+    display: block;
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid rgba(255,255,255,0.08);
+    transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.photo-gallery img {
+    width: 100%;
+    height: 120px;
+    object-fit: cover;
+}
+
+.photo-gallery a:hover {
+    transform: translateY(-4px);
+    border-color: rgba(255,255,255,0.2);
+}
+
+.form-group textarea,
+.form-group select,
+.form-group input,
+.form-check input {
+    width: 100%;
+    background: var(--input-background, rgba(255,255,255,0.05));
+    border: 1px solid var(--input-border, rgba(255,255,255,0.12));
+    border-radius: 12px;
+    padding: 12px;
+    color: var(--text-primary, #fff);
+}
+
+.form-group textarea {
+    min-height: 110px;
+    resize: vertical;
+}
+
+.form-check {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.form-check input[type="checkbox"] {
+    width: auto;
+    height: 18px;
+}
+
+.admin-toast-container {
+    position: fixed;
+    top: 24px;
+    right: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    z-index: 3000;
+}
+
+.admin-toast {
+    background: rgba(18, 18, 24, 0.95);
+    color: #fff;
+    padding: 14px 18px;
+    border-radius: 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    box-shadow: 0 12px 30px rgba(0,0,0,0.35);
+    border-left: 4px solid;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.admin-toast.success { border-color: #28c76f; }
+.admin-toast.error { border-color: #dc3545; }
+
+.admin-toast.hide {
+    opacity: 0;
+    transform: translateY(-6px);
+}
+
+@media (max-width: 1024px) {
+    .filters-form {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+
+    .action-group {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+}
+
+@media (max-width: 768px) {
+    .filters-form {
+        grid-template-columns: 1fr;
+    }
+
+    .filter-actions {
+        justify-content: flex-start;
+    }
+
+    .badge-card.total {
+        grid-column: 1 / -1;
+    }
+}


### PR DESCRIPTION
## Summary
- add database tables and PHP model for storing incidents and related photos
- integrate worker floating incident report modal with dedicated API and assets
- build administrator dashboard with filtering, detail views, and status workflow updates plus supporting documentation

## Testing
- php -l models/Incident.php
- php -l api/incidents/create.php
- php -l api/incidents/update-status.php
- php -l incidents-admin.php
- php -l incident-report-worker.php

------
https://chatgpt.com/codex/tasks/task_e_68d52f3ce6a08320ac45f253755a5d33