### PR TITLE
Allow selecting storage level during factory receiving

### DIFF
--- a/warehouse_receiving.php
+++ b/warehouse_receiving.php
@@ -76,6 +76,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 // Get active locations for dropdown
 $locations = $locationModel->getActiveLocations();
+$locationLevels = $locationModel->getActiveLocationLevels();
 
 // Get recent receiving sessions for quick access
 $recentSessions = [];
@@ -220,6 +221,9 @@ $currentPage = 'warehouse_receiving';
                                 </div>
                                 <div class="form-group">
                                     <label class="form-label">Locație de depozitare</label>
+                                    <select id="prod-location-select" class="form-input" data-placeholder="Selectează nivelul de depozitare">
+                                        <option value="">Selectează nivelul de depozitare</option>
+                                    </select>
                                     <div id="prod-location-info" class="production-location-info" data-state="idle">
                                         Selectează un produs pentru a vedea locația sugerată de stocare.
                                     </div>
@@ -501,6 +505,17 @@ $currentPage = 'warehouse_receiving';
                     'type' => $loc['type']
                 ];
             }, $locations)) ?>,
+            locationLevels: <?= json_encode(array_map(function($level) {
+                return [
+                    'location_id' => $level['location_id'],
+                    'location_code' => $level['location_code'],
+                    'zone' => $level['zone'],
+                    'type' => $level['type'],
+                    'level_number' => $level['level_number'],
+                    'level_name' => $level['level_name'],
+                    'display_code' => $level['display_code']
+                ];
+            }, $locationLevels)) ?>,
             defaultLocation: '<?= htmlspecialchars($locations[0]['location_code'] ?? '') ?>'
         };
     </script>


### PR DESCRIPTION
## Summary
- add a selectable storage level field to the production receiving flow and expose level metadata from the backend
- update the warehouse receiving frontend to manage level suggestions, messaging, and submit the chosen location level
- extend the production receipt API to accept the selected level/shelf metadata when adding stock

## Testing
- php -l models/Location.php
- php -l warehouse_receiving.php
- php -l api/receiving/record_production_receipt.php

------
https://chatgpt.com/codex/tasks/task_e_68de6803c24c8320b01a36812bab8129