### PR TITLE
Add self-service Cargus locality mapping admin interface

### DIFF
--- a/api/cargus_mappings/list.php
+++ b/api/cargus_mappings/list.php
@@ -1,0 +1,126 @@
+<?php
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'admin') {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Acces interzis']);
+    exit;
+}
+
+try {
+    $config = require BASE_PATH . '/config/config.php';
+    $db = $config['connection_factory']();
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Nu se poate conecta la baza de date']);
+    exit;
+}
+
+$page = max(1, (int)($_GET['page'] ?? 1));
+$perPage = (int)($_GET['per_page'] ?? 20);
+$perPage = max(5, min(100, $perPage));
+$search = trim((string)($_GET['search'] ?? ''));
+$onlyMissing = filter_var($_GET['only_missing'] ?? false, FILTER_VALIDATE_BOOLEAN) || ($_GET['only_missing'] ?? '') === '1';
+
+$whereClauses = [];
+$params = [];
+
+if ($search !== '') {
+    $whereClauses[] = '(
+        county_name LIKE :search
+        OR locality_name LIKE :search
+        OR cargus_county_name LIKE :search
+        OR cargus_locality_name LIKE :search
+    )';
+    $params[':search'] = '%' . $search . '%';
+}
+
+if ($onlyMissing) {
+    $whereClauses[] = '(cargus_locality_id IS NULL OR cargus_locality_id = 0)';
+}
+
+$whereSql = $whereClauses ? 'WHERE ' . implode(' AND ', $whereClauses) : '';
+
+try {
+    $countSql = "SELECT COUNT(*) FROM address_location_mappings {$whereSql}";
+    $countStmt = $db->prepare($countSql);
+    foreach ($params as $key => $value) {
+        $countStmt->bindValue($key, $value);
+    }
+    $countStmt->execute();
+    $total = (int)$countStmt->fetchColumn();
+
+    $offset = ($page - 1) * $perPage;
+
+    $listSql = "
+        SELECT
+            id,
+            county_name,
+            locality_name,
+            cargus_county_id,
+            cargus_locality_id,
+            cargus_county_name,
+            cargus_locality_name,
+            cargus_postal_code,
+            mapping_confidence,
+            is_verified,
+            usage_count,
+            last_used_at,
+            updated_at,
+            created_at
+        FROM address_location_mappings
+        {$whereSql}
+        ORDER BY
+            (cargus_locality_id IS NULL OR cargus_locality_id = 0) DESC,
+            updated_at DESC
+        LIMIT :limit OFFSET :offset
+    ";
+
+    $listStmt = $db->prepare($listSql);
+    foreach ($params as $key => $value) {
+        $listStmt->bindValue($key, $value);
+    }
+    $listStmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
+    $listStmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+    $listStmt->execute();
+
+    $mappings = $listStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $statsStmt = $db->query("SELECT
+        COUNT(*) AS total,
+        SUM(CASE WHEN cargus_locality_id IS NULL OR cargus_locality_id = 0 THEN 1 ELSE 0 END) AS missing,
+        SUM(CASE WHEN is_verified = 1 THEN 1 ELSE 0 END) AS verified,
+        SUM(CASE WHEN last_used_at IS NOT NULL AND last_used_at >= DATE_SUB(NOW(), INTERVAL 30 DAY) THEN 1 ELSE 0 END) AS recent_usage
+    FROM address_location_mappings");
+    $stats = $statsStmt->fetch(PDO::FETCH_ASSOC) ?: ['total' => 0, 'missing' => 0, 'verified' => 0, 'recent_usage' => 0];
+
+    echo json_encode([
+        'success' => true,
+        'data' => $mappings,
+        'pagination' => [
+            'page' => $page,
+            'per_page' => $perPage,
+            'total' => $total,
+            'total_pages' => (int)ceil($total / $perPage)
+        ],
+        'stats' => [
+            'total' => (int)($stats['total'] ?? 0),
+            'missing' => (int)($stats['missing'] ?? 0),
+            'verified' => (int)($stats['verified'] ?? 0),
+            'recent_usage' => (int)($stats['recent_usage'] ?? 0)
+        ]
+    ]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Eroare la preluarea mapărilor',
+        'details' => $e->getMessage()
+    ]);
+}

--- a/api/cargus_mappings/search.php
+++ b/api/cargus_mappings/search.php
@@ -1,0 +1,59 @@
+<?php
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'admin') {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Acces interzis']);
+    exit;
+}
+
+$county = trim((string)($_GET['county'] ?? ''));
+$locality = trim((string)($_GET['locality'] ?? ''));
+$mappingId = (int)($_GET['mapping_id'] ?? 0);
+
+if ($county === '' || $locality === '') {
+    http_response_code(422);
+    echo json_encode(['success' => false, 'error' => 'Județul și localitatea sunt obligatorii']);
+    exit;
+}
+
+try {
+    $config = require BASE_PATH . '/config/config.php';
+    $db = $config['connection_factory']();
+
+    require_once BASE_PATH . '/models/CargusService.php';
+    $cargusService = new CargusService($db);
+
+    $result = $cargusService->searchLocalities($county, $locality);
+
+    if (!is_array($result) || !($result['success'] ?? false)) {
+        $message = is_array($result) ? ($result['error'] ?? 'Nu am găsit rezultate') : 'Nu am găsit rezultate';
+        http_response_code(404);
+        echo json_encode([
+            'success' => false,
+            'error' => $message,
+            'matches' => $result['matches'] ?? []
+        ]);
+        exit;
+    }
+
+    echo json_encode([
+        'success' => true,
+        'mapping_id' => $mappingId,
+        'matches' => $result['matches'],
+        'debug' => $result['debug'] ?? null
+    ]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Eroare la interogarea API-ului Cargus',
+        'details' => $e->getMessage()
+    ]);
+}

--- a/api/cargus_mappings/update.php
+++ b/api/cargus_mappings/update.php
@@ -1,0 +1,197 @@
+<?php
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'admin') {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Acces interzis']);
+    exit;
+}
+
+$payload = json_decode(file_get_contents('php://input'), true);
+if (!is_array($payload)) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Date JSON invalide']);
+    exit;
+}
+
+$mappingId = (int)($payload['mapping_id'] ?? 0);
+$countyId = (int)($payload['county_id'] ?? 0);
+$localityId = (int)($payload['locality_id'] ?? 0);
+$countyName = trim((string)($payload['county_name'] ?? ''));
+$localityName = trim((string)($payload['locality_name'] ?? ''));
+$postalCode = trim((string)($payload['postal_code'] ?? ''));
+$updateOrders = filter_var($payload['update_orders'] ?? false, FILTER_VALIDATE_BOOLEAN);
+
+if ($mappingId <= 0 || $countyId <= 0 || $localityId <= 0 || $countyName === '' || $localityName === '') {
+    http_response_code(422);
+    echo json_encode(['success' => false, 'error' => 'Toate câmpurile sunt obligatorii pentru actualizare']);
+    exit;
+}
+
+$postalCode = $postalCode !== '' ? $postalCode : null;
+
+try {
+    $config = require BASE_PATH . '/config/config.php';
+    $db = $config['connection_factory']();
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $fetchStmt = $db->prepare('SELECT * FROM address_location_mappings WHERE id = :id');
+    $fetchStmt->execute([':id' => $mappingId]);
+    $existing = $fetchStmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$existing) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'error' => 'Maparea selectată nu a fost găsită']);
+        exit;
+    }
+
+    $db->beginTransaction();
+
+    $updateStmt = $db->prepare('
+        UPDATE address_location_mappings
+        SET
+            cargus_county_id = :county_id,
+            cargus_locality_id = :locality_id,
+            cargus_county_name = :county_name,
+            cargus_locality_name = :locality_name,
+            cargus_postal_code = :postal_code,
+            mapping_confidence = :confidence,
+            is_verified = 1,
+            last_used_at = NOW(),
+            updated_at = NOW()
+        WHERE id = :id
+    ');
+
+    $updateStmt->execute([
+        ':county_id' => $countyId,
+        ':locality_id' => $localityId,
+        ':county_name' => $countyName,
+        ':locality_name' => $localityName,
+        ':postal_code' => $postalCode,
+        ':confidence' => 'manual',
+        ':id' => $mappingId
+    ]);
+
+    $ordersUpdated = 0;
+
+    if ($updateOrders) {
+        $ordersUpdated = updatePendingOrders($db, $existing, [
+            'county_id' => $countyId,
+            'locality_id' => $localityId,
+            'county_name' => $countyName,
+            'locality_name' => $localityName,
+            'postal_code' => $postalCode
+        ]);
+    }
+
+    $db->commit();
+
+    $fetchUpdated = $db->prepare('SELECT * FROM address_location_mappings WHERE id = :id');
+    $fetchUpdated->execute([':id' => $mappingId]);
+    $updated = $fetchUpdated->fetch(PDO::FETCH_ASSOC);
+
+    if (function_exists('logActivity')) {
+        logActivity(
+            (int)$_SESSION['user_id'],
+            'update',
+            'cargus_mapping',
+            $mappingId,
+            'Actualizare manuală mapare Cargus',
+            $existing,
+            array_merge($updated ?: [], ['orders_updated' => $ordersUpdated])
+        );
+    }
+
+    echo json_encode([
+        'success' => true,
+        'message' => 'Maparea a fost actualizată cu succes',
+        'orders_updated' => $ordersUpdated,
+        'mapping' => $updated
+    ]);
+} catch (Throwable $e) {
+    if (isset($db) && $db->inTransaction()) {
+        $db->rollBack();
+    }
+
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'error' => 'A apărut o eroare la actualizare',
+        'details' => $e->getMessage()
+    ]);
+}
+
+function updatePendingOrders(PDO $db, array $existing, array $newValues): int
+{
+    $checkStmt = $db->prepare("SHOW COLUMNS FROM orders LIKE :column");
+
+    $conditions = [];
+    foreach (['shipping_county', 'recipient_county_name'] as $countyColumn) {
+        $checkStmt->execute([':column' => $countyColumn]);
+        $countyExists = (bool)$checkStmt->fetch(PDO::FETCH_ASSOC);
+
+        $cityColumn = $countyColumn === 'shipping_county' ? 'shipping_city' : 'recipient_locality_name';
+        $checkStmt->execute([':column' => $cityColumn]);
+        $cityExists = (bool)$checkStmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($countyExists && $cityExists) {
+            $conditions[] = sprintf(
+                '(LOWER(%s) = LOWER(:match_county) AND LOWER(%s) = LOWER(:match_locality))',
+                $countyColumn,
+                $cityColumn
+            );
+        }
+    }
+
+    if (empty($conditions)) {
+        return 0;
+    }
+
+    $updateFields = [
+        'recipient_county_id = :county_id',
+        'recipient_locality_id = :locality_id',
+        'recipient_county_name = :new_county_name',
+        'recipient_locality_name = :new_locality_name'
+    ];
+
+    $checkStmt->execute([':column' => 'recipient_postal']);
+    if ($checkStmt->fetch(PDO::FETCH_ASSOC)) {
+        $updateFields[] = 'recipient_postal = :postal_code';
+    }
+
+    $checkStmt->execute([':column' => 'updated_at']);
+    $hasUpdatedAt = (bool)$checkStmt->fetch(PDO::FETCH_ASSOC);
+
+    $sql = sprintf(
+        'UPDATE orders SET %s%s WHERE status IN (\'pending\', \'processing\') AND (%s)',
+        implode(', ', $updateFields),
+        $hasUpdatedAt ? ', updated_at = NOW()' : '',
+        implode(' OR ', $conditions)
+    );
+
+    $stmt = $db->prepare($sql);
+    $stmt->bindValue(':county_id', $newValues['county_id'], PDO::PARAM_INT);
+    $stmt->bindValue(':locality_id', $newValues['locality_id'], PDO::PARAM_INT);
+    $stmt->bindValue(':new_county_name', $newValues['county_name']);
+    $stmt->bindValue(':new_locality_name', $newValues['locality_name']);
+    $stmt->bindValue(':match_county', $existing['county_name'] ?? $newValues['county_name']);
+    $stmt->bindValue(':match_locality', $existing['locality_name'] ?? $newValues['locality_name']);
+
+    if (in_array('recipient_postal = :postal_code', $updateFields, true)) {
+        if ($newValues['postal_code'] !== null && $newValues['postal_code'] !== '') {
+            $stmt->bindValue(':postal_code', $newValues['postal_code']);
+        } else {
+            $stmt->bindValue(':postal_code', null, PDO::PARAM_NULL);
+        }
+    }
+
+    $stmt->execute();
+
+    return $stmt->rowCount();
+}

--- a/cargus_mappings.php
+++ b/cargus_mappings.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Admin interface for managing Cargus locality mappings.
+ */
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', __DIR__);
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'admin') {
+    header('Location: ' . getNavUrl('index.php'));
+    exit;
+}
+
+$pageTitle = 'Mapări Localități Cargus';
+$currentPage = 'cargus_mappings';
+?>
+<!DOCTYPE html>
+<html lang="ro" data-theme="dark">
+<head>
+    <?php require_once BASE_PATH . '/includes/header.php'; ?>
+    <meta name="csrf-token" content="<?= htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+</head>
+<body>
+<div class="app">
+    <?php require_once BASE_PATH . '/includes/navbar.php'; ?>
+
+    <main class="main-content">
+        <div class="page-container">
+            <div class="page-header">
+                <div class="page-header-content">
+                    <h1 class="page-title">
+                        <span class="material-symbols-outlined">pin_drop</span>
+                        Mapări Localități Cargus
+                    </h1>
+                    <p class="page-subtitle">
+                        Gestionează corelarea județelor și localităților din baza ta de date cu codurile oficiale Cargus.
+                    </p>
+                </div>
+                <div class="header-actions">
+                    <button class="btn btn-secondary" type="button" id="refreshMappings">
+                        <span class="material-symbols-outlined">refresh</span>
+                        Actualizează lista
+                    </button>
+                </div>
+            </div>
+
+            <section class="mappings-stats" id="mappingsStats">
+                <article class="stat-card" aria-live="polite">
+                    <div class="stat-card__label">Total mapări</div>
+                    <div class="stat-card__value" id="totalMappings">-</div>
+                </article>
+                <article class="stat-card stat-card--warning" aria-live="polite">
+                    <div class="stat-card__label">Mapări de completat</div>
+                    <div class="stat-card__value" id="missingMappings">-</div>
+                </article>
+                <article class="stat-card stat-card--success" aria-live="polite">
+                    <div class="stat-card__label">Mapări verificate</div>
+                    <div class="stat-card__value" id="verifiedMappings">-</div>
+                </article>
+                <article class="stat-card" aria-live="polite">
+                    <div class="stat-card__label">Utilizări recente</div>
+                    <div class="stat-card__value" id="recentUsage">-</div>
+                </article>
+            </section>
+
+            <section class="mappings-toolbar" aria-label="Filtre mapări">
+                <div class="toolbar-group">
+                    <label class="search-input">
+                        <span class="material-symbols-outlined">search</span>
+                        <input type="search"
+                               id="searchMappings"
+                               placeholder="Caută județ sau localitate"
+                               autocomplete="off"
+                               aria-label="Caută mapări">
+                    </label>
+                    <label class="select-input">
+                        <span class="material-symbols-outlined">list_alt</span>
+                        <select id="perPageSelect" aria-label="Rezultate pe pagină">
+                            <option value="10">10 / pagină</option>
+                            <option value="20" selected>20 / pagină</option>
+                            <option value="50">50 / pagină</option>
+                        </select>
+                    </label>
+                </div>
+                <div class="toolbar-actions">
+                    <label class="toggle-filter">
+                        <input type="checkbox" id="onlyMissingToggle">
+                        <span>Doar mapări incomplete</span>
+                    </label>
+                    <button class="btn btn-tertiary" type="button" id="resetFilters">Resetează filtrele</button>
+                </div>
+            </section>
+
+            <section class="table-card" aria-live="polite">
+                <table class="mappings-table">
+                    <thead>
+                        <tr>
+                            <th>Județ (WMS)</th>
+                            <th>Localitate (WMS)</th>
+                            <th>Județ Cargus</th>
+                            <th>Localitate Cargus</th>
+                            <th>Cod Poștal</th>
+                            <th>Încredere</th>
+                            <th>Acțiuni</th>
+                        </tr>
+                    </thead>
+                    <tbody id="mappingsTableBody">
+                        <tr>
+                            <td colspan="7" class="table-placeholder">Se încarcă datele...</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <div class="table-footer">
+                    <div class="results-summary" id="resultsSummary"></div>
+                    <nav class="pagination" id="mappingsPagination" aria-label="Paginare mapări"></nav>
+                </div>
+            </section>
+
+            <div class="feedback-banner" id="feedbackBanner" role="alert" hidden></div>
+        </div>
+    </main>
+</div>
+
+<div class="page-loading" id="pageLoadingOverlay" hidden>
+    <div class="page-loading__content">
+        <span class="material-symbols-outlined spinning">progress_activity</span>
+        <span>Se încarcă...</span>
+    </div>
+</div>
+
+<div class="mapping-modal" id="mappingModal" aria-hidden="true">
+    <div class="mapping-modal__backdrop" data-modal-close></div>
+    <div class="mapping-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="mappingModalTitle">
+        <header class="mapping-modal__header">
+            <div>
+                <h2 class="mapping-modal__title" id="mappingModalTitle">Actualizează maparea Cargus</h2>
+                <p class="mapping-modal__subtitle" id="mappingModalSubtitle"></p>
+            </div>
+            <button class="modal-close" type="button" data-modal-close aria-label="Închide">
+                <span class="material-symbols-outlined">close</span>
+            </button>
+        </header>
+        <section class="mapping-modal__body">
+            <div class="mapping-modal__summary">
+                <div>
+                    <span class="summary-label">Județ WMS</span>
+                    <strong class="summary-value" id="modalCounty"></strong>
+                </div>
+                <div>
+                    <span class="summary-label">Localitate WMS</span>
+                    <strong class="summary-value" id="modalLocality"></strong>
+                </div>
+                <div class="summary-meta">
+                    <span id="modalMeta"></span>
+                </div>
+            </div>
+
+            <div class="mapping-modal__alert" id="modalAlert" hidden></div>
+
+            <div class="mapping-modal__loading" id="modalLoading" hidden>
+                <span class="material-symbols-outlined spinning">progress_activity</span>
+                <span>Căutăm localități în Cargus...</span>
+            </div>
+
+            <div class="mapping-modal__matches" id="mappingMatches" hidden>
+                <div class="matches-header">
+                    <h3>Rezultate Cargus propuse</h3>
+                    <button class="btn btn-link" type="button" id="retrySearch">
+                        <span class="material-symbols-outlined">refresh</span>
+                        Reîncearcă căutarea
+                    </button>
+                </div>
+                <div class="matches-table" role="group" aria-labelledby="mappingModalTitle">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th></th>
+                                <th>Județ</th>
+                                <th>Localitate</th>
+                                <th>Cod Poștal</th>
+                                <th>Potrivire</th>
+                            </tr>
+                        </thead>
+                        <tbody id="matchesTableBody"></tbody>
+                    </table>
+                </div>
+            </div>
+        </section>
+        <footer class="mapping-modal__footer">
+            <label class="orders-toggle">
+                <input type="checkbox" id="applyToOrders" checked>
+                <span>Actualizează și comenzile în curs cu această mapare</span>
+            </label>
+            <div class="footer-actions">
+                <button class="btn btn-secondary" type="button" data-modal-close>Anulează</button>
+                <button class="btn btn-primary" type="button" id="confirmMapping" disabled>
+                    <span class="material-symbols-outlined">save</span>
+                    Salvează maparea
+                </button>
+            </div>
+        </footer>
+    </div>
+</div>
+
+<?php require_once __DIR__ . '/includes/footer.php'; ?>
+</body>
+</html>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -50,6 +50,7 @@ $pageSpecificJS = [
     'sellers' => ['sellers.js', 'sellers-import.js'],
     'purchase_orders' => 'purchase_orders.js',
     'product-units' => 'product-units.js',
+    'cargus_mappings' => 'cargus_mappings.js',
     'printer-management' => 'printer-management.js',
     'qc_management' => 'qc-management.js',
     'returns_dashboard' => 'returns_dashboard.js',

--- a/includes/header.php
+++ b/includes/header.php
@@ -30,6 +30,7 @@ $pageSpecificCSS = [
     'sellers' => 'sellers.css',
     'purchase_orders' => 'purchase_orders.css',
     'product-units' => 'product-units.css',
+    'cargus_mappings' => 'cargus_mappings.css',
     'printer-management' => 'printer-management.css',
     'qc_management' => 'qc-management.css',
     'returns_dashboard' => 'returns_dashboard.css',

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -203,12 +203,22 @@ if ($incidentSidebarCount === null) {
             </a>
         </li>
         <li class="sidebar__item">
-            <a href="<?= getNavUrl('product-units.php') ?>" 
+            <a href="<?= getNavUrl('product-units.php') ?>"
                class="sidebar__link <?= getActiveClass('product-units.php') ?>"
                data-tooltip="Unități Produse">
                 <span class="material-symbols-outlined">rule_settings</span> <span class="link-text">Setări Produse</span>
             </a>
         </li>
+        <?php if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin'): ?>
+        <li class="sidebar__item">
+            <a href="<?= getNavUrl('cargus_mappings.php') ?>"
+               class="sidebar__link <?= getActiveClass('cargus_mappings.php') ?>"
+               data-tooltip="Mapări Cargus">
+                <span class="material-symbols-outlined">pin_drop</span>
+                <span class="link-text">Mapări Cargus</span>
+            </a>
+        </li>
+        <?php endif; ?>
         <li class="sidebar__item">
             <a href="<?= getNavUrl('printer-management.php') ?>"
                class="sidebar__link <?= getActiveClass('printer-management.php') ?>"

--- a/scripts/cargus_mappings.js
+++ b/scripts/cargus_mappings.js
@@ -1,0 +1,564 @@
+(() => {
+    'use strict';
+
+    const baseUrl = (window.APP_CONFIG && window.APP_CONFIG.baseUrl) || '';
+    const apiEndpoints = {
+        list: `${baseUrl}/api/cargus_mappings/list.php`,
+        search: `${baseUrl}/api/cargus_mappings/search.php`,
+        update: `${baseUrl}/api/cargus_mappings/update.php`
+    };
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
+
+    const state = {
+        page: 1,
+        perPage: 20,
+        search: '',
+        onlyMissing: false,
+        mappings: [],
+        matches: [],
+        selectedMapping: null,
+        selectedMatchIndex: null,
+        loading: false
+    };
+
+    const elements = {
+        tableBody: document.getElementById('mappingsTableBody'),
+        pagination: document.getElementById('mappingsPagination'),
+        resultsSummary: document.getElementById('resultsSummary'),
+        totalMappings: document.getElementById('totalMappings'),
+        missingMappings: document.getElementById('missingMappings'),
+        verifiedMappings: document.getElementById('verifiedMappings'),
+        recentUsage: document.getElementById('recentUsage'),
+        searchInput: document.getElementById('searchMappings'),
+        perPageSelect: document.getElementById('perPageSelect'),
+        onlyMissingToggle: document.getElementById('onlyMissingToggle'),
+        refreshButton: document.getElementById('refreshMappings'),
+        resetButton: document.getElementById('resetFilters'),
+        feedbackBanner: document.getElementById('feedbackBanner'),
+        loadingOverlay: document.getElementById('pageLoadingOverlay'),
+        modal: document.getElementById('mappingModal'),
+        modalTitle: document.getElementById('mappingModalTitle'),
+        modalSubtitle: document.getElementById('mappingModalSubtitle'),
+        modalCounty: document.getElementById('modalCounty'),
+        modalLocality: document.getElementById('modalLocality'),
+        modalMeta: document.getElementById('modalMeta'),
+        modalAlert: document.getElementById('modalAlert'),
+        modalLoading: document.getElementById('modalLoading'),
+        modalMatches: document.getElementById('mappingMatches'),
+        matchesTableBody: document.getElementById('matchesTableBody'),
+        retrySearchButton: document.getElementById('retrySearch'),
+        applyToOrders: document.getElementById('applyToOrders'),
+        confirmButton: document.getElementById('confirmMapping')
+    };
+
+    const formatDateTime = (value) => {
+        if (!value) {
+            return '—';
+        }
+        try {
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) {
+                return value;
+            }
+            return date.toLocaleString('ro-RO');
+        } catch (error) {
+            return value;
+        }
+    };
+
+    const togglePageLoading = (show) => {
+        if (!elements.loadingOverlay) {
+            return;
+        }
+        if (show) {
+            elements.loadingOverlay.removeAttribute('hidden');
+        } else {
+            elements.loadingOverlay.setAttribute('hidden', 'hidden');
+        }
+    };
+
+    const showFeedback = (message, type = 'success') => {
+        if (!elements.feedbackBanner) {
+            return;
+        }
+
+        elements.feedbackBanner.textContent = message;
+        elements.feedbackBanner.classList.remove('feedback-banner--success', 'feedback-banner--error', 'is-visible');
+
+        if (type === 'success') {
+            elements.feedbackBanner.classList.add('feedback-banner--success');
+        } else {
+            elements.feedbackBanner.classList.add('feedback-banner--error');
+        }
+
+        elements.feedbackBanner.classList.add('is-visible');
+    };
+
+    const hideFeedback = () => {
+        if (!elements.feedbackBanner) {
+            return;
+        }
+        elements.feedbackBanner.classList.remove('is-visible', 'feedback-banner--success', 'feedback-banner--error');
+        elements.feedbackBanner.textContent = '';
+    };
+
+    const renderStats = (stats) => {
+        if (!stats) {
+            return;
+        }
+        if (elements.totalMappings) {
+            elements.totalMappings.textContent = stats.total ?? '0';
+        }
+        if (elements.missingMappings) {
+            elements.missingMappings.textContent = stats.missing ?? '0';
+        }
+        if (elements.verifiedMappings) {
+            elements.verifiedMappings.textContent = stats.verified ?? '0';
+        }
+        if (elements.recentUsage) {
+            elements.recentUsage.textContent = stats.recent_usage ?? '0';
+        }
+    };
+
+    const renderMappings = (mappings) => {
+        if (!elements.tableBody) {
+            return;
+        }
+
+        elements.tableBody.innerHTML = '';
+
+        if (!Array.isArray(mappings) || mappings.length === 0) {
+            const row = document.createElement('tr');
+            const cell = document.createElement('td');
+            cell.colSpan = 7;
+            cell.className = 'table-placeholder';
+            cell.textContent = 'Nu există mapări pentru criteriile selectate.';
+            row.appendChild(cell);
+            elements.tableBody.appendChild(row);
+            return;
+        }
+
+        mappings.forEach((mapping) => {
+            const row = document.createElement('tr');
+            const needsAttention = !mapping.cargus_locality_id;
+            if (needsAttention) {
+                row.classList.add('mapping-row--missing');
+            }
+
+            const confidenceLabel = mapping.mapping_confidence ? mapping.mapping_confidence.toUpperCase() : 'NECUNOSCUT';
+            const verifiedBadge = mapping.is_verified ? '<span class="badge badge--verified">Verificat</span>' : '<span class="badge badge--missing">Necesită verificare</span>';
+
+            row.innerHTML = `
+                <td>${mapping.county_name ?? '—'}</td>
+                <td>${mapping.locality_name ?? '—'}</td>
+                <td>${mapping.cargus_county_name ?? '—'}</td>
+                <td>${mapping.cargus_locality_name ?? '—'}</td>
+                <td>${mapping.cargus_postal_code ?? '—'}</td>
+                <td>
+                    <div class="mapping-confidence">
+                        <span class="badge">${confidenceLabel}</span>
+                        ${verifiedBadge}
+                    </div>
+                </td>
+                <td class="table-actions">
+                    <button class="btn btn-primary btn-sm" type="button" data-action="fix-mapping" data-id="${mapping.id}">
+                        <span class="material-symbols-outlined">handyman</span>
+                        Rezolvă
+                    </button>
+                </td>
+            `;
+
+            elements.tableBody.appendChild(row);
+        });
+    };
+
+    const renderPagination = (pagination) => {
+        if (!elements.pagination) {
+            return;
+        }
+
+        elements.pagination.innerHTML = '';
+
+        if (!pagination || pagination.total_pages <= 1) {
+            return;
+        }
+
+        const createPageButton = (label, page, disabled = false, isActive = false) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.textContent = label;
+            if (isActive) {
+                button.classList.add('active');
+            }
+            if (disabled) {
+                button.disabled = true;
+            } else {
+                button.addEventListener('click', () => {
+                    state.page = page;
+                    fetchMappings();
+                });
+            }
+            return button;
+        };
+
+        const prevButton = createPageButton('‹', Math.max(1, pagination.page - 1), pagination.page === 1);
+        elements.pagination.appendChild(prevButton);
+
+        for (let page = 1; page <= pagination.total_pages; page += 1) {
+            if (page === 1 || page === pagination.total_pages || Math.abs(page - pagination.page) <= 1) {
+                const pageButton = createPageButton(page, page, false, page === pagination.page);
+                elements.pagination.appendChild(pageButton);
+            } else if (page === 2 && pagination.page > 3) {
+                const dots = document.createElement('span');
+                dots.textContent = '…';
+                elements.pagination.appendChild(dots);
+            } else if (page === pagination.total_pages - 1 && pagination.page < pagination.total_pages - 2) {
+                const dots = document.createElement('span');
+                dots.textContent = '…';
+                elements.pagination.appendChild(dots);
+            }
+        }
+
+        const nextButton = createPageButton('›', Math.min(pagination.total_pages, pagination.page + 1), pagination.page === pagination.total_pages);
+        elements.pagination.appendChild(nextButton);
+    };
+
+    const renderResultsSummary = (pagination) => {
+        if (!elements.resultsSummary || !pagination) {
+            return;
+        }
+        const total = Number(pagination.total ?? 0);
+        if (total === 0) {
+            elements.resultsSummary.textContent = 'Nu există mapări pentru criteriile selectate.';
+            return;
+        }
+        const start = (pagination.page - 1) * pagination.per_page + 1;
+        const end = Math.min(pagination.page * pagination.per_page, total);
+        elements.resultsSummary.textContent = `Afișate ${start} – ${end} din ${total} mapări`;
+    };
+
+    const fetchMappings = async () => {
+        state.loading = true;
+        togglePageLoading(state.page === 1);
+        hideFeedback();
+
+        try {
+            const url = new URL(apiEndpoints.list, window.location.origin);
+            url.searchParams.set('page', state.page.toString());
+            url.searchParams.set('per_page', state.perPage.toString());
+            if (state.search) {
+                url.searchParams.set('search', state.search);
+            }
+            if (state.onlyMissing) {
+                url.searchParams.set('only_missing', '1');
+            }
+
+            const response = await fetch(url.toString(), {
+                credentials: 'same-origin',
+                headers: {
+                    'Accept': 'application/json'
+                }
+            });
+
+            const data = await response.json();
+            if (!data.success) {
+                throw new Error(data.error || 'Nu am putut încărca mapările');
+            }
+
+            state.mappings = data.data || [];
+            renderMappings(state.mappings);
+            renderPagination(data.pagination);
+            renderResultsSummary(data.pagination);
+            renderStats(data.stats);
+        } catch (error) {
+            console.error('Cargus mappings fetch error', error);
+            showFeedback(error.message || 'Nu am putut încărca mapările', 'error');
+            renderMappings([]);
+            renderPagination(null);
+            renderResultsSummary({ page: 1, per_page: 0, total: 0 });
+        } finally {
+            state.loading = false;
+            togglePageLoading(false);
+        }
+    };
+
+    const closeModal = () => {
+        if (!elements.modal) {
+            return;
+        }
+        elements.modal.classList.remove('is-open');
+        elements.modal.setAttribute('aria-hidden', 'true');
+        elements.matchesTableBody.innerHTML = '';
+        elements.modalAlert.setAttribute('hidden', 'hidden');
+        elements.modalMatches.setAttribute('hidden', 'hidden');
+        elements.modalLoading.setAttribute('hidden', 'hidden');
+        elements.confirmButton.disabled = true;
+        state.matches = [];
+        state.selectedMapping = null;
+        state.selectedMatchIndex = null;
+    };
+
+    const openModal = (mapping) => {
+        if (!elements.modal) {
+            return;
+        }
+
+        state.selectedMapping = mapping;
+        state.selectedMatchIndex = null;
+        state.matches = [];
+
+        elements.modalCounty.textContent = mapping.county_name ?? '';
+        elements.modalLocality.textContent = mapping.locality_name ?? '';
+        elements.modalSubtitle.textContent = mapping.cargus_locality_id
+            ? 'Actualizează codurile Cargus dacă există o potrivire mai bună.'
+            : 'Nu există cod Cargus asociat. Selectează mai jos varianta corectă.';
+        elements.modalMeta.textContent = `Ultima actualizare: ${formatDateTime(mapping.updated_at)} · Utilizat de ${mapping.usage_count ?? 0} ori`;
+
+        elements.modalAlert.setAttribute('hidden', 'hidden');
+        elements.modalMatches.setAttribute('hidden', 'hidden');
+        elements.modalLoading.removeAttribute('hidden');
+        elements.confirmButton.disabled = true;
+
+        elements.modal.classList.add('is-open');
+        elements.modal.setAttribute('aria-hidden', 'false');
+
+        fetchMatches();
+    };
+
+    const renderMatches = (matches) => {
+        elements.matchesTableBody.innerHTML = '';
+
+        if (!Array.isArray(matches) || matches.length === 0) {
+            elements.modalAlert.textContent = 'Nu am găsit potriviri pentru această localitate în Cargus.';
+            elements.modalAlert.removeAttribute('hidden');
+            elements.modalMatches.setAttribute('hidden', 'hidden');
+            return;
+        }
+
+        elements.modalAlert.setAttribute('hidden', 'hidden');
+        elements.modalMatches.removeAttribute('hidden');
+
+        matches.forEach((match, index) => {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>
+                    <input type="radio" name="cargusMatch" value="${index}" data-index="${index}">
+                </td>
+                <td>${match.county_name}</td>
+                <td>${match.locality_name}</td>
+                <td>${match.postal_code ?? '—'}</td>
+                <td>${match.score}%</td>
+            `;
+            elements.matchesTableBody.appendChild(row);
+        });
+    };
+
+    const fetchMatches = async () => {
+        if (!state.selectedMapping) {
+            return;
+        }
+
+        elements.modalLoading.removeAttribute('hidden');
+        elements.modalMatches.setAttribute('hidden', 'hidden');
+        elements.modalAlert.setAttribute('hidden', 'hidden');
+        elements.confirmButton.disabled = true;
+
+        try {
+            const url = new URL(apiEndpoints.search, window.location.origin);
+            url.searchParams.set('county', state.selectedMapping.county_name ?? '');
+            url.searchParams.set('locality', state.selectedMapping.locality_name ?? '');
+            url.searchParams.set('mapping_id', state.selectedMapping.id);
+
+            const response = await fetch(url.toString(), {
+                credentials: 'same-origin',
+                headers: {
+                    'Accept': 'application/json'
+                }
+            });
+
+            const data = await response.json();
+            if (!response.ok || !data.success) {
+                const message = data.error || 'Nu am putut căuta localitatea în API-ul Cargus';
+                throw new Error(message);
+            }
+
+            state.matches = data.matches || [];
+            renderMatches(state.matches);
+        } catch (error) {
+            console.error('Cargus mapping search error', error);
+            elements.modalAlert.textContent = error.message || 'Nu am putut căuta localitatea în API-ul Cargus';
+            elements.modalAlert.removeAttribute('hidden');
+        } finally {
+            elements.modalLoading.setAttribute('hidden', 'hidden');
+        }
+    };
+
+    const submitMappingUpdate = async () => {
+        if (state.selectedMatchIndex === null || state.selectedMatchIndex === undefined) {
+            showFeedback('Selectează mai întâi o potrivire Cargus.', 'error');
+            return;
+        }
+
+        const selectedMatch = state.matches[state.selectedMatchIndex];
+        if (!selectedMatch || !state.selectedMapping) {
+            showFeedback('Nu am putut identifica potrivirea selectată.', 'error');
+            return;
+        }
+
+        elements.confirmButton.disabled = true;
+        elements.confirmButton.classList.add('is-loading');
+
+        try {
+            const response = await fetch(apiEndpoints.update, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                    'X-CSRF-Token': csrfToken
+                },
+                body: JSON.stringify({
+                    mapping_id: state.selectedMapping.id,
+                    county_id: selectedMatch.county_id,
+                    locality_id: selectedMatch.locality_id,
+                    county_name: selectedMatch.county_name,
+                    locality_name: selectedMatch.locality_name,
+                    postal_code: selectedMatch.postal_code,
+                    update_orders: elements.applyToOrders?.checked ?? false
+                })
+            });
+
+            const data = await response.json();
+            if (!response.ok || !data.success) {
+                throw new Error(data.error || 'Nu am putut salva maparea selectată');
+            }
+
+            closeModal();
+            await fetchMappings();
+
+            const ordersInfo = typeof data.orders_updated === 'number'
+                ? ` · Comenzi actualizate: ${data.orders_updated}`
+                : '';
+            showFeedback(`Maparea a fost actualizată cu succes${ordersInfo}.`, 'success');
+        } catch (error) {
+            console.error('Cargus mapping update error', error);
+            elements.confirmButton.disabled = false;
+            showFeedback(error.message || 'Nu am putut salva maparea selectată', 'error');
+        } finally {
+            elements.confirmButton.classList.remove('is-loading');
+        }
+    };
+
+    const handleTableClick = (event) => {
+        const target = event.target.closest('[data-action="fix-mapping"]');
+        if (!target) {
+            return;
+        }
+        const mappingId = Number(target.dataset.id);
+        const mapping = state.mappings.find((item) => Number(item.id) === mappingId);
+        if (mapping) {
+            openModal(mapping);
+        }
+    };
+
+    const handleMatchSelection = (event) => {
+        if (event.target.name !== 'cargusMatch') {
+            return;
+        }
+        const index = Number(event.target.dataset.index);
+        if (!Number.isNaN(index)) {
+            state.selectedMatchIndex = index;
+            elements.confirmButton.disabled = false;
+        }
+    };
+
+    const initEvents = () => {
+        if (elements.tableBody) {
+            elements.tableBody.addEventListener('click', handleTableClick);
+        }
+
+        if (elements.matchesTableBody) {
+            elements.matchesTableBody.addEventListener('change', handleMatchSelection);
+        }
+
+        if (elements.retrySearchButton) {
+            elements.retrySearchButton.addEventListener('click', fetchMatches);
+        }
+
+        if (elements.confirmButton) {
+            elements.confirmButton.addEventListener('click', submitMappingUpdate);
+        }
+
+        document.querySelectorAll('[data-modal-close]').forEach((button) => {
+            button.addEventListener('click', closeModal);
+        });
+
+        if (elements.modal) {
+            elements.modal.addEventListener('click', (event) => {
+                if (event.target === elements.modal.querySelector('.mapping-modal__backdrop')) {
+                    closeModal();
+                }
+            });
+        }
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && elements.modal?.classList.contains('is-open')) {
+                closeModal();
+            }
+        });
+
+        if (elements.refreshButton) {
+            elements.refreshButton.addEventListener('click', () => {
+                fetchMappings();
+            });
+        }
+
+        if (elements.resetButton) {
+            elements.resetButton.addEventListener('click', () => {
+                elements.searchInput.value = '';
+                elements.perPageSelect.value = '20';
+                elements.onlyMissingToggle.checked = false;
+                state.search = '';
+                state.perPage = 20;
+                state.onlyMissing = false;
+                state.page = 1;
+                fetchMappings();
+            });
+        }
+
+        if (elements.searchInput) {
+            let debounceTimer;
+            elements.searchInput.addEventListener('input', (event) => {
+                clearTimeout(debounceTimer);
+                const value = event.target.value.trim();
+                debounceTimer = setTimeout(() => {
+                    state.search = value;
+                    state.page = 1;
+                    fetchMappings();
+                }, 300);
+            });
+        }
+
+        if (elements.perPageSelect) {
+            elements.perPageSelect.addEventListener('change', (event) => {
+                state.perPage = Number(event.target.value) || 20;
+                state.page = 1;
+                fetchMappings();
+            });
+        }
+
+        if (elements.onlyMissingToggle) {
+            elements.onlyMissingToggle.addEventListener('change', (event) => {
+                state.onlyMissing = event.target.checked;
+                state.page = 1;
+                fetchMappings();
+            });
+        }
+    };
+
+    document.addEventListener('DOMContentLoaded', () => {
+        initEvents();
+        fetchMappings();
+    });
+})();

--- a/styles/cargus_mappings.css
+++ b/styles/cargus_mappings.css
@@ -1,0 +1,505 @@
+.page-container {
+    gap: var(--grid-gap);
+}
+
+.mappings-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--grid-gap);
+    margin-bottom: var(--grid-gap);
+}
+
+.stat-card {
+    background: var(--surface-background);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-large);
+    padding: 1.25rem 1.5rem;
+    box-shadow: var(--card-shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    transition: var(--transition);
+}
+
+.stat-card--warning {
+    border-left: 3px solid var(--attention-color);
+}
+
+.stat-card--success {
+    border-left: 3px solid var(--success-color);
+}
+
+.stat-card__label {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.stat-card__value {
+    font-size: 1.9rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.mappings-toolbar {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    background: var(--surface-background);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-large);
+    padding: 1rem 1.5rem;
+    box-shadow: var(--card-shadow);
+}
+
+.toolbar-group,
+.toolbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.search-input,
+.select-input {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--input-background);
+    border: 1px solid var(--input-border);
+    border-radius: var(--border-radius);
+    padding: 0.65rem 0.85rem;
+}
+
+.search-input input,
+.select-input select {
+    background: transparent;
+    border: none;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    outline: none;
+    min-width: 220px;
+}
+
+.select-input select {
+    min-width: 140px;
+}
+
+.search-input .material-symbols-outlined,
+.select-input .material-symbols-outlined {
+    color: var(--text-secondary);
+}
+
+.toggle-filter {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+}
+
+.toggle-filter input {
+    accent-color: var(--primary-color);
+    width: 18px;
+    height: 18px;
+}
+
+.btn-tertiary {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    padding: 0.55rem 1.1rem;
+    border-radius: var(--border-radius);
+    transition: var(--transition);
+    cursor: pointer;
+}
+
+.btn-tertiary:hover {
+    color: var(--text-primary);
+    border-color: var(--text-secondary);
+}
+
+.btn-link {
+    background: transparent;
+    border: none;
+    color: var(--primary-color);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    cursor: pointer;
+    padding: 0;
+}
+
+.btn-link:hover {
+    text-decoration: underline;
+}
+
+.table-card {
+    background: var(--surface-background);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-large);
+    box-shadow: var(--card-shadow);
+    overflow: hidden;
+}
+
+.mappings-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.mappings-table th,
+.mappings-table td {
+    padding: 0.85rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.mappings-table thead th {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.mappings-table tbody tr:hover {
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.table-placeholder {
+    text-align: center;
+    color: var(--text-secondary);
+    padding: 2.5rem 1rem;
+}
+
+.mapping-row--missing {
+    border-left: 3px solid var(--attention-color);
+    background: rgba(255, 123, 0, 0.08);
+}
+
+.mapping-row--missing td {
+    border-bottom-color: rgba(255, 123, 0, 0.15);
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text-primary);
+}
+
+.badge--missing {
+    background: rgba(255, 123, 0, 0.15);
+    color: #ffb267;
+}
+
+.badge--verified {
+    background: rgba(25, 135, 84, 0.18);
+    color: #65d69d;
+}
+
+.mapping-confidence {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.table-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.table-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.85rem 1rem;
+    background: rgba(255, 255, 255, 0.02);
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.results-summary {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.pagination {
+    display: inline-flex;
+    gap: 0.4rem;
+    align-items: center;
+}
+
+.pagination button {
+    background: var(--input-background);
+    border: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    padding: 0.35rem 0.75rem;
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.pagination button[disabled],
+.pagination button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.pagination button.active {
+    background: var(--primary-color);
+    color: #fff;
+    border-color: var(--primary-color);
+}
+
+.feedback-banner {
+    margin-top: 1rem;
+    padding: 0.85rem 1rem;
+    border-radius: var(--border-radius);
+    border: 1px solid transparent;
+    display: none;
+}
+
+.feedback-banner.is-visible {
+    display: block;
+}
+
+.feedback-banner--success {
+    background: rgba(25, 135, 84, 0.18);
+    border-color: rgba(25, 135, 84, 0.45);
+    color: #65d69d;
+}
+
+.feedback-banner--error {
+    background: rgba(220, 53, 69, 0.18);
+    border-color: rgba(220, 53, 69, 0.45);
+    color: #ff9aa6;
+}
+
+.page-loading {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 16, 19, 0.75);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1200;
+}
+
+.page-loading__content {
+    background: var(--surface-background);
+    padding: 1.5rem 2rem;
+    border-radius: var(--border-radius-large);
+    box-shadow: var(--card-shadow);
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.mapping-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    z-index: 1300;
+}
+
+.mapping-modal.is-open {
+    display: block;
+}
+
+.mapping-modal__backdrop {
+    position: absolute;
+    inset: 0;
+    background: var(--modal-backdrop-color);
+}
+
+.mapping-modal__dialog {
+    position: relative;
+    max-width: 720px;
+    margin: 5vh auto;
+    background: var(--modal-surface-background);
+    border-radius: var(--border-radius-large);
+    border: 1px solid var(--modal-border-color);
+    box-shadow: var(--modal-shadow);
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+}
+
+.mapping-modal__header,
+.mapping-modal__footer {
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.mapping-modal__body {
+    padding: 0 1.5rem 1.5rem;
+    overflow-y: auto;
+}
+
+.mapping-modal__title {
+    font-size: 1.4rem;
+    margin-bottom: 0.2rem;
+}
+
+.mapping-modal__subtitle {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.mapping-modal__summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.2rem;
+    padding: 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.summary-label {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.summary-value {
+    font-size: 1.05rem;
+}
+
+.summary-meta {
+    grid-column: 1 / -1;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.mapping-modal__alert {
+    padding: 0.75rem 1rem;
+    border-radius: var(--border-radius);
+    margin-bottom: 1rem;
+    border: 1px solid rgba(255, 123, 0, 0.45);
+    background: rgba(255, 123, 0, 0.12);
+    color: #ffb267;
+}
+
+.mapping-modal__loading {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem;
+    border: 1px dashed var(--border-color);
+    border-radius: var(--border-radius);
+    color: var(--text-secondary);
+}
+
+.mapping-modal__matches {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.matches-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.matches-table table {
+    width: 100%;
+    border-collapse: collapse;
+    border-radius: var(--border-radius);
+    overflow: hidden;
+}
+
+.matches-table th,
+.matches-table td {
+    padding: 0.65rem 0.75rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    text-align: left;
+}
+
+.matches-table tbody tr:hover {
+    background: rgba(13, 110, 253, 0.08);
+}
+
+.orders-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+}
+
+.orders-toggle input {
+    accent-color: var(--primary-color);
+    width: 18px;
+    height: 18px;
+}
+
+.footer-actions {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.modal-close {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 0.25rem;
+    border-radius: 50%;
+    transition: var(--transition);
+}
+
+.modal-close:hover {
+    color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.btn.is-loading {
+    opacity: 0.65;
+    pointer-events: none;
+}
+
+.spinning {
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+@media (max-width: 768px) {
+    .mappings-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .toolbar-group,
+    .toolbar-actions {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .search-input input,
+    .select-input select {
+        min-width: 0;
+        width: 100%;
+    }
+
+    .mapping-modal__dialog {
+        margin: 3vh 1rem;
+        max-width: none;
+    }
+}


### PR DESCRIPTION
## Summary
- add an admin Mapări Cargus page with highlighting, filters, and modal workflow so staff can complete missing locality mappings
- expose API endpoints and CargusService helpers that perform fuzzy county/locality searches via the Cargus API and persist verified mappings with audit logs
- allow optional propagation of manually verified mappings to pending orders and update navigation/assets to surface the tool in the admin UI

## Testing
- php -l cargus_mappings.php
- php -l api/cargus_mappings/list.php
- php -l api/cargus_mappings/search.php
- php -l api/cargus_mappings/update.php
- php -l models/CargusService.php

------
https://chatgpt.com/codex/tasks/task_e_68de264fa7b083208e048cf0568c81a6