### PR TITLE
Improve incidents admin modal responsiveness and styles

### DIFF
--- a/incidents-admin.php
+++ b/incidents-admin.php
@@ -173,11 +173,11 @@ $scriptUrl = file_exists($scriptPath) ? rtrim(BASE_URL, '/') . '/scripts/inciden
                             <input type="search" id="filter-search" name="search" value="<?= htmlspecialchars($filters['search']) ?>" placeholder="Număr, titlu sau raportant">
                         </div>
                         <div class="filter-actions">
-                            <button type="submit" class="btn-primary">
+                            <button type="submit" class="btn btn-primary">
                                 <span class="material-symbols-outlined">filter_alt</span>
                                 Filtrează
                             </button>
-                            <a class="btn-secondary" href="<?= htmlspecialchars($_SERVER['PHP_SELF']) ?>">
+                            <a class="btn btn-secondary" href="<?= htmlspecialchars($_SERVER['PHP_SELF']) ?>">
                                 <span class="material-symbols-outlined">refresh</span>
                                 Resetează
                             </a>
@@ -231,11 +231,11 @@ $scriptUrl = file_exists($scriptPath) ? rtrim(BASE_URL, '/') . '/scripts/inciden
                                             <td><?= htmlspecialchars($incident['reported_at_display']) ?></td>
                                             <td>
                                                 <div class="action-group">
-                                                    <button type="button" class="btn-icon view-incident" data-incident='<?= $incidentJson ?>'>
+                                                    <button type="button" class="btn btn-icon view-incident" data-incident='<?= $incidentJson ?>'>
                                                         <span class="material-symbols-outlined">visibility</span>
                                                         Vezi Detalii
                                                     </button>
-                                                    <button type="button" class="btn-icon update-incident" data-incident='<?= $incidentJson ?>'>
+                                                    <button type="button" class="btn btn-icon update-incident" data-incident='<?= $incidentJson ?>'>
                                                         <span class="material-symbols-outlined">playlist_add_check</span>
                                                         Actualizează Status
                                                     </button>
@@ -263,7 +263,7 @@ $scriptUrl = file_exists($scriptPath) ? rtrim(BASE_URL, '/') . '/scripts/inciden
                 </header>
                 <div class="modal-body" id="incident-detail-body"></div>
                 <footer class="modal-footer">
-                    <button type="button" class="btn-secondary" data-modal-close>Închide</button>
+                    <button type="button" class="btn btn-secondary" data-modal-close>Închide</button>
                 </footer>
             </div>
         </div>
@@ -302,8 +302,8 @@ $scriptUrl = file_exists($scriptPath) ? rtrim(BASE_URL, '/') . '/scripts/inciden
                     </div>
                 </form>
                 <footer class="modal-footer">
-                    <button type="button" class="btn-secondary" data-modal-close>Anulează</button>
-                    <button type="button" class="btn-primary" id="status-save-btn">
+                    <button type="button" class="btn btn-secondary" data-modal-close>Anulează</button>
+                    <button type="button" class="btn btn-primary" id="status-save-btn">
                         <span class="material-symbols-outlined">save</span>
                         Salvează
                     </button>

--- a/styles/incidents-admin.css
+++ b/styles/incidents-admin.css
@@ -101,6 +101,20 @@
     border-radius: var(--border-radius);
     padding: 0.75rem;
     color: var(--text-primary);
+    appearance: none;
+}
+
+.filter-group select,
+.form-group select {
+    background-color: var(--surface-background);
+    border-color: var(--border-color-strong);
+    color: var(--text-primary);
+}
+
+.filter-group select option,
+.form-group select option {
+    background-color: var(--surface-background);
+    color: var(--text-primary);
 }
 
 .filter-group input[type="search"]::placeholder {
@@ -212,22 +226,26 @@
 }
 
 .btn-icon {
-    background: var(--button-background);
-    border: 1px solid transparent;
-    color: var(--text-primary);
+    background: color-mix(in srgb, var(--primary-color) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--primary-color) 45%, transparent);
+    color: var(--primary-color);
     border-radius: var(--border-radius);
-    padding: 0.65rem 0.75rem;
+    padding: 0.65rem 0.9rem;
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 0.5rem;
-    font-size: 0.85rem;
+    font-size: 0.9rem;
+    font-weight: 600;
     cursor: pointer;
     transition: var(--transition);
+    box-shadow: var(--base-shadow);
 }
 
 .btn-icon:hover {
-    background: var(--button-hover);
-    border-color: var(--border-color);
+    background: color-mix(in srgb, var(--primary-color) 25%, transparent);
+    border-color: var(--primary-color);
+    color: var(--white);
 }
 
 .empty-state {
@@ -260,13 +278,20 @@
 .modal-dialog {
     background: var(--container-background);
     border-radius: var(--border-radius-large);
-    width: min(960px, 100%);
-    max-height: 85vh;
+    width: min(1100px, 95vw);
+    max-height: calc(100vh - 3rem);
     overflow: hidden;
     box-shadow: var(--base-shadow);
     border: 1px solid var(--border-color);
     display: flex;
     flex-direction: column;
+}
+
+.modal-content {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    max-height: inherit;
 }
 
 .modal-header,
@@ -320,6 +345,7 @@
 .modal-body {
     padding: 1.5rem;
     overflow-y: auto;
+    flex: 1;
 }
 
 .modal-body .detail-layout {
@@ -401,6 +427,10 @@
 .photo-gallery a:hover {
     transform: translateY(-2px);
     border-color: var(--border-color-strong);
+}
+
+body.modal-open {
+    overflow: hidden;
 }
 
 @media (min-width: 992px) {
@@ -487,6 +517,27 @@
 }
 
 @media (max-width: 768px) {
+    .modal.incident-modal {
+        padding: 0.75rem;
+    }
+
+    .modal-dialog {
+        width: 100%;
+        max-height: calc(100vh - 1.5rem);
+    }
+
+    .modal-body {
+        padding: 1rem;
+    }
+
+    .modal-body .detail-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .photo-gallery {
+        grid-template-columns: 1fr;
+    }
+
     .filters-form {
         grid-template-columns: 1fr;
     }
@@ -497,5 +548,11 @@
 
     .incident-badges {
         grid-template-columns: 1fr;
+    }
+}
+
+@media (min-width: 1200px) {
+    .modal-dialog {
+        width: min(1280px, 92vw);
     }
 }


### PR DESCRIPTION
## Summary
- ensure incidents admin filter, detail, and status buttons use the shared button styles for consistent presentation
- restyle the action buttons and select dropdowns so they remain legible and obvious across themes
- expand the incident detail modal responsiveness to better use large screens while remaining scrollable and stacked on small devices

## Testing
- php -l incidents-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d6310f4c3c83208fe89f96efd9d979