### PR TITLE
Implement real-time updates for orders table

### DIFF
--- a/api/orders/updates.php
+++ b/api/orders/updates.php
@@ -1,0 +1,178 @@
+<?php
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=utf-8');
+
+if (!defined('BASE_PATH')) {
+    $currentDir = __DIR__;
+    $possiblePaths = [
+        dirname($currentDir, 2),
+        dirname($currentDir, 3),
+        $_SERVER['DOCUMENT_ROOT'] ?? null,
+        isset($_SERVER['DOCUMENT_ROOT']) ? rtrim($_SERVER['DOCUMENT_ROOT'], '/') . '/product_wms' : null,
+    ];
+
+    foreach ($possiblePaths as $path) {
+        if ($path && file_exists($path . '/config/config.php')) {
+            define('BASE_PATH', $path);
+            break;
+        }
+    }
+
+    if (!defined('BASE_PATH')) {
+        $scriptDir = dirname($_SERVER['SCRIPT_FILENAME'] ?? __FILE__);
+        $currentPath = $scriptDir;
+        for ($i = 0; $i < 6; $i++) {
+            if (file_exists($currentPath . '/config/config.php')) {
+                define('BASE_PATH', $currentPath);
+                break;
+            }
+            $currentPath = dirname($currentPath);
+        }
+    }
+
+    if (!defined('BASE_PATH')) {
+        http_response_code(500);
+        echo json_encode([
+            'status' => 'error',
+            'message' => 'Nu a putut fi determinată calea de bază a aplicației.'
+        ]);
+        exit;
+    }
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+try {
+    $config = require BASE_PATH . '/config/config.php';
+
+    if (!isset($config['connection_factory']) || !is_callable($config['connection_factory'])) {
+        throw new RuntimeException('Configurația bazei de date este invalidă.');
+    }
+
+    $dbFactory = $config['connection_factory'];
+    $db = $dbFactory();
+
+    require_once BASE_PATH . '/models/Order.php';
+
+    $orderModel = new Order($db);
+
+    $sinceRaw = trim($_GET['since'] ?? '');
+    $statusFilter = strtolower(trim($_GET['status'] ?? ''));
+    $priorityFilter = trim($_GET['priority'] ?? '');
+    $search = trim($_GET['search'] ?? '');
+    $page = max(1, (int)($_GET['page'] ?? 1));
+    $pageSize = max(1, min(100, (int)($_GET['pageSize'] ?? 25)));
+
+    $since = null;
+    if ($sinceRaw !== '') {
+        try {
+            $sinceDate = new DateTimeImmutable($sinceRaw);
+            $since = $sinceDate->format('Y-m-d H:i:s');
+        } catch (Exception $e) {
+            http_response_code(400);
+            echo json_encode([
+                'status' => 'error',
+                'message' => 'Parametrul "since" nu are un format valid ISO8601.'
+            ]);
+            exit;
+        }
+    }
+
+    // Fetch more records than a single page to account for multiple updates.
+    $updates = $orderModel->getOrdersUpdatedSince($since, $statusFilter, $priorityFilter, $search, $pageSize * 2);
+
+    $statusLabels = $orderModel->getStatuses();
+    $priorityLabels = [
+        'normal' => 'Normal',
+        'high' => 'Înaltă',
+        'urgent' => 'Urgentă'
+    ];
+
+    $latestTimestamp = $since ? new DateTimeImmutable($since) : null;
+    $responseOrders = [];
+
+    foreach ($updates as $order) {
+        $orderUpdatedAt = $order['updated_at'] ?? $order['created_at'] ?? $order['order_date'];
+        $updatedAtIso = null;
+        if (!empty($orderUpdatedAt)) {
+            $updatedAtDate = new DateTimeImmutable($orderUpdatedAt);
+            $updatedAtIso = $updatedAtDate->format(DateTimeInterface::ATOM);
+            if ($latestTimestamp === null || $updatedAtDate > $latestTimestamp) {
+                $latestTimestamp = $updatedAtDate;
+            }
+        }
+
+        $orderDateIso = null;
+        if (!empty($order['order_date'])) {
+            $orderDateIso = (new DateTimeImmutable($order['order_date']))->format(DateTimeInterface::ATOM);
+        }
+
+        $awbCreatedAtIso = null;
+        if (!empty($order['awb_created_at'])) {
+            $awbCreatedAtIso = (new DateTimeImmutable($order['awb_created_at']))->format(DateTimeInterface::ATOM);
+        }
+
+        $items = $orderModel->getOrderItems((int)$order['id']);
+        $weightParts = [];
+        $calculatedWeight = 0.0;
+        foreach ($items as $item) {
+            $itemWeightPerUnit = (float)($item['weight_per_unit'] ?? 0);
+            $itemWeight = $itemWeightPerUnit * (int)($item['quantity'] ?? 0);
+            $calculatedWeight += $itemWeight;
+            if ($itemWeightPerUnit > 0) {
+                $weightParts[] = sprintf('%s (%d×%skg)', $item['product_name'] ?? 'Produs', (int)($item['quantity'] ?? 0), number_format($itemWeightPerUnit, 3, '.', ''));
+            }
+        }
+
+        $displayWeight = (float)($order['total_weight'] ?? 0);
+        if ($displayWeight <= 0 && $calculatedWeight > 0) {
+            $displayWeight = $calculatedWeight;
+        }
+
+        $awbBarcode = trim((string)($order['awb_barcode'] ?? ''));
+
+        $responseOrders[] = [
+            'id' => (int)$order['id'],
+            'order_number' => $order['order_number'],
+            'customer_name' => $order['customer_name'],
+            'customer_email' => $order['customer_email'],
+            'status' => strtolower((string)$order['status']),
+            'status_raw' => $order['status'],
+            'status_label' => $statusLabels[strtolower((string)$order['status'])] ?? ucfirst((string)$order['status']),
+            'priority' => strtolower((string)($order['priority'] ?? 'normal')),
+            'priority_label' => $priorityLabels[strtolower((string)($order['priority'] ?? 'normal'))] ?? ucfirst((string)($order['priority'] ?? 'Normal')),
+            'total_value' => (float)($order['total_value'] ?? 0),
+            'total_items' => (int)($order['total_items'] ?? 0),
+            'order_date' => $orderDateIso,
+            'order_date_display' => !empty($order['order_date']) ? date('d.m.Y H:i', strtotime((string)$order['order_date'])) : null,
+            'updated_at' => $updatedAtIso,
+            'awb_barcode' => $awbBarcode,
+            'awb_created_at' => $awbCreatedAtIso,
+            'awb_generation_attempts' => (int)($order['awb_generation_attempts'] ?? 0),
+            'total_weight' => $displayWeight,
+            'weight_display' => $displayWeight > 0 ? number_format($displayWeight, 3, '.', '') : null,
+            'weight_breakdown' => !empty($weightParts) ? implode(' + ', $weightParts) : '',
+            'notes' => $order['notes'] ?? '',
+        ];
+    }
+
+    $latestIso = $latestTimestamp ? $latestTimestamp->format(DateTimeInterface::ATOM) : ($since ? (new DateTimeImmutable($since))->format(DateTimeInterface::ATOM) : null);
+
+    echo json_encode([
+        'status' => 'success',
+        'data' => [
+            'orders' => $responseOrders,
+            'latestTimestamp' => $latestIso,
+            'page' => $page,
+            'pageSize' => $pageSize,
+        ]
+    ]);
+} catch (Throwable $e) {
+    error_log('Order updates error: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'A apărut o eroare la încărcarea actualizărilor de comenzi.'
+    ]);
+}

--- a/scripts/orders.js
+++ b/scripts/orders.js
@@ -6,12 +6,18 @@
 document.addEventListener('DOMContentLoaded', function() {
     console.log('Orders page successfully loaded and scripts are running.');
     initRealtimeSearch();
+    initOrdersRealtimeUpdates();
 });
 
 const POLLING_INTERVAL_MS = 2000;
 let pollingTimer = null;
 let pollingOrderId = null;
 let pollingController = null;
+
+const ORDERS_REALTIME_INTERVAL_MS = 5000;
+let ordersRealtimeTimer = null;
+let ordersRealtimeController = null;
+let ordersLatestTimestamp = null;
 
 function initRealtimeSearch() {
     const searchInput = document.querySelector('.search-input');
@@ -24,6 +30,526 @@ function initRealtimeSearch() {
             row.style.display = text.includes(term) ? '' : 'none';
         });
     });
+}
+
+function initOrdersRealtimeUpdates() {
+    const table = document.querySelector('.orders-table');
+    const tbody = table ? table.querySelector('tbody') : null;
+
+    if (!table || !tbody) {
+        return;
+    }
+
+    ordersLatestTimestamp = table.dataset.lastUpdated || '';
+    if (!ordersLatestTimestamp) {
+        ordersLatestTimestamp = new Date().toISOString();
+    }
+
+    const handleVisibility = () => {
+        if (document.hidden) {
+            stopOrdersRealtimePolling();
+        } else {
+            startOrdersRealtimePolling();
+        }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('beforeunload', stopOrdersRealtimePolling);
+
+    document.addEventListener('orders:awb-generated', event => {
+        const detail = event.detail || {};
+        if (!detail.orderId) {
+            return;
+        }
+        const row = tbody.querySelector(`tr[data-order-id="${detail.orderId}"]`);
+        if (!row) {
+            return;
+        }
+        if (detail.awbCode) {
+            row.dataset.awb = detail.awbCode;
+            showOrdersToast('success', `AWB generat pentru comanda ${detail.orderNumber || detail.awbCode}.`);
+        }
+    });
+
+    startOrdersRealtimePolling();
+}
+
+function startOrdersRealtimePolling() {
+    if (ordersRealtimeTimer || document.hidden) {
+        return;
+    }
+
+    const poll = () => {
+        if (document.hidden) {
+            ordersRealtimeTimer = null;
+            return;
+        }
+
+        fetchOrderUpdates()
+            .catch(error => {
+                console.error('Order updates polling error:', error);
+            })
+            .finally(() => {
+                ordersRealtimeTimer = setTimeout(poll, ORDERS_REALTIME_INTERVAL_MS);
+            });
+    };
+
+    poll();
+}
+
+function stopOrdersRealtimePolling() {
+    if (ordersRealtimeTimer) {
+        clearTimeout(ordersRealtimeTimer);
+        ordersRealtimeTimer = null;
+    }
+    if (ordersRealtimeController) {
+        ordersRealtimeController.abort();
+        ordersRealtimeController = null;
+    }
+}
+
+function fetchOrderUpdates() {
+    const table = document.querySelector('.orders-table');
+    if (!table) {
+        return Promise.resolve();
+    }
+
+    const tbody = table.querySelector('tbody');
+    if (!tbody) {
+        return Promise.resolve();
+    }
+
+    const params = new URLSearchParams();
+    if (ordersLatestTimestamp) {
+        params.set('since', ordersLatestTimestamp);
+    }
+    params.set('status', table.dataset.statusFilter || '');
+    params.set('priority', table.dataset.priorityFilter || '');
+    params.set('search', table.dataset.search || '');
+    params.set('page', table.dataset.page || '1');
+    params.set('pageSize', table.dataset.pageSize || '25');
+
+    if (ordersRealtimeController) {
+        ordersRealtimeController.abort();
+    }
+    ordersRealtimeController = new AbortController();
+
+    return fetch(`api/orders/updates.php?${params.toString()}`, {
+        signal: ordersRealtimeController.signal,
+        credentials: 'same-origin'
+    })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(payload => {
+            if (payload.status !== 'success' || !payload.data) {
+                throw new Error(payload.message || 'Răspuns invalid de la server');
+            }
+
+            const updates = Array.isArray(payload.data.orders) ? payload.data.orders : [];
+            if (payload.data.latestTimestamp) {
+                ordersLatestTimestamp = payload.data.latestTimestamp;
+                table.dataset.lastUpdated = ordersLatestTimestamp;
+            }
+
+            if (updates.length) {
+                applyOrderUpdates(updates, tbody);
+            }
+        })
+        .catch(error => {
+            if (error.name === 'AbortError') {
+                return;
+            }
+            throw error;
+        });
+}
+
+function applyOrderUpdates(updates, tbody) {
+    const table = tbody.closest('.orders-table');
+    const scrollContainer = table ? table.closest('.table-responsive') : null;
+    const previousScrollTop = scrollContainer ? scrollContainer.scrollTop : 0;
+
+    const existingRows = new Map();
+    tbody.querySelectorAll('tr[data-order-id]').forEach(row => {
+        const id = Number(row.getAttribute('data-order-id'));
+        if (!Number.isNaN(id)) {
+            existingRows.set(id, row);
+        }
+    });
+
+    const newRows = [];
+
+    updates.forEach(order => {
+        const id = Number(order.id);
+        if (Number.isNaN(id)) {
+            return;
+        }
+
+        const existingRow = existingRows.get(id);
+        if (existingRow) {
+            const changes = updateOrderRow(existingRow, order);
+            if (changes.statusChanged) {
+                flashStatusChange(existingRow);
+                showOrdersToast('info', `Statusul comenzii ${order.order_number || `#${id}`} a devenit ${order.status_label || ''}.`);
+            }
+            if (changes.awbUpdated) {
+                showOrdersToast('success', `AWB generat pentru comanda ${order.order_number || `#${id}`}.`);
+            }
+        } else if (shouldRenderOrder(order, table)) {
+            const row = renderOrderRow(order);
+            newRows.push({ row, order });
+        }
+    });
+
+    if (newRows.length) {
+        newRows.sort((a, b) => {
+            const aDate = new Date(a.order.order_date || a.order.updated_at || 0).getTime();
+            const bDate = new Date(b.order.order_date || b.order.updated_at || 0).getTime();
+            return bDate - aDate;
+        });
+
+        newRows.forEach(({ row }) => {
+            tbody.insertBefore(row, tbody.firstChild);
+            flashNewOrder(row);
+        });
+
+        const firstOrder = newRows[0].order;
+        const toastMessage = newRows.length === 1
+            ? `A fost adăugată o comandă nouă: ${firstOrder.order_number || `#${firstOrder.id}`}.`
+            : `${newRows.length} comenzi noi au fost adăugate.`;
+        showOrdersToast('success', toastMessage);
+    }
+
+    if (scrollContainer) {
+        scrollContainer.scrollTop = previousScrollTop;
+    }
+}
+
+function shouldRenderOrder(order, table) {
+    const currentPage = Number(table.dataset.page || '1');
+    if (currentPage > 1) {
+        return false;
+    }
+    return true;
+}
+
+function updateOrderRow(row, order) {
+    const status = (order.status || '').toLowerCase();
+    const statusRaw = order.status_raw || order.status || status;
+    const previousStatus = row.getAttribute('data-status') || '';
+    const result = { statusChanged: false, awbUpdated: false };
+
+    if (status && previousStatus !== status) {
+        result.statusChanged = true;
+        row.setAttribute('data-status', status);
+    }
+
+    if (order.updated_at) {
+        row.setAttribute('data-updated-at', order.updated_at);
+    }
+
+    const orderNumberEl = row.querySelector('.order-number');
+    if (orderNumberEl && order.order_number) {
+        orderNumberEl.textContent = order.order_number;
+    }
+
+    const customerInfo = row.querySelector('.customer-info');
+    if (customerInfo) {
+        const name = order.customer_name || '';
+        const email = order.customer_email || '';
+        customerInfo.innerHTML = `<strong>${escapeHtml(name)}</strong>${email ? `<br><small>${escapeHtml(email)}</small>` : ''}`;
+    }
+
+    const orderDateEl = row.querySelector('.order-date-value');
+    if (orderDateEl) {
+        const formattedDate = order.order_date_display || formatRomanianDate(order.order_date);
+        if (formattedDate) {
+            orderDateEl.textContent = formattedDate;
+        }
+    }
+
+    const statusBadge = row.querySelector('.status-badge');
+    if (statusBadge) {
+        statusBadge.textContent = order.status_label || capitalize(status);
+        statusBadge.dataset.status = status;
+        statusBadge.className = `status-badge status-${sanitizeStatus(status)}`;
+    }
+
+    const priorityBadge = row.querySelector('.priority-badge');
+    if (priorityBadge) {
+        const priority = (order.priority || 'normal').toLowerCase();
+        priorityBadge.textContent = order.priority_label || capitalize(priority);
+        priorityBadge.className = `priority-badge priority-${sanitizeStatus(priority)}`;
+    }
+
+    const totalValueEl = row.querySelector('.order-total-value');
+    if (totalValueEl) {
+        totalValueEl.textContent = `${formatCurrency(order.total_value)} Lei`;
+    }
+
+    const itemsCountEl = row.querySelector('.order-items-count');
+    if (itemsCountEl) {
+        const items = Number(order.total_items || 0);
+        itemsCountEl.textContent = `${items} ${items === 1 ? 'produs' : 'produse'}`;
+    }
+
+    const weightEl = row.querySelector('.order-weight');
+    if (weightEl) {
+        const weight = order.weight_display ? `${order.weight_display} kg` : '0.000 kg';
+        weightEl.textContent = weight;
+        if (order.weight_breakdown) {
+            weightEl.setAttribute('title', order.weight_breakdown);
+        } else {
+            weightEl.removeAttribute('title');
+        }
+    }
+
+    const previousAwb = row.getAttribute('data-awb') || '';
+    const newAwb = order.awb_barcode ? String(order.awb_barcode) : '';
+
+    const awbCell = row.querySelector('.awb-cell');
+    if (awbCell) {
+        awbCell.innerHTML = renderAwbCell(order);
+        if (previousAwb !== newAwb) {
+            awbCell.classList.add('awb-update-flash');
+            awbCell.addEventListener('animationend', () => awbCell.classList.remove('awb-update-flash'), { once: true });
+        }
+    }
+
+    if (previousAwb !== newAwb) {
+        result.awbUpdated = !!newAwb;
+        row.setAttribute('data-awb', newAwb);
+    }
+
+    const statusButton = row.querySelector('.btn-group .btn-outline-secondary');
+    if (statusButton) {
+        statusButton.setAttribute('onclick', `openStatusModal(${order.id}, '${escapeJsString(statusRaw)}')`);
+    }
+
+    return result;
+}
+
+function renderOrderRow(order) {
+    const row = document.createElement('tr');
+    row.className = 'order-row';
+    row.setAttribute('data-order-id', order.id);
+    const status = (order.status || '').toLowerCase();
+    const statusRaw = order.status_raw || order.status || status;
+    row.setAttribute('data-status', status);
+    if (order.updated_at) {
+        row.setAttribute('data-updated-at', order.updated_at);
+    }
+    row.setAttribute('data-awb', order.awb_barcode ? String(order.awb_barcode) : '');
+
+    const priority = (order.priority || 'normal').toLowerCase();
+    const orderDateDisplay = order.order_date_display || formatRomanianDate(order.order_date);
+    const customerEmail = order.customer_email ? `<br><small>${escapeHtml(order.customer_email)}</small>` : '';
+
+    row.innerHTML = `
+        <td>
+            <code class="order-number">${escapeHtml(order.order_number || '')}</code>
+        </td>
+        <td>
+            <div class="customer-info">
+                <strong>${escapeHtml(order.customer_name || '')}</strong>
+                ${customerEmail}
+            </div>
+        </td>
+        <td class="order-date-cell">
+            <small class="order-date-value">${escapeHtml(orderDateDisplay || '')}</small>
+        </td>
+        <td>
+            <span class="status-badge status-${sanitizeStatus(status)}" data-status="${escapeHtml(status)}">${escapeHtml(order.status_label || capitalize(status))}</span>
+        </td>
+        <td>
+            <span class="priority-badge priority-${sanitizeStatus(priority)}">${escapeHtml(order.priority_label || capitalize(priority))}</span>
+        </td>
+        <td>
+            <strong class="order-total-value">${formatCurrency(order.total_value)} Lei</strong>
+        </td>
+        <td>
+            <span class="text-center order-items-count">${Number(order.total_items || 0)} ${Number(order.total_items || 0) === 1 ? 'produs' : 'produse'}</span>
+        </td>
+        <td>
+            <span class="order-weight"${order.weight_breakdown ? ` title="${escapeHtml(order.weight_breakdown)}"` : ''}>${order.weight_display ? escapeHtml(`${order.weight_display} kg`) : '0.000 kg'}</span>
+        </td>
+        <td class="awb-column awb-cell">
+            ${renderAwbCell(order)}
+        </td>
+        <td>
+            ${renderOrderActions(order, statusRaw)}
+        </td>
+    `;
+
+    return row;
+}
+
+function renderAwbCell(order) {
+    const attempts = Number(order.awb_generation_attempts || 0);
+    const awb = order.awb_barcode ? String(order.awb_barcode) : '';
+    const hasAwb = awb !== '';
+    const orderId = Number(order.id);
+    const orderNumber = order.order_number || `#${orderId}`;
+    const attemptMessage = !hasAwb && attempts > 0
+        ? `${attempts} ${attempts === 1 ? 'încercare efectuată' : 'încercări efectuate'}`
+        : '';
+
+    const attemptHtml = attemptMessage ? `<div class="awb-attempts">${escapeHtml(attemptMessage)}</div>` : '';
+
+    if (hasAwb) {
+        const trackingUrl = `https://www.cargus.ro/personal/urmareste-coletul/?tracking_number=${encodeURIComponent(awb)}&Urm%C4%83re%C8%99te=Urm%C4%83re%C8%99te`;
+        const awbDate = order.awb_created_at ? formatRomanianDate(order.awb_created_at) : '';
+        const escapedOrderNumber = escapeJsString(orderNumber);
+        const escapedAwb = escapeJsString(awb);
+        return `
+            ${attemptHtml}
+            <div class="awb-info">
+                <span class="awb-barcode">${escapeHtml(awb)}</span>
+                ${awbDate ? `<small>${escapeHtml(awbDate)}</small>` : ''}
+                <a href="${trackingUrl}" class="btn btn-sm btn-outline-secondary track-awb-link" target="_blank" rel="noopener noreferrer">
+                    <span class="material-symbols-outlined">open_in_new</span> Urmărește AWB
+                </a>
+                <button type="button" class="btn btn-sm btn-outline-success print-awb-btn" onclick="printAWB(${orderId}, '${escapedAwb}', '${escapedOrderNumber}')">
+                    <span class="material-symbols-outlined">print</span> Printează AWB
+                </button>
+            </div>
+        `;
+    }
+
+    return `
+        ${attemptHtml}
+        <button type="button" class="btn btn-sm btn-outline-primary generate-awb-btn" data-order-id="${orderId}" title="Generează AWB">
+            <span class="material-symbols-outlined">local_shipping</span>
+            Generează AWB
+        </button>
+    `;
+}
+
+function renderOrderActions(order, statusRawValue) {
+    const id = Number(order.id);
+    const orderNumber = order.order_number || `#${id}`;
+    const escapedOrderNumber = escapeJsString(orderNumber);
+    const status = escapeJsString(statusRawValue || order.status || '');
+
+    return `
+        <div class="btn-group">
+            <button class="btn btn-sm btn-outline-primary" onclick="viewOrderDetails(${id})" title="Vezi detalii">
+                <span class="material-symbols-outlined">visibility</span>
+            </button>
+            <button class="btn btn-sm btn-outline-secondary" onclick="openStatusModal(${id}, '${status}')" title="Schimbă status">
+                <span class="material-symbols-outlined">edit</span>
+            </button>
+            <button class="btn btn-sm btn-outline-info" onclick="printInvoiceWithSelection(${id})" title="Printează Factura">
+                <span class="material-symbols-outlined">print</span>
+            </button>
+            <button class="btn btn-sm btn-outline-danger" onclick="openDeleteModal(${id}, '${escapedOrderNumber}')" title="Șterge">
+                <span class="material-symbols-outlined">delete</span>
+            </button>
+        </div>
+    `;
+}
+
+function flashNewOrder(row) {
+    row.classList.add('order-row-new');
+    row.addEventListener('animationend', () => row.classList.remove('order-row-new'), { once: true });
+}
+
+function flashStatusChange(row) {
+    row.classList.add('order-status-changed');
+    row.addEventListener('animationend', () => row.classList.remove('order-status-changed'), { once: true });
+    const badge = row.querySelector('.status-badge');
+    if (badge) {
+        badge.classList.add('status-change-flash');
+        badge.addEventListener('animationend', () => badge.classList.remove('status-change-flash'), { once: true });
+    }
+}
+
+function showOrdersToast(type, message) {
+    if (!message) {
+        return;
+    }
+
+    const container = document.querySelector('.orders-toast-container');
+    if (!container) {
+        return;
+    }
+
+    const toast = document.createElement('div');
+    toast.className = `orders-toast orders-toast-${type || 'info'}`;
+
+    const icon = document.createElement('span');
+    icon.className = 'material-symbols-outlined';
+    icon.textContent = type === 'success' ? 'check_circle' : type === 'warning' ? 'warning' : 'info';
+
+    const messageEl = document.createElement('div');
+    messageEl.className = 'orders-toast-message';
+    messageEl.textContent = message;
+
+    toast.appendChild(icon);
+    toast.appendChild(messageEl);
+
+    container.appendChild(toast);
+
+    requestAnimationFrame(() => {
+        toast.classList.add('show');
+    });
+
+    setTimeout(() => {
+        toast.classList.remove('show');
+        toast.classList.add('hide');
+        toast.addEventListener('animationend', () => toast.remove(), { once: true });
+    }, 3000);
+}
+
+function sanitizeStatus(value) {
+    return (value || '').toLowerCase().replace(/[^a-z0-9_-]/g, '-');
+}
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+function escapeJsString(value) {
+    return String(value ?? '')
+        .replace(/\\/g, '\\\\')
+        .replace(/'/g, "\\'")
+        .replace(/"/g, '\\"');
+}
+
+function formatCurrency(value) {
+    const number = Number(value || 0);
+    return number.toLocaleString('ro-RO', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function formatRomanianDate(value) {
+    if (!value) {
+        return '';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return '';
+    }
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const year = date.getFullYear();
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    return `${day}.${month}.${year} ${hours}:${minutes}`;
+}
+
+function capitalize(value) {
+    if (!value) {
+        return '';
+    }
+    return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
 let itemCounter = 1;

--- a/scripts/orders_awb.js
+++ b/scripts/orders_awb.js
@@ -139,10 +139,14 @@ async function generateAWBDirect(orderId, manualData = {}) {
             if (window.IS_PICKING_INTERFACE) {
                 document.dispatchEvent(new CustomEvent('awbGenerated', { detail: { orderId, awbCode } }));
             } else {
-                updateOrderAWBStatus(orderId, awbCode, button);
-                setTimeout(() => {
-                    window.location.reload();
-                }, 2000);
+                const generatedForOrder = updateOrderAWBStatus(orderId, awbCode, button);
+                document.dispatchEvent(new CustomEvent('orders:awb-generated', {
+                    detail: {
+                        orderId: Number(orderId),
+                        awbCode,
+                        orderNumber: generatedForOrder
+                    }
+                }));
             }
 
         } else {
@@ -758,8 +762,15 @@ function updateOrderAWBStatus(orderId, barcode, generateBtn) {
                 </button>
             </div>
         `;
-        
+        awbCell.classList.add('awb-update-flash');
+        awbCell.addEventListener('animationend', () => awbCell.classList.remove('awb-update-flash'), { once: true });
     }
+
+    if (row) {
+        row.setAttribute('data-awb', barcode);
+    }
+
+    return orderNumber;
 }
 
 /**

--- a/styles/orders.css
+++ b/styles/orders.css
@@ -115,6 +115,123 @@
     gap: 4px;
 }
 
+/* ===== REALTIME UPDATES ===== */
+.orders-table .order-row-new {
+    animation: ordersNewRowFlash 2.2s ease-out;
+}
+
+.order-status-changed {
+    animation: ordersStatusFlash 1.8s ease-out;
+}
+
+.status-change-flash {
+    animation: ordersStatusBadgeFlash 1.6s ease-out;
+}
+
+.awb-update-flash {
+    animation: ordersAwbFlash 1.6s ease-out;
+}
+
+@keyframes ordersNewRowFlash {
+    0% {
+        background-color: rgba(76, 175, 80, 0.15);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
+@keyframes ordersStatusFlash {
+    0% {
+        background-color: rgba(255, 193, 7, 0.18);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
+@keyframes ordersStatusBadgeFlash {
+    0% {
+        background-color: rgba(255, 193, 7, 0.35);
+    }
+    50% {
+        background-color: rgba(255, 193, 7, 0.12);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
+@keyframes ordersAwbFlash {
+    0% {
+        background-color: rgba(76, 175, 80, 0.18);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
+.orders-toast-container {
+    position: fixed;
+    top: 1.5rem;
+    right: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    z-index: 1200;
+    pointer-events: none;
+}
+
+.orders-toast {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: var(--surface-background);
+    color: var(--text-primary);
+    border-radius: var(--border-radius);
+    padding: 0.75rem 1rem;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+    border-left: 4px solid var(--primary-color);
+    opacity: 0;
+    transform: translateX(16px);
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    pointer-events: auto;
+}
+
+.orders-toast .material-symbols-outlined {
+    font-size: 1.5rem;
+}
+
+.orders-toast.show {
+    opacity: 1;
+    transform: translateX(0);
+}
+
+.orders-toast.hide {
+    opacity: 0;
+    transform: translateX(16px);
+}
+
+.orders-toast-success {
+    border-left-color: var(--success-color, #2e7d32);
+}
+
+.orders-toast-success .material-symbols-outlined {
+    color: var(--success-color, #2e7d32);
+}
+
+.orders-toast-info {
+    border-left-color: var(--primary-color, #2563eb);
+}
+
+.orders-toast-warning {
+    border-left-color: var(--warning-color, #f59e0b);
+}
+
+.orders-toast-message {
+    font-weight: 500;
+}
+
 .modal-close:hover {
     background-color: var(--button-hover);
     color: var(--text-primary);


### PR DESCRIPTION
## Summary
- add an incremental updates API for orders and expose consistent status labels
- update the orders page markup to provide metadata, Romanian labels, and a toast container for live notifications
- implement client polling with animated row/status/AWB refreshes, reusable toasts, and sync AWB generation without reloading
- style new highlight effects and toast notifications for real-time events
- fix the new-order row renderer to pass the raw status so live inserts no longer throw and display immediately

## Testing
- php -l orders.php
- php -l models/Order.php
- php -l api/orders/updates.php


------
https://chatgpt.com/codex/tasks/task_e_68dd5fd1d578832091d3b8631abbd5d7