### PR TITLE
Improve spacing and readability of autoorder email

### DIFF
--- a/models/Inventory.php
+++ b/models/Inventory.php
@@ -2163,37 +2163,47 @@ public function getCriticalStockAlerts(int $limit = 10): array {
         $pret = $context['comanda']['pret_unitar'] ?? 0.0;
         $total = $context['comanda']['valoare_totala'] ?? 0.0;
         $currency = $context['comanda']['currency'] ?? 'RON';
-        $dataGenerarii = date('d.m.Y H:i');
+        $dataGenerarii = date('d.m.Y, ora H:i');
 
         $pretFormatat = number_format((float)$pret, 2, ',', '.');
         $totalFormatat = number_format((float)$total, 2, ',', '.');
 
         $subiect = sprintf('🤖 Autocomandă generată automat - %s (%s)', $orderNumber, $numeProdus);
 
-        $corp = <<<EOT
-Bună ziua,
+        $lines = [
+            'Detalii comandă',
+            '',
+            "Număr comandă: {$orderNumber}",
+            '',
+            "Data generării: {$dataGenerarii}",
+            '',
+            'Tip comandă: Autocomandă generată automat',
+            '',
+            "Denumire produs: {$numeProdus}",
+            '',
+            "Cod / SKU: {$sku}",
+            '',
+            "Cantitate solicitată: {$cantitate} bucăți",
+            '',
+            'Bună ziua,',
+            '',
+            "Sistemul WMS a detectat că produsul \"{$numeProdus}\" (SKU: {$sku}) a atins nivelul minim de stoc și necesită reaprovizionare.",
+            '',
+            'Detalii financiare',
+            '',
+            "Preț unitar estimat: {$pretFormatat} {$currency}",
+            '',
+            "Valoare totală estimată: {$totalFormatat} {$currency}",
+            '',
+            'Această autocomandă a fost creată automat conform pragurilor de stoc configurate în sistem.',
+            '',
+            'Vă mulțumim pentru promptitudine.',
+            '',
+            'Cu stimă,',
+            'Echipa Wartung – Sistem WMS',
+        ];
 
-Sistemul WMS a detectat că produsul "{$numeProdus}" (SKU: {$sku}) a atins nivelul minim de stoc și necesită reaprovizionare.
-
-Detalii comandă:
-  • Număr comandă: {$orderNumber}
-  • Data generării: {$dataGenerarii}
-  • Tip comandă: Autocomandă generată automat
-
-Produs comandat:
-  • Denumire: {$numeProdus}
-  • Cod / SKU: {$sku}
-  • Cantitate solicitată: {$cantitate} bucăți
-  • Preț unitar estimat: {$pretFormatat} {$currency}
-  • Valoare totală estimată: {$totalFormatat} {$currency}
-
-Această autocomandă a fost creată automat conform pragurilor de stoc configurate în sistem.
-
-Vă mulțumim pentru promptitudine.
-
-Cu stimă,
-Echipa Wartung – Sistem WMS
-EOT;
+        $corp = implode(PHP_EOL, $lines);
 
         return [
             'subiect' => $subiect,


### PR DESCRIPTION
## Summary
- restructure the autoorder email body to include blank lines between sections so recipients see clear spacing
- build the email text from an ordered list of lines joined with PHP_EOL for consistent formatting across mail clients

## Testing
- php -l models/Inventory.php

------
https://chatgpt.com/codex/tasks/task_e_68da5eb7a79c8320b7b4e7b3fb9fceb9