### PR TITLE
Implement real-time updates for orders table

### DIFF
--- a/api/orders/updates.php
+++ b/api/orders/updates.php
@@ -1,0 +1,178 @@
+<?php
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=utf-8');
+
+if (!defined('BASE_PATH')) {
+    $currentDir = __DIR__;
+    $possiblePaths = [
+        dirname($currentDir, 2),
+        dirname($currentDir, 3),
+        $_SERVER['DOCUMENT_ROOT'] ?? null,
+        isset($_SERVER['DOCUMENT_ROOT']) ? rtrim($_SERVER['DOCUMENT_ROOT'], '/') . '/product_wms' : null,
+    ];
+
+    foreach ($possiblePaths as $path) {
+        if ($path && file_exists($path . '/config/config.php')) {
+            define('BASE_PATH', $path);
+            break;
+        }
+    }
+
+    if (!defined('BASE_PATH')) {
+        $scriptDir = dirname($_SERVER['SCRIPT_FILENAME'] ?? __FILE__);
+        $currentPath = $scriptDir;
+        for ($i = 0; $i < 6; $i++) {
+            if (file_exists($currentPath . '/config/config.php')) {
+                define('BASE_PATH', $currentPath);
+                break;
+            }
+            $currentPath = dirname($currentPath);
+        }
+    }
+
+    if (!defined('BASE_PATH')) {
+        http_response_code(500);
+        echo json_encode([
+            'status' => 'error',
+            'message' => 'Nu a putut fi determinată calea de bază a aplicației.'
+        ]);
+        exit;
+    }
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+try {
+    $config = require BASE_PATH . '/config/config.php';
+
+    if (!isset($config['connection_factory']) || !is_callable($config['connection_factory'])) {
+        throw new RuntimeException('Configurația bazei de date este invalidă.');
+    }
+
+    $dbFactory = $config['connection_factory'];
+    $db = $dbFactory();
+
+    require_once BASE_PATH . '/models/Order.php';
+
+    $orderModel = new Order($db);
+
+    $sinceRaw = trim($_GET['since'] ?? '');
+    $statusFilter = strtolower(trim($_GET['status'] ?? ''));
+    $priorityFilter = trim($_GET['priority'] ?? '');
+    $search = trim($_GET['search'] ?? '');
+    $page = max(1, (int)($_GET['page'] ?? 1));
+    $pageSize = max(1, min(100, (int)($_GET['pageSize'] ?? 25)));
+
+    $since = null;
+    if ($sinceRaw !== '') {
+        try {
+            $sinceDate = new DateTimeImmutable($sinceRaw);
+            $since = $sinceDate->format('Y-m-d H:i:s');
+        } catch (Exception $e) {
+            http_response_code(400);
+            echo json_encode([
+                'status' => 'error',
+                'message' => 'Parametrul "since" nu are un format valid ISO8601.'
+            ]);
+            exit;
+        }
+    }
+
+    // Fetch more records than a single page to account for multiple updates.
+    $updates = $orderModel->getOrdersUpdatedSince($since, $statusFilter, $priorityFilter, $search, $pageSize * 2);
+
+    $statusLabels = $orderModel->getStatuses();
+    $priorityLabels = [
+        'normal' => 'Normal',
+        'high' => 'Înaltă',
+        'urgent' => 'Urgentă'
+    ];
+
+    $latestTimestamp = $since ? new DateTimeImmutable($since) : null;
+    $responseOrders = [];
+
+    foreach ($updates as $order) {
+        $orderUpdatedAt = $order['updated_at'] ?? $order['created_at'] ?? $order['order_date'];
+        $updatedAtIso = null;
+        if (!empty($orderUpdatedAt)) {
+            $updatedAtDate = new DateTimeImmutable($orderUpdatedAt);
+            $updatedAtIso = $updatedAtDate->format(DateTimeInterface::ATOM);
+            if ($latestTimestamp === null || $updatedAtDate > $latestTimestamp) {
+                $latestTimestamp = $updatedAtDate;
+            }
+        }
+
+        $orderDateIso = null;
+        if (!empty($order['order_date'])) {
+            $orderDateIso = (new DateTimeImmutable($order['order_date']))->format(DateTimeInterface::ATOM);
+        }
+
+        $awbCreatedAtIso = null;
+        if (!empty($order['awb_created_at'])) {
+            $awbCreatedAtIso = (new DateTimeImmutable($order['awb_created_at']))->format(DateTimeInterface::ATOM);
+        }
+
+        $items = $orderModel->getOrderItems((int)$order['id']);
+        $weightParts = [];
+        $calculatedWeight = 0.0;
+        foreach ($items as $item) {
+            $itemWeightPerUnit = (float)($item['weight_per_unit'] ?? 0);
+            $itemWeight = $itemWeightPerUnit * (int)($item['quantity'] ?? 0);
+            $calculatedWeight += $itemWeight;
+            if ($itemWeightPerUnit > 0) {
+                $weightParts[] = sprintf('%s (%d×%skg)', $item['product_name'] ?? 'Produs', (int)($item['quantity'] ?? 0), number_format($itemWeightPerUnit, 3, '.', ''));
+            }
+        }
+
+        $displayWeight = (float)($order['total_weight'] ?? 0);
+        if ($displayWeight <= 0 && $calculatedWeight > 0) {
+            $displayWeight = $calculatedWeight;
+        }
+
+        $awbBarcode = trim((string)($order['awb_barcode'] ?? ''));
+
+        $responseOrders[] = [
+            'id' => (int)$order['id'],
+            'order_number' => $order['order_number'],
+            'customer_name' => $order['customer_name'],
+            'customer_email' => $order['customer_email'],
+            'status' => strtolower((string)$order['status']),
+            'status_raw' => $order['status'],
+            'status_label' => $statusLabels[strtolower((string)$order['status'])] ?? ucfirst((string)$order['status']),
+            'priority' => strtolower((string)($order['priority'] ?? 'normal')),
+            'priority_label' => $priorityLabels[strtolower((string)($order['priority'] ?? 'normal'))] ?? ucfirst((string)($order['priority'] ?? 'Normal')),
+            'total_value' => (float)($order['total_value'] ?? 0),
+            'total_items' => (int)($order['total_items'] ?? 0),
+            'order_date' => $orderDateIso,
+            'order_date_display' => !empty($order['order_date']) ? date('d.m.Y H:i', strtotime((string)$order['order_date'])) : null,
+            'updated_at' => $updatedAtIso,
+            'awb_barcode' => $awbBarcode,
+            'awb_created_at' => $awbCreatedAtIso,
+            'awb_generation_attempts' => (int)($order['awb_generation_attempts'] ?? 0),
+            'total_weight' => $displayWeight,
+            'weight_display' => $displayWeight > 0 ? number_format($displayWeight, 3, '.', '') : null,
+            'weight_breakdown' => !empty($weightParts) ? implode(' + ', $weightParts) : '',
+            'notes' => $order['notes'] ?? '',
+        ];
+    }
+
+    $latestIso = $latestTimestamp ? $latestTimestamp->format(DateTimeInterface::ATOM) : ($since ? (new DateTimeImmutable($since))->format(DateTimeInterface::ATOM) : null);
+
+    echo json_encode([
+        'status' => 'success',
+        'data' => [
+            'orders' => $responseOrders,
+            'latestTimestamp' => $latestIso,
+            'page' => $page,
+            'pageSize' => $pageSize,
+        ]
+    ]);
+} catch (Throwable $e) {
+    error_log('Order updates error: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'A apărut o eroare la încărcarea actualizărilor de comenzi.'
+    ]);
+}

--- a/scripts/orders_awb.js
+++ b/scripts/orders_awb.js
@@ -139,10 +139,14 @@ async function generateAWBDirect(orderId, manualData = {}) {
             if (window.IS_PICKING_INTERFACE) {
                 document.dispatchEvent(new CustomEvent('awbGenerated', { detail: { orderId, awbCode } }));
             } else {
-                updateOrderAWBStatus(orderId, awbCode, button);
-                setTimeout(() => {
-                    window.location.reload();
-                }, 2000);
+                const generatedForOrder = updateOrderAWBStatus(orderId, awbCode, button);
+                document.dispatchEvent(new CustomEvent('orders:awb-generated', {
+                    detail: {
+                        orderId: Number(orderId),
+                        awbCode,
+                        orderNumber: generatedForOrder
+                    }
+                }));
             }
 
         } else {
@@ -758,8 +762,15 @@ function updateOrderAWBStatus(orderId, barcode, generateBtn) {
                 </button>
             </div>
         `;
-        
+        awbCell.classList.add('awb-update-flash');
+        awbCell.addEventListener('animationend', () => awbCell.classList.remove('awb-update-flash'), { once: true });
     }
+
+    if (row) {
+        row.setAttribute('data-awb', barcode);
+    }
+
+    return orderNumber;
 }
 
 /**

--- a/styles/orders.css
+++ b/styles/orders.css
@@ -115,6 +115,123 @@
     gap: 4px;
 }
 
+/* ===== REALTIME UPDATES ===== */
+.orders-table .order-row-new {
+    animation: ordersNewRowFlash 2.2s ease-out;
+}
+
+.order-status-changed {
+    animation: ordersStatusFlash 1.8s ease-out;
+}
+
+.status-change-flash {
+    animation: ordersStatusBadgeFlash 1.6s ease-out;
+}
+
+.awb-update-flash {
+    animation: ordersAwbFlash 1.6s ease-out;
+}
+
+@keyframes ordersNewRowFlash {
+    0% {
+        background-color: rgba(76, 175, 80, 0.15);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
+@keyframes ordersStatusFlash {
+    0% {
+        background-color: rgba(255, 193, 7, 0.18);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
+@keyframes ordersStatusBadgeFlash {
+    0% {
+        background-color: rgba(255, 193, 7, 0.35);
+    }
+    50% {
+        background-color: rgba(255, 193, 7, 0.12);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
+@keyframes ordersAwbFlash {
+    0% {
+        background-color: rgba(76, 175, 80, 0.18);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
+.orders-toast-container {
+    position: fixed;
+    top: 1.5rem;
+    right: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    z-index: 1200;
+    pointer-events: none;
+}
+
+.orders-toast {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: var(--surface-background);
+    color: var(--text-primary);
+    border-radius: var(--border-radius);
+    padding: 0.75rem 1rem;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+    border-left: 4px solid var(--primary-color);
+    opacity: 0;
+    transform: translateX(16px);
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    pointer-events: auto;
+}
+
+.orders-toast .material-symbols-outlined {
+    font-size: 1.5rem;
+}
+
+.orders-toast.show {
+    opacity: 1;
+    transform: translateX(0);
+}
+
+.orders-toast.hide {
+    opacity: 0;
+    transform: translateX(16px);
+}
+
+.orders-toast-success {
+    border-left-color: var(--success-color, #2e7d32);
+}
+
+.orders-toast-success .material-symbols-outlined {
+    color: var(--success-color, #2e7d32);
+}
+
+.orders-toast-info {
+    border-left-color: var(--primary-color, #2563eb);
+}
+
+.orders-toast-warning {
+    border-left-color: var(--warning-color, #f59e0b);
+}
+
+.orders-toast-message {
+    font-weight: 500;
+}
+
 .modal-close:hover {
     background-color: var(--button-hover);
     color: var(--text-primary);


### PR DESCRIPTION
## Summary
- add an incremental updates API for orders and expose consistent status labels
- update the orders page markup to provide metadata, Romanian labels, and a toast container for live notifications
- implement client polling with animated row/status/AWB refreshes, reusable toasts, and sync AWB generation without reloading
- style new highlight effects and toast notifications for real-time events

## Testing
- php -l orders.php
- php -l models/Order.php
- php -l api/orders/updates.php

------
https://chatgpt.com/codex/tasks/task_e_68dd5fd1d578832091d3b8631abbd5d7