### PR TITLE
Revamp NOTSOWMS landing page layout

### DIFF
--- a/landing.php
+++ b/landing.php
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>NOTSOWMS - Soluții Complete de Gestionare Depozit</title>
+    <title>NOTSOWMS - Enterprise Warehouse Management System</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,300,0,0" rel="stylesheet" />
     <style>
-        /* ===== CSS VARIABLES - MONOCHROME COLOR SCHEME ===== */
         :root {
             --black: #0F1013;
             --dark-gray: #1A1A1D;
@@ -16,12 +16,10 @@
             --light-gray: #94A1B2;
             --lighter-gray: #AAAAAA;
             --white: #FEFFFF;
+            --transition: all 0.35s ease;
         }
 
-        /* ===== GLOBAL STYLES ===== */
-        * {
-            margin: 0;
-            padding: 0;
+        *, *::before, *::after {
             box-sizing: border-box;
         }
 
@@ -30,947 +28,949 @@
         }
 
         body {
+            margin: 0;
             font-family: 'Poppins', sans-serif;
-            background-color: var(--black);
+            background: radial-gradient(circle at top right, rgba(148, 161, 178, 0.12), transparent 45%),
+                        linear-gradient(180deg, var(--black) 0%, var(--darker-gray) 55%, var(--black) 100%);
             color: var(--white);
-            overflow-x: hidden;
-            line-height: 1.6;
+            min-height: 100vh;
         }
 
-        /* Prevent scrolling when mobile menu is open */
-        body.nav-open {
-            overflow: hidden;
+        a {
+            color: inherit;
         }
 
-        .container {
-            max-width: 1200px;
-            margin: 0 auto;
-            padding: 0 2rem;
+        img {
+            max-width: 100%;
+            display: block;
         }
 
-        section {
-            padding: 5rem 0;
-        }
-
-        /* ===== HEADER ===== */
-        .header {
+        header {
             position: fixed;
-            top: 0;
-            width: 100%;
-            background: rgba(15, 16, 19, 0.95);
-            backdrop-filter: blur(20px);
-            -webkit-backdrop-filter: blur(20px); /* Safari support */
+            inset: 0 0 auto 0;
             z-index: 1000;
-            padding: 1rem 0;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-            transition: all 0.3s ease;
-        }
-        
-        /* ===== FIX: ADDED THIS NEW RULE ===== */
-        /* This disables the filter when the menu is open, fixing the layout bug. */
-        .header.nav-open {
-            backdrop-filter: none;
-            -webkit-backdrop-filter: none;
+            background: rgba(15, 16, 19, 0.92);
+            backdrop-filter: blur(18px);
+            border-bottom: 1px solid rgba(148, 161, 178, 0.08);
         }
 
-        .nav {
-            max-width: 1200px;
+        .nav-container {
             margin: 0 auto;
+            max-width: 1180px;
+            padding: 0.9rem 1.5rem;
             display: flex;
-            justify-content: space-between;
             align-items: center;
-            padding: 0 2rem;
+            justify-content: space-between;
+            gap: 1rem;
         }
 
-        .logo {
-            font-size: 1.5rem;
-            font-weight: 500;
+        .brand {
+            display: flex;
+            align-items: center;
+            gap: 0.65rem;
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            text-decoration: none;
+        }
+
+        .brand-icon {
+            display: grid;
+            place-items: center;
+            width: 42px;
+            height: 42px;
+            border-radius: 12px;
+            background: linear-gradient(135deg, rgba(148, 161, 178, 0.16), rgba(148, 161, 178, 0.05));
+            border: 1px solid rgba(148, 161, 178, 0.22);
+            box-shadow: 0 18px 36px rgba(15, 16, 19, 0.45);
             color: var(--white);
-            z-index: 1001; /* Ensure logo is above mobile menu background */
+        }
+
+        nav {
+            display: flex;
+            align-items: center;
+            gap: 2.5rem;
         }
 
         .nav-links {
             display: flex;
+            align-items: center;
+            gap: 1.75rem;
             list-style: none;
-            gap: 2rem;
+            margin: 0;
+            padding: 0;
         }
 
         .nav-links a {
             text-decoration: none;
-            color: var(--lighter-gray);
+            font-size: 0.95rem;
             font-weight: 400;
-            font-size: 0.95rem;
-            transition: color 0.3s ease;
-        }
-
-        .nav-links a:hover {
-            color: var(--white);
-        }
-
-        .cta-button {
-            background-color: var(--white);
-            color: var(--black);
-            padding: 12px 24px;
-            text-decoration: none;
-            border-radius: 4px;
-            font-weight: 500;
-            font-size: 0.95rem;
-            transition: all 0.3s ease;
-        }
-
-        .cta-button:hover {
-            background-color: rgba(255, 255, 255, 0.9);
-            transform: translateY(-2px);
-        }
-        
-        .mobile-menu-toggle {
-            display: none;
-            background: none;
-            border: none;
-            font-size: 1.8rem;
             color: var(--lighter-gray);
-            cursor: pointer;
-            z-index: 1001; 
-            transition: color 0.3s ease;
+            transition: var(--transition);
         }
-        .mobile-menu-toggle:hover {
+
+        .nav-links a:hover,
+        .nav-links a:focus {
             color: var(--white);
         }
 
-        /* ===== HERO SECTION ===== */
-        .hero {
-            min-height: 100vh;
-            padding-top: 80px;
-            display: flex;
+        .language-toggle {
+            display: inline-flex;
             align-items: center;
-            background: linear-gradient(135deg, var(--black) 0%, var(--darker-gray) 100%);
+            gap: 0.35rem;
+            border-radius: 999px;
+            padding: 0.25rem;
+            border: 1px solid rgba(148, 161, 178, 0.22);
+            background: linear-gradient(135deg, rgba(148, 161, 178, 0.1), rgba(26, 26, 29, 0.7));
+            box-shadow: inset 0 0 0 1px rgba(254, 255, 255, 0.05);
+        }
+
+        .language-toggle button {
+            border: none;
+            background: transparent;
+            color: var(--lighter-gray);
+            font-size: 0.82rem;
+            font-weight: 500;
+            padding: 0.35rem 0.85rem;
+            border-radius: 999px;
+            cursor: pointer;
+            transition: var(--transition);
+        }
+
+        .language-toggle button.active {
+            color: var(--black);
+            background: var(--white);
+        }
+
+        .menu-toggle {
+            display: none;
+            border: 1px solid rgba(148, 161, 178, 0.22);
+            background: rgba(26, 26, 29, 0.8);
+            color: var(--white);
+            padding: 0.45rem 0.75rem;
+            border-radius: 10px;
+            cursor: pointer;
+        }
+
+        main {
+            padding-top: 88px;
+        }
+
+        section {
+            padding: 5rem 1.5rem;
+        }
+
+        .section-inner {
+            max-width: 1180px;
+            margin: 0 auto;
+        }
+
+        .section-header {
+            max-width: 720px;
+            margin-bottom: 2.5rem;
+        }
+
+        .section-title {
+            font-size: clamp(1.8rem, 3vw, 2.6rem);
+            font-weight: 600;
+            letter-spacing: 0.02em;
+        }
+
+        .section-subtitle {
+            margin-top: 0.85rem;
+            color: var(--light-gray);
+            font-weight: 400;
+        }
+
+        .hero {
             position: relative;
             overflow: hidden;
         }
 
-        .hero-content {
-            display: grid;
-            grid-template-columns: 1fr 350px;
-            gap: 4rem;
-            align-items: center;
-            width: 100%;
+        .hero::before {
+            content: "";
+            position: absolute;
+            inset: -10% 35% 40% -25%;
+            background: radial-gradient(circle, rgba(148, 161, 178, 0.14), transparent 60%);
+            pointer-events: none;
         }
 
-        .hero-text-content {
-            max-width: 600px;
+        .hero::after {
+            content: "";
+            position: absolute;
+            inset: 35% -25% -20% 40%;
+            background: radial-gradient(circle, rgba(148, 161, 178, 0.1), transparent 65%);
+            pointer-events: none;
+        }
+
+        .hero-grid {
+            position: relative;
+            display: grid;
+            gap: 3rem;
+        }
+
+        .hero-text {
+            display: grid;
+            gap: 1.5rem;
+        }
+
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.7rem;
+            padding: 0.55rem 1rem;
+            border-radius: 999px;
+            background: rgba(148, 161, 178, 0.1);
+            border: 1px solid rgba(148, 161, 178, 0.2);
+            font-size: 0.85rem;
+            font-weight: 500;
+            color: var(--light-gray);
         }
 
         .hero-title {
-            font-size: 3.5rem;
-            font-weight: 500;
-            color: var(--white);
-            margin-bottom: 1rem;
-            line-height: 1.2;
+            font-size: clamp(2.2rem, 4vw, 3.4rem);
+            font-weight: 600;
+            max-width: 720px;
+            line-height: 1.1;
         }
 
-        .hero-divider {
-            width: 60px;
-            height: 2px;
-            background-color: var(--white);
-            margin: 2rem 0;
+        .hero-subtitle {
+            color: var(--lighter-gray);
+            max-width: 640px;
+            font-weight: 400;
         }
 
-        .hero-description {
-            font-size: 1.2rem;
-            color: var(--light-gray);
-            margin-bottom: 3rem;
-            line-height: 1.6;
-        }
-
-        .hero-expertise {
-            margin-bottom: 3rem;
-        }
-
-        .expertise-item {
+        .hero-actions {
             display: flex;
-            align-items: flex-start;
-            margin-bottom: 2rem;
-            gap: 1.5rem;
+            flex-wrap: wrap;
+            gap: 1rem;
+            align-items: center;
         }
 
-        .expertise-number {
-            font-size: 1.2rem;
-            font-weight: 500;
-            color: var(--white);
-            background-color: rgba(255, 255, 255, 0.1);
-            width: 40px;
-            height: 40px;
-            border-radius: 50%;
-            display: flex;
+        .btn {
+            display: inline-flex;
             align-items: center;
             justify-content: center;
-            flex-shrink: 0;
-        }
-
-        .expertise-text h3 {
-            font-size: 1.2rem;
-            color: var(--white);
-            margin-bottom: 0.5rem;
-            font-weight: 500;
-        }
-
-        .expertise-text p {
-            color: var(--lighter-gray);
+            gap: 0.5rem;
+            padding: 0.95rem 1.9rem;
+            border-radius: 12px;
             font-size: 0.95rem;
-            line-height: 1.5;
-        }
-
-        .hero-cta {
-            display: flex;
-            align-items: center;
-            gap: 2rem;
+            font-weight: 600;
+            text-decoration: none;
+            cursor: pointer;
+            transition: var(--transition);
+            border: 1px solid transparent;
         }
 
         .btn-primary {
-            padding: 14px 32px;
-            background-color: var(--white);
+            background: linear-gradient(135deg, var(--white), #d8dce2);
             color: var(--black);
-            border: none;
-            font-size: 1rem;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            border-radius: 4px;
-            text-decoration: none;
-            display: inline-block;
+            box-shadow: 0 20px 48px rgba(15, 16, 19, 0.45);
         }
 
         .btn-primary:hover {
-            background-color: rgba(255, 255, 255, 0.9);
-            transform: translateY(-3px);
+            transform: translateY(-2px);
+            box-shadow: 0 26px 60px rgba(15, 16, 19, 0.55);
         }
 
-        .hero-visual {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            text-align: center;
+        .btn-secondary {
+            background: transparent;
+            color: var(--white);
+            border: 1px solid rgba(148, 161, 178, 0.35);
         }
 
-        .dashboard-mockup {
-            width: 100%;
-            background-color: var(--dark-gray);
-            border-radius: 6px;
-            padding: 2rem;
-            margin-bottom: 2rem;
-            border: 1px solid rgba(255, 255, 255, 0.1);
+        .btn-secondary:hover {
+            transform: translateY(-2px);
+            border-color: rgba(254, 255, 255, 0.6);
         }
 
-        .mockup-header {
-            display: flex;
-            gap: 0.5rem;
-            margin-bottom: 1.5rem;
-        }
-
-        .mockup-dot {
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            background: rgba(255, 255, 255, 0.3);
-        }
-
-        .mockup-content {
-            height: 200px;
-            background: linear-gradient(135deg, var(--darker-gray) 0%, var(--black) 100%);
-            border-radius: 4px;
+        .hero-right {
             position: relative;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .system-preview {
-            color: var(--lighter-gray);
-            font-size: 0.9rem;
-            text-align: center;
-        }
-
-        .clients-section {
-            text-align: center;
-        }
-
-        .clients-label {
-            font-size: 0.9rem;
-            color: var(--lighter-gray);
-            margin-bottom: 1rem;
-        }
-
-        .tech-logos {
-            display: flex;
-            justify-content: center;
-            gap: 1.5rem;
-            align-items: center;
-            flex-wrap: wrap;
-        }
-
-        .tech-logo {
-            padding: 0.5rem 1rem;
-            background-color: rgba(255, 255, 255, 0.05);
-            border: 1px solid rgba(255, 255, 255, 0.1);
-            border-radius: 4px;
-            color: var(--lighter-gray);
-            font-size: 0.85rem;
-            transition: all 0.3s ease;
-        }
-
-        .tech-logo:hover {
-            background-color: rgba(255, 255, 255, 0.1);
-            color: var(--white);
-        }
-
-        .section-header {
-            text-align: center;
-            margin-bottom: 4rem;
-        }
-
-        .section-header h2 {
-            font-size: 2.5rem;
-            font-weight: 500;
-            color: var(--white);
-            margin-bottom: 1rem;
-        }
-
-        .section-divider {
-            width: 60px;
-            height: 2px;
-            background-color: var(--white);
-            margin: 0 auto 2rem;
-        }
-
-        .section-description {
-            font-size: 1.1rem;
-            color: var(--lighter-gray);
-            max-width: 600px;
-            margin: 0 auto;
-            line-height: 1.6;
-        }
-
-        .features {
-            background-color: var(--darker-gray);
-        }
-
-        .features-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-            gap: 2rem;
-        }
-
-        .feature-card {
-            background-color: var(--dark-gray);
+            border-radius: 28px;
             padding: 2.5rem;
-            border-radius: 6px;
-            transition: transform 0.3s ease, box-shadow 0.3s ease;
-            border: 1px solid rgba(255, 255, 255, 0.1);
-        }
-
-        .feature-card:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 10px 20px rgba(0,0,0,0.2);
-        }
-
-        .feature-number {
-            font-size: 1.2rem;
-            font-weight: 500;
-            color: var(--white);
-            background-color: rgba(255, 255, 255, 0.1);
-            width: 40px;
-            height: 40px;
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            margin-bottom: 1.5rem;
-        }
-
-        .feature-card h3 {
-            font-size: 1.25rem;
-            font-weight: 500;
-            margin-bottom: 1rem;
-            color: var(--white);
-        }
-
-        .feature-card p {
-            color: var(--lighter-gray);
-            line-height: 1.6;
-            font-size: 0.95rem;
-        }
-
-        .benefits {
-            background-color: var(--black);
-        }
-
-        .benefits-content {
+            background: linear-gradient(145deg, rgba(26, 26, 29, 0.95), rgba(15, 16, 19, 0.9));
+            border: 1px solid rgba(148, 161, 178, 0.18);
+            box-shadow: 0 38px 72px rgba(15, 16, 19, 0.5);
             display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 4rem;
-            align-items: center;
-        }
-
-        .benefits-text h2 {
-            font-size: 2.5rem;
-            font-weight: 500;
-            margin-bottom: 1.5rem;
-            color: var(--white);
-        }
-
-        .benefits-text p {
-            color: var(--lighter-gray);
-            font-size: 1.1rem;
-            margin-bottom: 2rem;
-            line-height: 1.6;
-        }
-
-        .benefits-list {
-            list-style: none;
-            margin: 2rem 0;
-            display: flex;
-            flex-direction: column;
             gap: 1.5rem;
         }
 
-        .benefit-item {
-            display: flex;
-            align-items: flex-start;
-            gap: 1.5rem;
+        .hero-right::after {
+            content: "";
+            position: absolute;
+            inset: 18px;
+            border-radius: 24px;
+            border: 1px dashed rgba(148, 161, 178, 0.18);
+            pointer-events: none;
         }
 
-        .benefit-number {
-            width: 40px;
-            height: 40px;
-            background-color: rgba(255, 255, 255, 0.1);
-            border-radius: 50%;
+        .hero-right-header {
             display: flex;
             align-items: center;
-            justify-content: center;
-            flex-shrink: 0;
-            font-weight: 500;
-            color: var(--white);
+            justify-content: space-between;
         }
 
-        .benefit-text h4 {
-            color: var(--white);
-            font-size: 1.1rem;
-            margin-bottom: 0.5rem;
+        .hero-right-title {
             font-weight: 500;
-        }
-
-        .benefit-text p {
             color: var(--lighter-gray);
-            font-size: 0.95rem;
-            line-height: 1.5;
         }
 
-        .stats-grid {
+        .integrations-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.65rem;
+        }
+
+        .integration-pill {
+            padding: 0.6rem 1rem;
+            border-radius: 12px;
+            background: rgba(148, 161, 178, 0.08);
+            border: 1px solid rgba(148, 161, 178, 0.18);
+            font-weight: 500;
+            color: var(--light-gray);
+        }
+
+        .dashboard-preview {
             display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 2rem;
+            gap: 1.1rem;
+        }
+
+        .dashboard-card {
+            padding: 1.1rem;
+            border-radius: 14px;
+            border: 1px solid rgba(148, 161, 178, 0.2);
+            background: rgba(148, 161, 178, 0.05);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            color: var(--lighter-gray);
+        }
+
+        .dashboard-card strong {
+            display: block;
+            color: var(--white);
+            font-size: 1.05rem;
+        }
+
+        .hero-stats {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 1.25rem;
+            margin-top: 1rem;
         }
 
         .stat-card {
-            background-color: var(--dark-gray);
-            padding: 2rem;
-            border-radius: 6px;
-            text-align: center;
-            border: 1px solid rgba(255, 255, 255, 0.1);
-            transition: transform 0.3s ease;
+            padding: 1.4rem;
+            border-radius: 16px;
+            background: linear-gradient(140deg, rgba(148, 161, 178, 0.12), rgba(26, 26, 29, 0.75));
+            border: 1px solid rgba(148, 161, 178, 0.18);
+            box-shadow: 0 20px 44px rgba(15, 16, 19, 0.4);
+            display: grid;
+            gap: 0.35rem;
         }
 
-        .stat-card:hover {
-            transform: translateY(-3px);
-        }
-
-        .stat-number {
-            font-size: 2.5rem;
-            font-weight: 500;
-            color: var(--white);
-            margin-bottom: 0.5rem;
+        .stat-value {
+            font-size: 1.85rem;
+            font-weight: 600;
         }
 
         .stat-label {
+            font-size: 0.9rem;
             color: var(--lighter-gray);
-            font-weight: 400;
-            font-size: 0.95rem;
         }
 
-        .process {
-            background-color: var(--darker-gray);
-        }
-
-        .process-timeline {
-            position: relative;
-            max-width: 800px;
-            margin: 0 auto;
-        }
-
-        .process-timeline::before {
-            content: '';
-            position: absolute;
-            left: 29px;
-            top: 0;
-            bottom: 0;
-            width: 2px;
-            background-color: rgba(255, 255, 255, 0.3);
-        }
-
-        .timeline-item {
+        .trusted-bar {
+            margin-top: 2.75rem;
+            padding: 1.1rem 1.5rem;
+            border-radius: 14px;
+            border: 1px solid rgba(148, 161, 178, 0.18);
+            background: rgba(148, 161, 178, 0.05);
             display: flex;
-            align-items: flex-start;
-            margin-bottom: 3rem;
-            position: relative;
-        }
-
-        .timeline-item:last-child {
-            margin-bottom: 0;
-        }
-
-        .timeline-number {
-            width: 60px;
-            height: 60px;
-            background-color: var(--white);
-            color: var(--black);
-            border-radius: 50%;
-            display: flex;
+            flex-wrap: wrap;
+            gap: 1.25rem;
             align-items: center;
-            justify-content: center;
-            font-size: 1.2rem;
-            font-weight: 500;
-            flex-shrink: 0;
-            position: relative;
-            z-index: 2;
-        }
-
-        .timeline-content {
-            margin-left: 2rem;
-            padding: 2rem;
-            background-color: var(--dark-gray);
-            border-radius: 6px;
-            flex: 1;
-            border: 1px solid rgba(255, 255, 255, 0.1);
-        }
-
-        .timeline-content h3 {
-            font-size: 1.3rem;
-            color: var(--white);
-            margin-bottom: 1rem;
-            font-weight: 500;
-        }
-
-        .timeline-content p {
-            color: var(--lighter-gray);
-            line-height: 1.6;
-            font-size: 0.95rem;
-        }
-
-        .cta-section {
-            padding: 6rem 0;
-            background: linear-gradient(135deg, var(--black) 0%, var(--darker-gray) 100%);
-            text-align: center;
-        }
-
-        .cta-content h2 {
-            font-size: 2.5rem;
-            font-weight: 500;
-            margin-bottom: 1rem;
-            color: var(--white);
-        }
-
-        .cta-content p {
-            font-size: 1.2rem;
-            margin-bottom: 2rem;
-            color: var(--lighter-gray);
-        }
-
-        .footer {
-            background: var(--darker-gray);
-            color: var(--lighter-gray);
-            padding: 3rem 0 1rem;
-            text-align: center;
-            border-top: 1px solid rgba(255, 255, 255, 0.1);
-        }
-
-        .footer p {
+            color: var(--light-gray);
             font-size: 0.9rem;
         }
 
-        @media (max-width: 992px) {
-            .hero-content {
-                grid-template-columns: 1fr;
-                text-align: center;
-                gap: 3rem;
-                justify-items: center;
-            }
-            .hero-divider {
-                margin: 2rem auto;
-            }
-            .expertise-item {
-                text-align: left;
-            }
-            .hero-cta {
-                justify-content: center;
-            }
-            .benefits-content {
-                grid-template-columns: 1fr;
-                gap: 3rem;
-                text-align: center;
-            }
-            .benefit-item {
-                text-align: left;
-            }
-            .benefits-text {
-                max-width: 600px;
-                margin: 0 auto;
-            }
+        .trusted-brands {
+            display: flex;
+            gap: 1.5rem;
+            flex-wrap: wrap;
+            font-weight: 500;
+            letter-spacing: 0.05em;
         }
 
-        @media (max-width: 768px) {
-            .cta-button {
-                display: none;
-            }
-            .mobile-menu-toggle {
-                display: block;
-            }
-            
-            .nav-links {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100vh;
-            background-color: var(--black);
+        .cards-grid {
+            display: grid;
+            gap: 1.5rem;
+        }
+
+        .feature-card,
+        .integration-card {
+            position: relative;
+            padding: 2rem;
+            border-radius: 20px;
+            background: linear-gradient(140deg, rgba(148, 161, 178, 0.08), rgba(26, 26, 29, 0.85));
+            border: 1px solid rgba(148, 161, 178, 0.18);
+            box-shadow: 0 26px 52px rgba(15, 16, 19, 0.42);
+            transition: var(--transition);
+        }
+
+        .feature-card:hover,
+        .integration-card:hover {
+            transform: translateY(-6px);
+            border-color: rgba(254, 255, 255, 0.22);
+        }
+
+        .feature-card::after,
+        .integration-card::after {
+            content: "";
+            position: absolute;
+            inset: 1.2rem;
+            border-radius: 16px;
+            border: 1px dashed rgba(148, 161, 178, 0.16);
+            pointer-events: none;
+        }
+
+        .card-icon {
+            width: 54px;
+            height: 54px;
+            border-radius: 14px;
+            background: linear-gradient(135deg, rgba(254, 255, 255, 0.12), rgba(148, 161, 178, 0.08));
+            border: 1px solid rgba(148, 161, 178, 0.2);
+            display: grid;
+            place-items: center;
+            color: var(--white);
+            margin-bottom: 1.25rem;
+        }
+
+        .card-icon .material-symbols-outlined {
+            font-size: 28px;
+        }
+
+        .card-title {
+            font-size: 1.25rem;
+            font-weight: 600;
+            margin-bottom: 0.85rem;
+        }
+
+        .card-list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            display: grid;
+            gap: 0.55rem;
+            color: var(--lighter-gray);
+            font-size: 0.95rem;
+        }
+
+        .card-list li {
+            display: flex;
+            gap: 0.6rem;
+            align-items: flex-start;
+        }
+
+        .card-list li::before {
+            content: '\u2022';
+            color: var(--light-gray);
+            font-weight: 600;
+            margin-top: -0.05rem;
+        }
+
+        .statistics-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 1.5rem;
+            margin-top: 2.5rem;
+        }
+
+        .statistic-card {
+            padding: 1.9rem;
+            border-radius: 20px;
+            border: 1px solid rgba(148, 161, 178, 0.18);
+            background: linear-gradient(140deg, rgba(148, 161, 178, 0.06), rgba(26, 26, 29, 0.85));
+            box-shadow: 0 22px 44px rgba(15, 16, 19, 0.42);
+        }
+
+        .statistic-value {
+            font-size: 2.1rem;
+            font-weight: 600;
+            margin-bottom: 0.45rem;
+        }
+
+        .statistic-label {
+            color: var(--lighter-gray);
+        }
+
+        .cta-section {
+            position: relative;
+            overflow: hidden;
+        }
+
+        .cta-section::before {
+            content: "";
+            position: absolute;
+            inset: -20% -30% 0 -30%;
+            background: radial-gradient(circle at top, rgba(148, 161, 178, 0.16), transparent 60%);
+            pointer-events: none;
+        }
+
+        .cta-card {
+            position: relative;
+            padding: 3.2rem;
+            border-radius: 28px;
+            background: linear-gradient(145deg, rgba(148, 161, 178, 0.12), rgba(26, 26, 29, 0.92));
+            border: 1px solid rgba(148, 161, 178, 0.2);
+            box-shadow: 0 38px 72px rgba(15, 16, 19, 0.5);
+        }
+
+        .cta-card h2 {
+            font-size: clamp(1.9rem, 3vw, 2.8rem);
+            margin-bottom: 1.5rem;
+            font-weight: 600;
+        }
+
+        .cta-card p {
+            color: var(--lighter-gray);
+            max-width: 640px;
+            margin-bottom: 2.25rem;
+        }
+
+        footer {
+            padding: 2.75rem 1.5rem;
+            border-top: 1px solid rgba(148, 161, 178, 0.12);
+            background: var(--black);
+            color: var(--lighter-gray);
+            font-size: 0.9rem;
+        }
+
+        footer .footer-inner {
+            max-width: 1180px;
+            margin: 0 auto;
             display: flex;
             flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            transform: translateX(100%);
-            transition: transform 0.3s ease-in-out;
+            gap: 0.5rem;
         }
 
-        .nav-links.nav-open {
-            transform: translateX(0);
-            height: 100vh;
+        .reveal {
+            opacity: 0;
+            transform: translateY(40px);
+            transition: opacity 0.6s ease, transform 0.6s ease;
         }
-            .nav-links a {
-                font-size: 1.5rem;
-            }
 
-            .hero-title {
-                font-size: 2.5rem;
-            }
-            .hero-description {
-                font-size: 1.1rem;
-            }
-            .hero-cta {
-                flex-direction: column;
+        .reveal.visible {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        @media (min-width: 960px) {
+            .hero-grid {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
                 align-items: center;
-                gap: 1.5rem;
             }
-            .features-grid {
-                grid-template-columns: 1fr;
+
+            .cards-grid.features-grid {
+                grid-template-columns: repeat(3, minmax(0, 1fr));
             }
-            .feature-card {
+
+            .cards-grid.integrations-grid {
+                grid-template-columns: repeat(3, minmax(0, 1fr));
+            }
+        }
+
+        @media (max-width: 960px) {
+            nav {
+                position: fixed;
+                inset: 72px 1.5rem auto 1.5rem;
+                border-radius: 18px;
+                background: rgba(15, 16, 19, 0.95);
+                border: 1px solid rgba(148, 161, 178, 0.16);
+                padding: 1.75rem;
+                flex-direction: column;
+                align-items: stretch;
+                gap: 1.75rem;
+                transform-origin: top right;
+                transform: scale(0.9);
+                opacity: 0;
+                pointer-events: none;
+                transition: var(--transition);
+            }
+
+            nav.open {
+                opacity: 1;
+                pointer-events: auto;
+                transform: scale(1);
+            }
+
+            .nav-links {
+                flex-direction: column;
+                align-items: stretch;
+                gap: 1.25rem;
+            }
+
+            .language-toggle {
+                align-self: flex-end;
+            }
+
+            .menu-toggle {
+                display: inline-flex;
+                align-items: center;
+                gap: 0.35rem;
+            }
+        }
+
+        @media (max-width: 720px) {
+            .hero-actions {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .btn {
+                width: 100%;
+            }
+
+            .hero-right {
                 padding: 2rem;
             }
-            .stats-grid {
-                grid-template-columns: 1fr;
-            }
-            .process-timeline::before {
-                left: 24px;
-            }
-            .timeline-number {
-                width: 50px;
-                height: 50px;
-                font-size: 1rem;
-            }
-            .timeline-content {
-                margin-left: 1.5rem;
-                padding: 1.5rem;
-            }
-        }
 
-        @media (max-width: 576px) {
-            .container, .nav {
-                padding: 0 1rem;
-            }
-            .hero-title {
-                font-size: 2.2rem;
-            }
-            .section-header h2, .benefits-text h2, .cta-content h2 {
-                font-size: 2rem;
-            }
-            .dashboard-mockup {
-                padding: 1.5rem;
+            .cta-card {
+                padding: 2.5rem;
             }
         }
     </style>
 </head>
 <body>
-    <header class="header">
-        <nav class="nav">
-            <div class="logo">NOTSOWMS</div>
-            <ul class="nav-links">
-                <li><a href="#features">Funcționalități</a></li>
-                <li><a href="#benefits">Beneficii</a></li>
-                <li><a href="#process">Proces</a></li>
-                <li><a href="#demo">Contact</a></li>
-            </ul>
-            <a href="mailto:hello@notsomarketing.com?subject=Demo%20Gratuit%20NOTSOWMS" class="cta-button">Demo Gratuit</a>
-            <button class="mobile-menu-toggle" aria-label="Toggle Menu">☰</button>
-        </nav>
+    <header>
+        <div class="nav-container">
+            <a class="brand" href="#hero">
+                <span class="brand-icon material-symbols-outlined">inventory</span>
+                <span>NOTSOWMS</span>
+            </a>
+            <button class="menu-toggle" aria-expanded="false" aria-controls="primary-navigation">
+                <span class="material-symbols-outlined">menu</span>
+                <span class="translate" data-lang-ro="Meniu" data-lang-en="Menu">Meniu</span>
+            </button>
+            <nav id="primary-navigation" aria-label="Primary">
+                <ul class="nav-links">
+                    <li><a class="translate" data-lang-ro="Caracteristici" data-lang-en="Features" href="#features">Caracteristici</a></li>
+                    <li><a class="translate" data-lang-ro="Integrări" data-lang-en="Integrations" href="#integrations">Integrări</a></li>
+                    <li><a class="translate" data-lang-ro="Statistici" data-lang-en="Statistics" href="#statistics">Statistici</a></li>
+                    <li><a class="translate" data-lang-ro="Contact" data-lang-en="Contact" href="#contact">Contact</a></li>
+                </ul>
+                <div class="language-toggle" role="group" aria-label="Language toggle">
+                    <button type="button" class="lang-option active" data-language="ro">RO</button>
+                    <button type="button" class="lang-option" data-language="en">EN</button>
+                </div>
+            </nav>
+        </div>
     </header>
 
-    <section class="hero">
-        <div class="container">
-            <div class="hero-content">
-                <div class="hero-text-content">
-                    <h1 class="hero-title">Soluții tehnice pentru depozite în creștere</h1>
-                    <div class="hero-divider"></div>
-                    <p class="hero-description">Dezvolt sisteme WMS personalizate și automatizări care ajută afacerile românești să funcționeze mai eficient și mai eficace.</p>
-                    <div class="hero-expertise">
-                        <div class="expertise-item">
-                            <div class="expertise-number">1</div>
-                            <div class="expertise-text">
-                                <h3>Gestionare Inteligentă Inventar</h3>
-                                <p>Sisteme complete de urmărire stoc cu scanare mobilă și integrare SmartBill pentru conformitate fiscală românească.</p>
+    <main>
+        <section id="hero" class="hero reveal">
+            <div class="section-inner hero-grid">
+                <div class="hero-text">
+                    <span class="badge">
+                        <span class="material-symbols-outlined">workspace_premium</span>
+                        <span class="translate" data-lang-ro="Soluție enterprise pentru distribuție națională" data-lang-en="Enterprise solution for national distribution">Soluție enterprise pentru distribuție națională</span>
+                    </span>
+                    <h1 class="hero-title translate" data-lang-ro="Sistem enterprise de management al depozitului pentru România" data-lang-en="Enterprise Warehouse Management System for Romania">Sistem enterprise de management al depozitului pentru România</h1>
+                    <p class="hero-subtitle translate" data-lang-ro="Integrare nativă cu SmartBill și Cargus, aliniată la legislația ANAF pentru operațiuni fără blocaje." data-lang-en="Native SmartBill and Cargus integrations, aligned with ANAF regulations for frictionless operations.">Integrare nativă cu SmartBill și Cargus, aliniată la legislația ANAF pentru operațiuni fără blocaje.</p>
+                    <div class="hero-actions">
+                        <a class="btn btn-primary translate" href="#contact" data-lang-ro="Solicită Demo Enterprise" data-lang-en="Request Enterprise Demo">Solicită Demo Enterprise</a>
+                        <a class="btn btn-secondary translate" href="#features" data-lang-ro="Explorează Funcționalitățile" data-lang-en="Explore Features">Explorează Funcționalitățile</a>
+                    </div>
+                    <div class="trusted-bar">
+                        <span class="material-symbols-outlined">verified_user</span>
+                        <span class="translate" data-lang-ro="Ales de lideri din e-commerce, distribuție și 3PL" data-lang-en="Chosen by leaders in e-commerce, distribution, and 3PL">Ales de lideri din e-commerce, distribuție și 3PL</span>
+                        <div class="trusted-brands">
+                            <span>SmartBill</span>
+                            <span>Cargus</span>
+                            <span>ANAF</span>
+                            <span>ERP</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="hero-right">
+                    <div class="hero-right-header">
+                        <span class="hero-right-title translate" data-lang-ro="Turn de control operațional" data-lang-en="Operations control tower">Turn de control operațional</span>
+                        <span class="material-symbols-outlined">monitoring</span>
+                    </div>
+                    <div class="integrations-row">
+                        <span class="integration-pill">SmartBill</span>
+                        <span class="integration-pill">Cargus</span>
+                        <span class="integration-pill">ANAF</span>
+                        <span class="integration-pill">ERP</span>
+                    </div>
+                    <div class="dashboard-preview">
+                        <div class="dashboard-card">
+                            <div>
+                                <strong>SmartBill Sync</strong>
+                                <span class="translate" data-lang-ro="Documente fiscale generate instant" data-lang-en="Fiscal documents generated instantly">Documente fiscale generate instant</span>
                             </div>
+                            <span class="material-symbols-outlined">cloud_sync</span>
                         </div>
-                        <div class="expertise-item">
-                            <div class="expertise-number">2</div>
-                            <div class="expertise-text">
-                                <h3>Automatizarea Proceselor</h3>
-                                <p>Fluxuri de lucru simplificate pentru eliminarea sarcinilor repetitive și optimizarea operațiunilor de depozit.</p>
+                        <div class="dashboard-card">
+                            <div>
+                                <strong>Cargus AWB</strong>
+                                <span class="translate" data-lang-ro="AWB automat pentru fiecare comandă" data-lang-en="Automatic AWB for every order">AWB automat pentru fiecare comandă</span>
                             </div>
+                            <span class="material-symbols-outlined">local_shipping</span>
                         </div>
-                    </div>
-                    <div class="hero-cta">
-                         <a href="#demo" class="btn-primary">Solicită Demo Gratuit</a>
-                    </div>
-                </div>
-                <div class="hero-visual">
-                    <div class="dashboard-mockup">
-                        <div class="mockup-header">
-                            <div class="mockup-dot"></div>
-                            <div class="mockup-dot"></div>
-                            <div class="mockup-dot"></div>
-                        </div>
-                        <div class="mockup-content">
-                            <div class="system-preview">
-                                NOTSOWMS Dashboard<br>
-                                <small>Control complet asupra inventarului</small>
+                        <div class="dashboard-card">
+                            <div>
+                                <strong>ROI Monitor</strong>
+                                <span class="translate" data-lang-ro="Economie medie de 40 ore/lună" data-lang-en="Average saving of 40 hours/month">Economie medie de 40 ore/lună</span>
                             </div>
-                        </div>
-                    </div>
-                    <div class="clients-section">
-                        <p class="clients-label">Integrări și compatibilități</p>
-                        <div class="tech-logos">
-                            <div class="tech-logo">SmartBill</div>
-                            <div class="tech-logo">Mobile Scan</div>
-                            <div class="tech-logo">API REST</div>
-                            <div class="tech-logo">Cloud</div>
+                            <span class="material-symbols-outlined">trending_up</span>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
-    </section>
-    <section class="features" id="features">
-        <div class="container">
-            <div class="section-header">
-                <h2>Capabilități Complete de Gestionare</h2>
-                <div class="section-divider"></div>
-                <p class="section-description">Toate instrumentele necesare pentru operarea eficientă a depozitului, adaptate specificului afacerilor românești.</p>
-            </div>
-            <div class="features-grid">
-                <div class="feature-card">
-                    <div class="feature-number">1</div>
-                    <h3>Gestionare Produse</h3>
-                    <p>Administrare completă produse cu SKU-uri, categorii și prețuri. Sincronizare automată cu sisteme de facturare și contabilitate românești.</p>
+            <div class="section-inner hero-stats">
+                <div class="stat-card">
+                    <span class="stat-value">95%</span>
+                    <span class="stat-label translate" data-lang-ro="Reducere a erorilor operaționale" data-lang-en="Reduction in operational errors">Reducere a erorilor operaționale</span>
                 </div>
-                <div class="feature-card">
-                    <div class="feature-number">2</div>
-                    <h3>Picking Mobil</h3>
-                    <p>Aplicație mobilă pentru echipa de depozit cu scanare coduri QR/barcode și verificare locații în timp real pentru precizie maximă.</p>
+                <div class="stat-card">
+                    <span class="stat-value">60%</span>
+                    <span class="stat-label translate" data-lang-ro="Creștere a eficienței de picking" data-lang-en="Increase in picking efficiency">Creștere a eficienței de picking</span>
                 </div>
-                <div class="feature-card">
-                    <div class="feature-number">3</div>
-                    <h3>Control Inventar</h3>
-                    <p>Monitorizare stocuri în timp real cu alerte automate pentru stoc scăzut și rapoarte detaliate de mișcări inventar.</p>
-                </div>
-                <div class="feature-card">
-                    <div class="feature-number">4</div>
-                    <h3>Management Locații</h3>
-                    <p>Organizare optimă depozit pe zone și locații pentru reducerea timpilor de căutare și optimizarea rutelor de picking.</p>
-                </div>
-                <div class="feature-card">
-                    <div class="feature-number">5</div>
-                    <h3>Procesare Comenzi</h3>
-                    <p>Workflow complet de la primirea comenzii la expediere cu urmărire status și notificări automate pentru clienți.</p>
-                </div>
-                <div class="feature-card">
-                    <div class="feature-number">6</div>
-                    <h3>Integrare SmartBill</h3>
-                    <p>Sincronizare automată cu SmartBill pentru facturare conformă legislației românești și transfer rapid date produse.</p>
+                <div class="stat-card">
+                    <span class="stat-value">24/7</span>
+                    <span class="stat-label translate" data-lang-ro="Suport enterprise dedicat" data-lang-en="Dedicated enterprise support">Suport enterprise dedicat</span>
                 </div>
             </div>
-        </div>
-    </section>
-    <section class="benefits" id="benefits">
-        <div class="container">
-            <div class="benefits-content">
-                <div class="benefits-text">
-                    <h2>De ce NOTSOWMS?</h2>
-                    <p>Sistem dezvoltat specific pentru cerințele afacerilor românești cu focus pe eficiență, precizie și conformitate fiscală.</p>
-                    <div class="benefits-list">
-                        <div class="benefit-item">
-                            <div class="benefit-number">1</div>
-                            <div class="benefit-text">
-                                <h4>Reducerea erorilor cu 95%</h4>
-                                <p>Sisteme de verificare automată și scanare mobile elimină aproape complet erorile umane de inventar.</p>
-                            </div>
-                        </div>
-                        <div class="benefit-item">
-                            <div class="benefit-number">2</div>
-                            <div class="benefit-text">
-                                <h4>Creșterea productivității cu 40%</h4>
-                                <p>Optimizarea rutelor și automatizarea proceselor permite echipei să lucreze mai eficient.</p>
-                            </div>
-                        </div>
-                        <div class="benefit-item">
-                            <div class="benefit-number">3</div>
-                            <div class="benefit-text">
-                                <h4>Conformitate fiscală completă</h4>
-                                <p>Integrare perfectă cu SmartBill și conformitate cu toate cerințele ANAF pentru stocuri și facturare.</p>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="#demo" class="btn-primary">Solicită Demonstrație</a>
+        </section>
+
+        <section id="features" class="reveal">
+            <div class="section-inner">
+                <div class="section-header">
+                    <h2 class="section-title translate" data-lang-ro="Capabilități enterprise care scală cu depozitul tău" data-lang-en="Enterprise capabilities engineered for Romanian logistics">Capabilități enterprise care scală cu depozitul tău</h2>
+                    <p class="section-subtitle translate" data-lang-ro="Automatizăm procesele complexe ale depozitului și eliminăm blocajele operaționale cu fluxuri end-to-end." data-lang-en="Automate complex warehouse processes and eliminate operational bottlenecks with end-to-end flows.">Automatizăm procesele complexe ale depozitului și eliminăm blocajele operaționale cu fluxuri end-to-end.</p>
                 </div>
-                <div class="stats-grid">
-                    <div class="stat-card">
-                        <div class="stat-number">95%</div>
-                        <div class="stat-label">Reducerea Erorilor</div>
+                <div class="cards-grid features-grid">
+                    <article class="feature-card">
+                        <div class="card-icon"><span class="material-symbols-outlined">inventory_2</span></div>
+                        <h3 class="card-title translate" data-lang-ro="Management complet al stocului" data-lang-en="Complete inventory management">Management complet al stocului</h3>
+                        <ul class="card-list">
+                            <li class="translate" data-lang-ro="Trasabilitate lot/serie pentru fiecare mișcare" data-lang-en="Lot and serial traceability for every movement">Trasabilitate lot/serie pentru fiecare mișcare</li>
+                            <li class="translate" data-lang-ro="Reguli de slotting inteligente pentru zone rapide" data-lang-en="Intelligent slotting rules for fast lanes">Reguli de slotting inteligente pentru zone rapide</li>
+                            <li class="translate" data-lang-ro="Control automat al stocurilor de siguranță" data-lang-en="Automated safety stock enforcement">Control automat al stocurilor de siguranță</li>
+                        </ul>
+                    </article>
+                    <article class="feature-card">
+                        <div class="card-icon"><span class="material-symbols-outlined">smartphone</span></div>
+                        <h3 class="card-title translate" data-lang-ro="Aplicații mobile enterprise" data-lang-en="Enterprise mobile applications">Aplicații mobile enterprise</h3>
+                        <ul class="card-list">
+                            <li class="translate" data-lang-ro="Suport Android/iOS cu funcționare offline" data-lang-en="Android/iOS support with offline continuity">Suport Android/iOS cu funcționare offline</li>
+                            <li class="translate" data-lang-ro="Scanare coduri 1D/2D și validări în timp real" data-lang-en="1D/2D scanning with real-time validations">Scanare coduri 1D/2D și validări în timp real</li>
+                            <li class="translate" data-lang-ro="Fluxuri personalizate pentru picking și cross-docking" data-lang-en="Custom flows for picking and cross-docking">Fluxuri personalizate pentru picking și cross-docking</li>
+                        </ul>
+                    </article>
+                    <article class="feature-card">
+                        <div class="card-icon"><span class="material-symbols-outlined">assignment_return</span></div>
+                        <h3 class="card-title translate" data-lang-ro="Management avansat al retururilor" data-lang-en="Advanced returns management">Management avansat al retururilor</h3>
+                        <ul class="card-list">
+                            <li class="translate" data-lang-ro="Procesare automată a retururilor Cargus" data-lang-en="Automated processing for Cargus returns">Procesare automată a retururilor Cargus</li>
+                            <li class="translate" data-lang-ro="Decizii rapide prin workflows aprobate" data-lang-en="Rapid decisions through approved workflows">Decizii rapide prin workflows aprobate</li>
+                            <li class="translate" data-lang-ro="Reconcilieri SmartBill fără erori" data-lang-en="Error-free SmartBill reconciliations">Reconcilieri SmartBill fără erori</li>
+                        </ul>
+                    </article>
+                    <article class="feature-card">
+                        <div class="card-icon"><span class="material-symbols-outlined">verified</span></div>
+                        <h3 class="card-title translate" data-lang-ro="Control al calității integrat" data-lang-en="Integrated quality control">Control al calității integrat</h3>
+                        <ul class="card-list">
+                            <li class="translate" data-lang-ro="Check-list-uri digitale și rapoarte ANAF" data-lang-en="Digital checklists with ANAF-ready reports">Check-list-uri digitale și rapoarte ANAF</li>
+                            <li class="translate" data-lang-ro="Alertare instant pentru deviații critice" data-lang-en="Instant alerts for critical deviations">Alertare instant pentru deviații critice</li>
+                            <li class="translate" data-lang-ro="Audit trail complet și semnătură electronică" data-lang-en="Complete audit trail with electronic signature">Audit trail complet și semnătură electronică</li>
+                        </ul>
+                    </article>
+                    <article class="feature-card">
+                        <div class="card-icon"><span class="material-symbols-outlined">analytics</span></div>
+                        <h3 class="card-title translate" data-lang-ro="Analytics & raportare enterprise" data-lang-en="Enterprise analytics & reporting">Analytics & raportare enterprise</h3>
+                        <ul class="card-list">
+                            <li class="translate" data-lang-ro="KPIs operaționali și financiari în timp real" data-lang-en="Operational and financial KPIs in real time">KPIs operaționali și financiari în timp real</li>
+                            <li class="translate" data-lang-ro="Previziuni AI pentru stocuri sezoniere" data-lang-en="AI forecasting for seasonal stock">Previziuni AI pentru stocuri sezoniere</li>
+                            <li class="translate" data-lang-ro="Exporturi automate către board și ANAF" data-lang-en="Automated exports for board and ANAF">Exporturi automate către board și ANAF</li>
+                        </ul>
+                    </article>
+                    <article class="feature-card">
+                        <div class="card-icon"><span class="material-symbols-outlined">groups</span></div>
+                        <h3 class="card-title translate" data-lang-ro="Management enterprise al utilizatorilor" data-lang-en="Enterprise user management">Management enterprise al utilizatorilor</h3>
+                        <ul class="card-list">
+                            <li class="translate" data-lang-ro="Roluri granulare și politici Zero Trust" data-lang-en="Granular roles with Zero Trust policies">Roluri granulare și politici Zero Trust</li>
+                            <li class="translate" data-lang-ro="SSO și autentificare multi-factor" data-lang-en="SSO and multi-factor authentication">SSO și autentificare multi-factor</li>
+                            <li class="translate" data-lang-ro="Monitorizare a performanței echipelor" data-lang-en="Team performance monitoring">Monitorizare a performanței echipelor</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="integrations" class="reveal">
+            <div class="section-inner">
+                <div class="section-header">
+                    <h2 class="section-title translate" data-lang-ro="Integrări validate pe piața din România" data-lang-en="Integrations built for the Romanian market">Integrări validate pe piața din România</h2>
+                    <p class="section-subtitle translate" data-lang-ro="Operăm cu platformele critice pentru business-urile locale, cu sincronizări sigure și monitorizare permanentă." data-lang-en="Operate with the critical Romanian platforms through secure, continuously monitored integrations.">Operăm cu platformele critice pentru business-urile locale, cu sincronizări sigure și monitorizare permanentă.</p>
+                </div>
+                <div class="cards-grid integrations-grid">
+                    <article class="integration-card">
+                        <div class="card-icon"><span class="material-symbols-outlined">receipt_long</span></div>
+                        <h3 class="card-title">SmartBill</h3>
+                        <ul class="card-list">
+                            <li class="translate" data-lang-ro="Sincronizare automată a facturilor și stocurilor" data-lang-en="Automatic sync of invoices and stock">Sincronizare automată a facturilor și stocurilor</li>
+                            <li class="translate" data-lang-ro="Generare instant de documente fiscale" data-lang-en="Instant fiscal document generation">Generare instant de documente fiscale</li>
+                            <li class="translate" data-lang-ro="Aliniere completă la cerințele ANAF" data-lang-en="Full alignment with ANAF compliance">Aliniere completă la cerințele ANAF</li>
+                        </ul>
+                    </article>
+                    <article class="integration-card">
+                        <div class="card-icon"><span class="material-symbols-outlined">local_shipping</span></div>
+                        <h3 class="card-title">Cargus</h3>
+                        <ul class="card-list">
+                            <li class="translate" data-lang-ro="Generare automată a AWB-urilor" data-lang-en="Automatic AWB generation">Generare automată a AWB-urilor</li>
+                            <li class="translate" data-lang-ro="Tracking în timp real pentru fiecare expediție" data-lang-en="Real-time tracking for every shipment">Tracking în timp real pentru fiecare expediție</li>
+                            <li class="translate" data-lang-ro="Gestionare completă a retururilor" data-lang-en="Complete returns management">Gestionare completă a retururilor</li>
+                        </ul>
+                    </article>
+                    <article class="integration-card">
+                        <div class="card-icon"><span class="material-symbols-outlined">api</span></div>
+                        <h3 class="card-title">Enterprise REST API</h3>
+                        <ul class="card-list">
+                            <li class="translate" data-lang-ro="Autentificare securizată și token management" data-lang-en="Secure authentication and token management">Autentificare securizată și token management</li>
+                            <li class="translate" data-lang-ro="Limitare de trafic și SLA monitorizat" data-lang-en="Rate limiting with monitored SLAs">Limitare de trafic și SLA monitorizat</li>
+                            <li class="translate" data-lang-ro="Documentație completă pentru parteneri" data-lang-en="Comprehensive partner documentation">Documentație completă pentru parteneri</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="statistics" class="reveal">
+            <div class="section-inner">
+                <div class="section-header">
+                    <h2 class="section-title translate" data-lang-ro="Indicatori de performanță obținuți de clienții NOTSOWMS" data-lang-en="Performance indicators delivered by NOTSOWMS">Indicatori de performanță obținuți de clienții NOTSOWMS</h2>
+                    <p class="section-subtitle translate" data-lang-ro="Date validate în proiecte enterprise din e-commerce, distribuție și producție." data-lang-en="Validated data across enterprise projects in e-commerce, distribution, and manufacturing.">Date validate în proiecte enterprise din e-commerce, distribuție și producție.</p>
+                </div>
+                <div class="statistics-grid">
+                    <div class="statistic-card">
+                        <div class="statistic-value">95%</div>
+                        <div class="statistic-label translate" data-lang-ro="Reducere a erorilor de inventar" data-lang-en="Inventory error reduction">Reducere a erorilor de inventar</div>
                     </div>
-                    <div class="stat-card">
-                        <div class="stat-number">40%</div>
-                        <div class="stat-label">Creșterea Eficienței</div>
+                    <div class="statistic-card">
+                        <div class="statistic-value">60%</div>
+                        <div class="statistic-label translate" data-lang-ro="Creștere a eficienței de picking" data-lang-en="Increase in picking efficiency">Creștere a eficienței de picking</div>
                     </div>
-                    <div class="stat-card">
-                        <div class="stat-number">30</div>
-                        <div class="stat-label">Zile Implementare</div>
+                    <div class="statistic-card">
+                        <div class="statistic-value">80%</div>
+                        <div class="statistic-label translate" data-lang-ro="Reducere a timpului de procesare" data-lang-en="Processing time reduction">Reducere a timpului de procesare</div>
                     </div>
-                    <div class="stat-card">
-                        <div class="stat-number">24/7</div>
-                        <div class="stat-label">Suport Tehnic</div>
+                    <div class="statistic-card">
+                        <div class="statistic-value">99.9%</div>
+                        <div class="statistic-label translate" data-lang-ro="Disponibilitate a platformei" data-lang-en="Platform uptime">Disponibilitate a platformei</div>
+                    </div>
+                    <div class="statistic-card">
+                        <div class="statistic-value">15</div>
+                        <div class="statistic-label translate" data-lang-ro="Zile medii de implementare" data-lang-en="Average implementation days">Zile medii de implementare</div>
+                    </div>
+                    <div class="statistic-card">
+                        <div class="statistic-value">24/7</div>
+                        <div class="statistic-label translate" data-lang-ro="Suport enterprise permanent" data-lang-en="Permanent enterprise support">Suport enterprise permanent</div>
                     </div>
                 </div>
             </div>
-        </div>
-    </section>
-    <section class="process" id="process">
-        <div class="container">
-            <div class="section-header">
-                <h2>Procesul de Implementare</h2>
-                <div class="section-divider"></div>
-                <p class="section-description">Implementare rapidă și eficientă în maxim 30 de zile cu suport complet și training pentru echipa ta.</p>
-            </div>
-            <div class="process-timeline">
-                <div class="timeline-item">
-                    <div class="timeline-number">1</div>
-                    <div class="timeline-content">
-                        <h3>Analiză și Planificare</h3>
-                        <p>Analizăm în detaliu operațiunile curente ale depozitului tău și identificăm punctele de optimizare pentru a crea un plan personalizat de implementare.</p>
-                    </div>
-                </div>
-                <div class="timeline-item">
-                    <div class="timeline-number">2</div>
-                    <div class="timeline-content">
-                        <h3>Configurare și Personalizare</h3>
-                        <p>Configurăm sistemul conform cerințelor specifice, includem produsele existente și setăm integrările cu SmartBill și alte sisteme utilizate.</p>
-                    </div>
-                </div>
-                <div class="timeline-item">
-                    <div class="timeline-number">3</div>
-                    <div class="timeline-content">
-                        <h3>Training și Lansare</h3>
-                        <p>Oferim training complet echipei tale și suport în primele săptămâni de utilizare pentru a asigura o tranziție fără probleme.</p>
+        </section>
+
+        <section id="contact" class="cta-section reveal">
+            <div class="section-inner">
+                <div class="cta-card">
+                    <h2 class="translate" data-lang-ro="Transformă-ți operațiunile de depozit în doar câteva săptămâni" data-lang-en="Transform your warehouse operations in weeks">Transformă-ți operațiunile de depozit în doar câteva săptămâni</h2>
+                    <p class="translate" data-lang-ro="Programează un demo personalizat pentru a vedea cum NOTSOWMS conectează SmartBill, Cargus și procesele interne într-o singură platformă enterprise." data-lang-en="Schedule a personalized demo to see how NOTSOWMS connects SmartBill, Cargus, and internal processes into one enterprise platform.">Programează un demo personalizat pentru a vedea cum NOTSOWMS conectează SmartBill, Cargus și procesele interne într-o singură platformă enterprise.</p>
+                    <div class="hero-actions">
+                        <a class="btn btn-primary translate" href="mailto:enterprise@notsowms.ro" data-lang-ro="Rezervă un demo" data-lang-en="Book a demo">Rezervă un demo</a>
+                        <a class="btn btn-secondary translate" href="tel:+40371234567" data-lang-ro="Vorbește cu un consultant" data-lang-en="Speak with a consultant">Vorbește cu un consultant</a>
                     </div>
                 </div>
             </div>
-        </div>
-    </section>
-    <section class="cta-section" id="demo">
-        <div class="container">
-            <div class="cta-content">
-                <h2>Gata să Optimizezi Depozitul?</h2>
-                <p>Începe cu o demonstrație personalizată și vezi cum NOTSOWMS poate transforma operațiunile tale.</p>
-                <a href="mailto:hello@notsomarketing.com?subject=Demo%20Gratuit%20NOTSOWMS&body=Salut,%0A%0AAs%20dori%20să%20programez%20un%20demo%20gratuit%20pentru%20NOTSOWMS.%0A%0AInformații%20despre%20compania%20noastră:%0A-%20Nume%20companie:%20%0A-%20Persoană%20de%20contact:%20%0A-%20Telefon:%20%0A-%20Tipul%20afacerii:%20%0A-%20Mărimea%20depozitului:%20%0A-%20Numărul%20de%20produse%20gestionate:%20%0A-%20Sistemele%20actuale%20utilizate:%20%0A%0AMultumesc%20pentru%20timpul%20acordat!" class="btn-primary">Solicită Demo Gratuit</a>
-            </div>
-        </div>
-    </section>
-    <footer class="footer">
-        <div class="container">
-            <p>&copy; 2025 NOTSOWMS. Toate drepturile rezervate. Soluții tehnice pentru depozite în creștere.</p>
+        </section>
+    </main>
+
+    <footer>
+        <div class="footer-inner">
+            <span>© 2025 NOTSOWMS. All rights reserved.</span>
+            <span class="translate" data-lang-ro="Soluție enterprise de management al depozitelor construită în România." data-lang-en="Enterprise warehouse management solution built in Romania.">Soluție enterprise de management al depozitelor construită în România.</span>
         </div>
     </footer>
 
     <script>
-        document.addEventListener('DOMContentLoaded', function () {
-            
-            const mobileToggle = document.querySelector('.mobile-menu-toggle');
-            const navLinks = document.querySelector('.nav-links');
-            const body = document.querySelector('body');
-            // ===== FIX: Get the header element =====
-            const header = document.querySelector('.header');
+        (function () {
+            const nav = document.getElementById('primary-navigation');
+            const menuToggle = document.querySelector('.menu-toggle');
+            const langButtons = document.querySelectorAll('.lang-option');
+            const translatable = document.querySelectorAll('.translate');
+            const STORAGE_KEY = 'notsowms-language';
 
-            // Toggle menu open/close
-            mobileToggle.addEventListener('click', () => {
-                navLinks.classList.toggle('nav-open');
-                body.classList.toggle('nav-open');
-                // ===== FIX: Toggle the class on the header too =====
-                header.classList.toggle('nav-open');
+            function setLanguage(lang) {
+                document.documentElement.setAttribute('lang', lang);
+                localStorage.setItem(STORAGE_KEY, lang);
+                translatable.forEach(element => {
+                    const ro = element.dataset.langRo;
+                    const en = element.dataset.langEn;
+                    if (lang === 'en' && en) {
+                        element.textContent = en;
+                    } else if (lang === 'ro' && ro) {
+                        element.textContent = ro;
+                    }
+                });
+                langButtons.forEach(button => {
+                    button.classList.toggle('active', button.dataset.language === lang);
+                });
+            }
 
-                if (navLinks.classList.contains('nav-open')) {
-                    mobileToggle.innerHTML = '&times;';
-                    mobileToggle.style.fontSize = '2.5rem';
-                } else {
-                    mobileToggle.innerHTML = '☰';
-                    mobileToggle.style.fontSize = '1.8rem';
-                }
-            });
+            function initLanguage() {
+                const saved = localStorage.getItem(STORAGE_KEY);
+                const initial = saved === 'en' ? 'en' : 'ro';
+                setLanguage(initial);
+            }
 
-            // Close menu when a link is clicked
-            document.querySelectorAll('.nav-links a').forEach(link => {
-                link.addEventListener('click', () => {
-                    if (navLinks.classList.contains('nav-open')) {
-                        navLinks.classList.remove('nav-open');
-                        body.classList.remove('nav-open');
-                        // ===== FIX: Make sure to remove the class from the header =====
-                        header.classList.remove('nav-open');
-                        mobileToggle.innerHTML = '☰';
-                        mobileToggle.style.fontSize = '1.8rem';
+            function toggleMenu(forceState) {
+                const shouldOpen = typeof forceState === 'boolean' ? forceState : !nav.classList.contains('open');
+                nav.classList.toggle('open', shouldOpen);
+                menuToggle.setAttribute('aria-expanded', shouldOpen);
+            }
+
+            langButtons.forEach(button => {
+                button.addEventListener('click', () => {
+                    const lang = button.dataset.language;
+                    setLanguage(lang);
+                    if (nav.classList.contains('open')) {
+                        toggleMenu(false);
                     }
                 });
             });
 
-            // --- Header Style on Scroll ---
-            window.addEventListener('scroll', () => {
-                // We only apply this effect if the menu is not open
-                if (!header.classList.contains('nav-open')) {
-                    if (window.scrollY > 50) {
-                        header.style.background = 'rgba(15, 16, 19, 0.98)';
-                        header.style.boxShadow = '0 2px 10px rgba(0,0,0,0.2)';
-                    } else {
-                        header.style.background = 'rgba(15, 16, 19, 0.95)';
-                        header.style.boxShadow = 'none';
-                    }
+            menuToggle.addEventListener('click', () => toggleMenu());
+
+            document.addEventListener('click', event => {
+                if (!nav.contains(event.target) && !menuToggle.contains(event.target)) {
+                    toggleMenu(false);
                 }
             });
 
-        });
+            const observer = new IntersectionObserver((entries, obs) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add('visible');
+                        obs.unobserve(entry.target);
+                    }
+                });
+            }, {
+                threshold: 0.15
+            });
+
+            document.querySelectorAll('.reveal').forEach(section => observer.observe(section));
+
+            initLanguage();
+        })();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign the NOTSOWMS landing page with a full monochrome enterprise layout inspired by modern SaaS heroes, including navigation, hero, features, integrations, statistics, and CTA sections
- enhance bilingual UX with persistent language toggle, mobile navigation, trusted brands strip, and refreshed dashboard preview cards
- maintain subtle animations, hover states, gradients, and responsive grids for a polished enterprise presentation

## Testing
- php -l landing.php

------
https://chatgpt.com/codex/tasks/task_e_68d80ed6be2c83208cf50869563c2fc9