### PR TITLE
Add real-time picking updates to order details modal

### DIFF
--- a/api/warehouse/get_picking_status.php
+++ b/api/warehouse/get_picking_status.php
@@ -1,0 +1,82 @@
+<?php
+// File: api/warehouse/get_picking_status.php - Polling endpoint for order picking progress
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+$config = require BASE_PATH . '/config/config.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$allowedRoles = ['admin', 'warehouse', 'warehouse_worker'];
+if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'] ?? '', $allowedRoles, true)) {
+    http_response_code(403);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Autentificare necesară.'
+    ]);
+    exit;
+}
+
+$orderId = filter_input(INPUT_GET, 'order_id', FILTER_VALIDATE_INT);
+if (!$orderId) {
+    http_response_code(400);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Parametru order_id invalid.'
+    ]);
+    exit;
+}
+
+if (!isset($config['connection_factory']) || !is_callable($config['connection_factory'])) {
+    http_response_code(500);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Configurația bazei de date lipsește.'
+    ]);
+    exit;
+}
+
+try {
+    $dbFactory = $config['connection_factory'];
+    $db = $dbFactory();
+
+    $stmt = $db->prepare(
+        'SELECT 
+            oi.id AS order_item_id,
+            oi.quantity AS quantity_ordered,
+            COALESCE(oi.picked_quantity, 0) AS picked_quantity
+        FROM order_items oi
+        WHERE oi.order_id = :order_id
+        ORDER BY oi.id'
+    );
+    $stmt->execute([':order_id' => $orderId]);
+    $items = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode([
+        'status' => 'success',
+        'data' => [
+            'order_id' => $orderId,
+            'items' => array_map(static function ($item) {
+                return [
+                    'order_item_id' => (int) $item['order_item_id'],
+                    'quantity_ordered' => (int) $item['quantity_ordered'],
+                    'picked_quantity' => (int) $item['picked_quantity']
+                ];
+            }, $items),
+            'fetched_at' => date('c')
+        ]
+    ]);
+} catch (Throwable $e) {
+    error_log('get_picking_status error: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'A apărut o eroare la interogarea bazei de date.'
+    ]);
+}

--- a/styles/orders.css
+++ b/styles/orders.css
@@ -182,6 +182,65 @@
     align-self: flex-start;
 }
 
+/* ===== ORDER DETAILS REALTIME UPDATES ===== */
+.order-details .order-awb-link {
+    color: var(--primary-color);
+    text-decoration: underline;
+    text-underline-offset: 0.2rem;
+    font-weight: 600;
+}
+
+.order-details .order-awb-link:hover {
+    color: var(--primary-color-dark, #0b8457);
+}
+
+.order-details .order-items-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.order-details .order-items-table .order-item-row.item-complete {
+    background-color: rgba(40, 167, 69, 0.12);
+    transition: background-color 0.6s ease;
+}
+
+.order-details .order-items-table .order-item-row.item-complete .picked-quantity-value {
+    color: #155724;
+    font-weight: 600;
+}
+
+.order-details .picked-quantity-cell {
+    position: relative;
+}
+
+.order-details .picked-quantity-value {
+    display: inline-block;
+    min-width: 2.5rem;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    background-color: transparent;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.order-details .picked-quantity-value.quantity-flash {
+    animation: quantityFlash 1s ease forwards;
+}
+
+@keyframes quantityFlash {
+    0% {
+        background-color: rgba(40, 167, 69, 0.65);
+        color: #fff;
+    }
+    60% {
+        background-color: rgba(40, 167, 69, 0.3);
+        color: #fff;
+    }
+    100% {
+        background-color: transparent;
+        color: inherit;
+    }
+}
+
 /* ===== FILTER FORM ===== */
 .filter-form {
     display: flex;


### PR DESCRIPTION
## Summary
- add AJAX polling and progress refresh to the order details modal with AWB link updates
- create a lightweight polling endpoint that returns current picked quantities per line item
- style updated values and completed rows with visual feedback for real-time clarity

## Testing
- php -l api/warehouse/get_picking_status.php

------
https://chatgpt.com/codex/tasks/task_e_68dd5739bb688320982d4ec6c118fdcb