### PR TITLE
Add configurable inventory export

### DIFF
--- a/inventory.php
+++ b/inventory.php
@@ -166,6 +166,92 @@ $productFilter = $_GET['product'] ?? '';
 $locationFilter = $_GET['location'] ?? '';
 $lowStockOnly = isset($_GET['low_stock']);
 
+$inventoryExportColumns = [
+    'location_code' => ['label' => 'Locație', 'default' => true],
+    'shelf_level' => ['label' => 'Raft', 'default' => true],
+    'subdivision_number' => ['label' => 'Subdiviziune', 'default' => false],
+    'product_name' => ['label' => 'Produs', 'default' => true],
+    'sku' => ['label' => 'SKU', 'default' => true],
+    'quantity' => ['label' => 'Cantitate', 'default' => true],
+    'batch_number' => ['label' => 'Batch', 'default' => false],
+    'lot_number' => ['label' => 'Lot', 'default' => false],
+    'received_at' => ['label' => 'Data Primirii', 'default' => false],
+    'expiry_date' => ['label' => 'Data Expirării', 'default' => false],
+];
+
+if (isset($_GET['export_inventory'])) {
+    $requestedColumns = isset($_GET['columns']) && is_array($_GET['columns'])
+        ? array_map('strval', $_GET['columns'])
+        : [];
+
+    $availableKeys = array_keys($inventoryExportColumns);
+    $selectedColumns = array_values(array_intersect($requestedColumns, $availableKeys));
+
+    if (empty($selectedColumns)) {
+        $selectedColumns = array_keys(array_filter(
+            $inventoryExportColumns,
+            static fn($cfg) => !empty($cfg['default'])
+        ));
+    }
+
+    $exportRows = $inventoryModel->getInventoryWithFilters($productFilter, $locationFilter, $lowStockOnly);
+
+    header('Content-Type: text/csv');
+    header('Content-Disposition: attachment; filename="inventory_export_' . date('Ymd_His') . '.csv"');
+
+    $out = fopen('php://output', 'w');
+    $headerRow = array_map(static function ($columnKey) use ($inventoryExportColumns) {
+        return $inventoryExportColumns[$columnKey]['label'];
+    }, $selectedColumns);
+    fputcsv($out, $headerRow);
+
+    foreach ($exportRows as $row) {
+        $dataRow = [];
+        foreach ($selectedColumns as $columnKey) {
+            switch ($columnKey) {
+                case 'location_code':
+                    $dataRow[] = $row['location_code'] ?? '';
+                    break;
+                case 'shelf_level':
+                    $level = $row['shelf_level'] ?? '';
+                    $dataRow[] = $level !== null && $level !== '' ? ('Raft ' . $level) : '';
+                    break;
+                case 'subdivision_number':
+                    $sub = $row['subdivision_number'] ?? '';
+                    $dataRow[] = $sub !== null && $sub !== '' ? ('Subdiviziune ' . $sub) : '';
+                    break;
+                case 'product_name':
+                    $dataRow[] = $row['product_name'] ?? ($row['name'] ?? '');
+                    break;
+                case 'sku':
+                    $dataRow[] = $row['sku'] ?? '';
+                    break;
+                case 'quantity':
+                    $dataRow[] = isset($row['quantity']) ? (string)$row['quantity'] : '';
+                    break;
+                case 'batch_number':
+                    $dataRow[] = $row['batch_number'] ?? '';
+                    break;
+                case 'lot_number':
+                    $dataRow[] = $row['lot_number'] ?? '';
+                    break;
+                case 'received_at':
+                    $dataRow[] = !empty($row['received_at']) ? date('Y-m-d', strtotime($row['received_at'])) : '';
+                    break;
+                case 'expiry_date':
+                    $dataRow[] = !empty($row['expiry_date']) ? date('Y-m-d', strtotime($row['expiry_date'])) : '';
+                    break;
+                default:
+                    $dataRow[] = '';
+            }
+        }
+        fputcsv($out, $dataRow);
+    }
+
+    fclose($out);
+    exit;
+}
+
 // Pagination
 $page = max(1, intval($_GET['page'] ?? 1));
 $pageSize = 25;
@@ -312,6 +398,66 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
 <html lang="ro">
 <head>
     <?php require_once __DIR__ . '/includes/header.php'; ?>
+    <style>
+        #exportInventoryModal .export-columns-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 10px;
+        }
+
+        #exportInventoryModal .export-column-option {
+            margin: 0;
+            padding: 8px 10px;
+            border: 1px solid rgba(15, 23, 42, 0.16);
+            border-radius: 10px;
+            background: #f8fafc;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+            cursor: pointer;
+            min-height: 48px;
+        }
+
+        #exportInventoryModal .export-column-option:hover {
+            border-color: rgba(13, 110, 253, 0.5);
+            box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+        }
+
+        #exportInventoryModal .export-column-option input[type="checkbox"] {
+            margin: 0;
+        }
+
+        #exportInventoryModal .export-column-option .export-order-badge {
+            width: 26px;
+            height: 26px;
+            border-radius: 50%;
+            background: #0d6efd;
+            color: #fff;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 600;
+            font-size: 0.85rem;
+            visibility: hidden;
+        }
+
+        #exportInventoryModal .export-column-option.is-selected {
+            border-color: #0d6efd;
+            background: #eef4ff;
+            box-shadow: 0 0 0 1px rgba(13, 110, 253, 0.25);
+        }
+
+        #exportInventoryModal .export-column-option.is-selected .export-order-badge {
+            visibility: visible;
+        }
+
+        #exportInventoryModal .export-column-option .export-label-text {
+            flex: 1;
+            font-weight: 500;
+            color: #1f2937;
+        }
+    </style>
     <title>Gestionare Inventar - WMS</title>
 </head>
 <body>
@@ -334,6 +480,10 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                         <button class="btn btn-secondary" onclick="openImportStockModal()" style="margin-left:10px;">
                             <span class="material-symbols-outlined">upload_file</span>
                             Import Stoc
+                        </button>
+                        <button class="btn btn-outline-secondary" onclick="openExportModal()" style="margin-left:10px;">
+                            <span class="material-symbols-outlined">download</span>
+                            Exportă Inventar
                         </button>
                     </div>
                 </header>
@@ -888,6 +1038,56 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                     </div>
                 </div>
                 <?php endif; ?>
+            </div>
+        </div>
+    </div>
+
+    <!-- Inventory Export Modal -->
+    <div class="modal" id="exportInventoryModal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3 class="modal-title">Export Inventar</h3>
+                    <button class="modal-close" onclick="closeExportModal()">
+                        <span class="material-symbols-outlined">close</span>
+                    </button>
+                </div>
+                <form method="GET" id="inventory-export-form">
+                    <div class="modal-body">
+                        <input type="hidden" name="export_inventory" value="1">
+                        <input type="hidden" name="view" value="<?= htmlspecialchars($view) ?>">
+                        <?php if (!empty($productFilter)): ?>
+                            <input type="hidden" name="product" value="<?= htmlspecialchars($productFilter) ?>">
+                        <?php endif; ?>
+                        <?php if (!empty($locationFilter)): ?>
+                            <input type="hidden" name="location" value="<?= htmlspecialchars($locationFilter) ?>">
+                        <?php endif; ?>
+                        <?php if ($lowStockOnly): ?>
+                            <input type="hidden" name="low_stock" value="1">
+                        <?php endif; ?>
+
+                        <p>Selectează coloanele care vor fi incluse în fișierul exportat. Ordinea din CSV va urma numerele marcate pe fiecare câmp, în funcție de ordinea în care bifezi opțiunile.</p>
+                        <div class="export-columns-grid">
+                            <?php foreach ($inventoryExportColumns as $key => $columnConfig): ?>
+                                <?php $isDefault = !empty($columnConfig['default']); ?>
+                                <label class="export-column-option checkbox-label" data-column="<?= htmlspecialchars($key) ?>">
+                                    <input
+                                        type="checkbox"
+                                        name="columns[]"
+                                        value="<?= htmlspecialchars($key) ?>"
+                                        <?= $isDefault ? 'checked' : '' ?>
+                                    >
+                                    <span class="export-order-badge" aria-hidden="true"></span>
+                                    <span class="export-label-text"><?= htmlspecialchars($columnConfig['label']) ?></span>
+                                </label>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" onclick="closeExportModal()">Anulează</button>
+                        <button type="submit" class="btn btn-primary">Exportă</button>
+                    </div>
+                </form>
             </div>
         </div>
     </div>

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -57,8 +57,22 @@ function addStockForProduct(productId) {
     openAddStockModal(productId);
 }
 
+function openExportModal() {
+    const modal = document.getElementById('exportInventoryModal');
+    if (modal) {
+        modal.classList.add('show');
+    }
+}
+
+function closeExportModal() {
+    const modal = document.getElementById('exportInventoryModal');
+    if (modal) {
+        modal.classList.remove('show');
+    }
+}
+
 window.onclick = function(event) {
-    ['addStockModal','removeStockModal','moveStockModal'].forEach(id => {
+    ['addStockModal','removeStockModal','moveStockModal','exportInventoryModal'].forEach(id => {
         const modal = document.getElementById(id);
         if (event.target === modal) modal.classList.remove('show');
     });
@@ -69,6 +83,7 @@ document.addEventListener('keydown', function(event) {
         closeAddStockModal();
         closeRemoveStockModal();
         closeMoveStockModal();
+        closeExportModal();
     }
 });
 
@@ -199,6 +214,92 @@ async function fetchProductLocation(productId) {
     }
     return false;
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+    const exportForm = document.getElementById('inventory-export-form');
+    if (exportForm) {
+        const columnCheckboxes = Array.from(exportForm.querySelectorAll('input[name="columns[]"]'));
+        const selectionOrder = [];
+
+        columnCheckboxes.forEach((checkbox) => {
+            if (checkbox.checked) {
+                selectionOrder.push(checkbox.value);
+            }
+
+            checkbox.addEventListener('change', () => {
+                const idx = selectionOrder.indexOf(checkbox.value);
+                if (checkbox.checked) {
+                    if (idx === -1) {
+                        selectionOrder.push(checkbox.value);
+                    }
+                } else if (idx !== -1) {
+                    selectionOrder.splice(idx, 1);
+                }
+                refreshColumnOrderUI();
+            });
+        });
+
+        const refreshColumnOrderUI = () => {
+            columnCheckboxes.forEach((checkbox) => {
+                const label = checkbox.closest('.export-column-option');
+                if (!label) return;
+                const badge = label.querySelector('.export-order-badge');
+                const orderIndex = selectionOrder.indexOf(checkbox.value);
+                if (checkbox.checked && orderIndex !== -1) {
+                    label.classList.add('is-selected');
+                    if (badge) {
+                        badge.textContent = orderIndex + 1;
+                    }
+                } else {
+                    label.classList.remove('is-selected');
+                    if (badge) {
+                        badge.textContent = '';
+                    }
+                }
+            });
+        };
+
+        refreshColumnOrderUI();
+
+        exportForm.addEventListener('submit', (event) => {
+            const checked = columnCheckboxes.filter((checkbox) => checkbox.checked);
+            if (!checked.length) {
+                event.preventDefault();
+                alert('Selectează cel puțin o coloană pentru export.');
+                return;
+            }
+
+            const ordered = selectionOrder.filter((value) => checked.some((checkbox) => checkbox.value === value));
+            checked.forEach((checkbox) => {
+                if (!ordered.includes(checkbox.value)) {
+                    ordered.push(checkbox.value);
+                }
+            });
+
+            if (!ordered.length) {
+                event.preventDefault();
+                alert('Selectează cel puțin o coloană pentru export.');
+                return;
+            }
+
+            event.preventDefault();
+
+            const formData = new FormData(exportForm);
+            formData.delete('columns[]');
+            ordered.forEach((value) => formData.append('columns[]', value));
+
+            const params = new URLSearchParams();
+            for (const [key, value] of formData.entries()) {
+                params.append(key, value);
+            }
+
+            const actionAttr = exportForm.getAttribute('action');
+            const targetUrl = actionAttr ? new URL(actionAttr, window.location.href) : new URL(window.location.href);
+            targetUrl.search = params.toString();
+            window.location.href = targetUrl.toString();
+        });
+    }
+});
 
 // -------- Location Levels ---------
 async function loadLocationLevels(locationId) {


### PR DESCRIPTION
## Summary
- add configurable export column definitions and CSV streaming to `inventory.php`
- add an export modal that lets admins choose which inventory fields to include, showing selection order indicators
- update the inventory page script to handle the new modal lifecycle, validation, and ordered column submission

## Testing
- php -l inventory.php

------
https://chatgpt.com/codex/tasks/task_e_68dba8091d20832084bfe537b0a52674