### PR TITLE
Improve incident detail modal presentation

### DIFF
--- a/incidents-admin.php
+++ b/incidents-admin.php
@@ -257,7 +257,7 @@ $scriptUrl = file_exists($scriptPath) ? rtrim(BASE_URL, '/') . '/scripts/inciden
             <div class="modal-content">
                 <header class="modal-header">
                     <h2 class="modal-title">Detalii Incident</h2>
-                    <button type="button" class="modal-close" data-modal-close>
+                    <button type="button" class="modal-close" data-modal-close aria-label="Închide fereastra">
                         <span class="material-symbols-outlined">close</span>
                     </button>
                 </header>
@@ -274,7 +274,7 @@ $scriptUrl = file_exists($scriptPath) ? rtrim(BASE_URL, '/') . '/scripts/inciden
             <div class="modal-content">
                 <header class="modal-header">
                     <h2 class="modal-title">Actualizează Status Incident</h2>
-                    <button type="button" class="modal-close" data-modal-close>
+                    <button type="button" class="modal-close" data-modal-close aria-label="Închide fereastra">
                         <span class="material-symbols-outlined">close</span>
                     </button>
                 </header>

--- a/scripts/incidents-admin.js
+++ b/scripts/incidents-admin.js
@@ -56,6 +56,9 @@
         if (value === null || value === undefined || value === '') {
             return '<span class="text-muted">N/A</span>';
         }
+        if (typeof value === 'string') {
+            return value.replace(/\n/g, '<br>');
+        }
         return value;
     };
 
@@ -65,6 +68,7 @@
             .filter(Boolean)
             .join(' - ');
         const photos = Array.isArray(incident.photos) ? incident.photos : [];
+        const followUpRequired = incident.follow_up_required === '1' || incident.follow_up_required === 1;
         const photoHtml = photos.length
             ? `<div class="photo-gallery">${photos.map((photo) => {
                     const url = `${baseUrl.replace(/\/$/, '')}/${photo.file_path}`;
@@ -75,59 +79,70 @@
             : '<p class="text-muted">Nu există fotografii atașate.</p>';
 
         detailBody.innerHTML = `
-            <div class="detail-grid">
-                <div class="detail-card">
-                    <span class="label">Număr incident</span>
-                    <span class="value mono">${incident.incident_number}</span>
-                </div>
-                <div class="detail-card">
-                    <span class="label">Tip</span>
-                    <span class="value">${incident.type_label}</span>
-                </div>
-                <div class="detail-card">
-                    <span class="label">Severitate</span>
-                    <span class="value">${incident.severity_label}</span>
-                </div>
-                <div class="detail-card">
-                    <span class="label">Status</span>
-                    <span class="value">${incident.status_label}</span>
-                </div>
-                <div class="detail-card">
-                    <span class="label">Raportant</span>
-                    <span class="value">${incident.reporter_name} (${incident.reporter_email})</span>
-                </div>
-                <div class="detail-card">
-                    <span class="label">Data producerii</span>
-                    <span class="value">${incident.occurred_at_display}</span>
-                </div>
-                <div class="detail-card">
-                    <span class="label">Data raportării</span>
-                    <span class="value">${incident.reported_at_display}</span>
-                </div>
-                <div class="detail-card">
-                    <span class="label">Cost estimativ</span>
-                    <span class="value">${incident.estimated_cost_display}</span>
-                </div>
-                <div class="detail-card">
-                    <span class="label">Locație</span>
-                    <span class="value">${locationInfo || '<span class="text-muted">Nespecificat</span>'}</span>
-                </div>
-            </div>
-            <div class="detail-card">
-                <span class="label">Descriere</span>
-                <p>${formatValue(incident.description)}</p>
-            </div>
-            <div class="detail-card">
-                <span class="label">Note administrator</span>
-                <p>${formatValue(incident.admin_notes)}</p>
-            </div>
-            <div class="detail-card">
-                <span class="label">Note rezolvare</span>
-                <p>${formatValue(incident.resolution_notes)}</p>
-            </div>
-            <div class="detail-card">
-                <span class="label">Documentare foto</span>
-                ${photoHtml}
+            <div class="detail-layout">
+                <section class="detail-summary">
+                    <div class="detail-grid">
+                        <div class="detail-card">
+                            <span class="label">Număr incident</span>
+                            <span class="value mono">${incident.incident_number}</span>
+                        </div>
+                        <div class="detail-card">
+                            <span class="label">Tip</span>
+                            <span class="value">${incident.type_label}</span>
+                        </div>
+                        <div class="detail-card">
+                            <span class="label">Severitate</span>
+                            <span class="value">${incident.severity_label}</span>
+                        </div>
+                        <div class="detail-card">
+                            <span class="label">Status</span>
+                            <span class="value">${incident.status_label}</span>
+                        </div>
+        
+                        <div class="detail-card">
+                            <span class="label">Raportant</span>
+                            <span class="value">${incident.reporter_name} (${incident.reporter_email})</span>
+                        </div>
+                        <div class="detail-card">
+                            <span class="label">Data producerii</span>
+                            <span class="value">${incident.occurred_at_display}</span>
+                        </div>
+                        <div class="detail-card">
+                            <span class="label">Data raportării</span>
+                            <span class="value">${incident.reported_at_display}</span>
+                        </div>
+                        <div class="detail-card">
+                            <span class="label">Cost estimativ</span>
+                            <span class="value">${incident.estimated_cost_display}</span>
+                        </div>
+                        <div class="detail-card">
+                            <span class="label">Locație</span>
+                            <span class="value">${locationInfo || '<span class="text-muted">Nespecificat</span>'}</span>
+                        </div>
+                        <div class="detail-card">
+                            <span class="label">Acțiuni suplimentare</span>
+                            <span class="value">${followUpRequired ? 'Da' : 'Nu'}</span>
+                        </div>
+                    </div>
+                    <div class="detail-card">
+                        <span class="label">Descriere</span>
+                        <p>${formatValue(incident.description)}</p>
+                    </div>
+                </section>
+                <aside class="detail-meta">
+                    <div class="detail-card">
+                        <span class="label">Note administrator</span>
+                        <p>${formatValue(incident.admin_notes)}</p>
+                    </div>
+                    <div class="detail-card">
+                        <span class="label">Note rezolvare</span>
+                        <p>${formatValue(incident.resolution_notes)}</p>
+                    </div>
+                    <div class="detail-card full-height">
+                        <span class="label">Documentare foto</span>
+                        ${photoHtml}
+                    </div>
+                </aside>
             </div>
         `;
     };
@@ -178,9 +193,11 @@
             return;
         }
 
-        if (event.target.matches('[data-modal-close]')) {
-            const modal = event.target.closest('.modal');
+        const closeTrigger = event.target.closest('[data-modal-close]');
+        if (closeTrigger) {
+            const modal = closeTrigger.closest('.modal');
             closeModal(modal);
+            return;
         }
     });
 

--- a/styles/incidents-admin.css
+++ b/styles/incidents-admin.css
@@ -260,7 +260,7 @@
 .modal-dialog {
     background: var(--container-background);
     border-radius: var(--border-radius-large);
-    width: min(720px, 100%);
+    width: min(960px, 100%);
     max-height: 85vh;
     overflow: hidden;
     box-shadow: var(--base-shadow);
@@ -276,6 +276,12 @@
     background: var(--surface-background);
 }
 
+.modal-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
 .modal-footer {
     border-bottom: none;
     border-top: 1px solid var(--border-color);
@@ -288,6 +294,7 @@
     margin: 0;
     font-size: 1.2rem;
     color: var(--text-primary);
+    font-weight: 600;
 }
 
 .modal-close {
@@ -298,6 +305,11 @@
     padding: 0.4rem;
     border-radius: 50%;
     transition: var(--transition);
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    align-self: flex-start;
 }
 
 .modal-close:hover {
@@ -308,9 +320,27 @@
 .modal-body {
     padding: 1.5rem;
     overflow-y: auto;
+}
+
+.modal-body .detail-layout {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 1.5rem;
+}
+
+.modal-body .detail-summary,
+.modal-body .detail-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.modal-body .detail-summary {
+    flex: 1.2;
+}
+
+.modal-body .detail-meta {
+    flex: 1;
 }
 
 .modal-body .detail-grid {
@@ -327,6 +357,11 @@
     display: flex;
     flex-direction: column;
     gap: 0.4rem;
+}
+
+.modal-body .detail-card.full-height {
+    height: 100%;
+    flex: 1;
 }
 
 .detail-card .label {
@@ -354,17 +389,30 @@
     overflow: hidden;
     border: 1px solid var(--border-color);
     transition: var(--transition);
+    background: var(--surface-background);
 }
 
 .photo-gallery img {
     width: 100%;
-    height: 120px;
+    height: 160px;
     object-fit: cover;
 }
 
 .photo-gallery a:hover {
     transform: translateY(-2px);
     border-color: var(--border-color-strong);
+}
+
+@media (min-width: 992px) {
+    .modal-body .detail-layout {
+        flex-direction: row;
+        align-items: flex-start;
+    }
+
+    .modal-body .detail-summary,
+    .modal-body .detail-meta {
+        flex: 1;
+    }
 }
 
 .form-group textarea,


### PR DESCRIPTION
## Summary
- add accessible labels to modal close buttons and ensure clicks on nested icons close the dialog
- restructure the incident detail modal content to show information side-by-side, support multiline text, and surface follow-up status
- expand modal styling for wider layouts, aligned headers, and improved photo gallery visibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6239fd02883209d944e93fca59f60