### PR TITLE
Fix order status update errors and refresh order badge styling

### DIFF
--- a/orders.php
+++ b/orders.php
@@ -645,22 +645,34 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
             display: inline-flex;
             align-items: center;
             gap: 0.35rem;
-            padding: 0.25rem 0.55rem;
+            padding: 0.2rem 0.6rem;
             border-radius: 9999px;
-            font-size: 0.85rem;
+            font-size: 0.78rem;
             font-weight: 600;
-            background: #e0e7ff;
-            color: #1e3a8a;
+            letter-spacing: 0.01em;
+            text-transform: none;
+            border: 1px solid var(--border-color);
+            background-color: rgba(148, 161, 178, 0.14);
+            color: var(--text-secondary);
         }
 
-        .order-status-badge.canceled {
-            background: #f8d7da;
-            color: #842029;
+        [data-theme="dark"] .order-status-badge {
+            background-color: rgba(148, 161, 178, 0.2);
+            color: var(--text-primary);
+            border-color: rgba(148, 161, 178, 0.35);
+        }
+
+        .order-status-badge .material-symbols-outlined {
+            font-size: 1rem;
+        }
+
+        .order-status-badge .order-status-text {
+            line-height: 1;
         }
 
         .order-status-meta {
             font-size: 0.78rem;
-            color: #475467;
+            color: var(--text-secondary);
             margin-top: 0.25rem;
             line-height: 1.2;
         }
@@ -944,6 +956,8 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                                                 $statusKey = strtolower((string)$order['status']);
                                                 $isOrderCanceled = $statusKey === 'canceled';
                                                 $statusLabel = $statusDisplayLabels[$statusKey] ?? ($statuses[$statusKey] ?? ucfirst((string)$order['status']));
+                                                $statusClassSuffix = trim(preg_replace('/[^a-z0-9_-]+/', '-', $statusKey), '-');
+                                                $orderStatusBadgeClasses = 'status-badge order-status-badge' . ($statusClassSuffix !== '' ? ' status-' . $statusClassSuffix : '');
                                                 $awbBarcode = trim((string)($order['awb_barcode'] ?? ''));
 
                                                 $canceledAtRaw = $order['canceled_at'] ?? null;
@@ -1005,7 +1019,7 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                                                     <small class="order-date-value"><?= date('d.m.Y H:i', strtotime($order['order_date'])) ?></small>
                                                 </td>
                                                 <td>
-                                                    <span class="order-status-badge <?= $isOrderCanceled ? 'canceled' : '' ?>"
+                                                    <span class="<?= htmlspecialchars($orderStatusBadgeClasses) ?>"
                                                           data-status="<?= htmlspecialchars($statusKey) ?>">
                                                         <span class="material-symbols-outlined" aria-hidden="true">
                                                             <?= $isOrderCanceled ? 'block' : 'flag' ?>

--- a/scripts/orders.js
+++ b/scripts/orders.js
@@ -277,8 +277,22 @@ function updateOrderRow(row, order) {
 
     const statusBadge = row.querySelector('.order-status-badge');
     if (statusBadge) {
+        const sanitizedStatus = sanitizeStatus(status);
         statusBadge.dataset.status = status;
-        statusBadge.classList.toggle('canceled', isCanceled);
+
+        const classesToRemove = Array.from(statusBadge.classList).filter((cls) =>
+            cls.startsWith('status-') &&
+            cls !== 'status-badge' &&
+            cls !== 'status-change-flash' &&
+            cls !== `status-${sanitizedStatus}`
+        );
+
+        classesToRemove.forEach((cls) => statusBadge.classList.remove(cls));
+        statusBadge.classList.add('status-badge', 'order-status-badge');
+        if (sanitizedStatus) {
+            statusBadge.classList.add(`status-${sanitizedStatus}`);
+        }
+
         const statusIcon = statusBadge.querySelector('.material-symbols-outlined');
         if (statusIcon) {
             statusIcon.textContent = isCanceled ? 'block' : 'flag';
@@ -371,6 +385,7 @@ function updateOrderRow(row, order) {
 function renderOrderRow(order) {
     const row = document.createElement('tr');
     const status = (order.status || '').toLowerCase();
+    const sanitizedStatus = sanitizeStatus(status);
     const statusRaw = order.status_raw || order.status || status;
     const isCanceled = status === 'canceled';
 
@@ -409,7 +424,7 @@ function renderOrderRow(order) {
             <small class="order-date-value">${escapeHtml(orderDateDisplay || '')}</small>
         </td>
         <td>
-            <span class="order-status-badge${isCanceled ? ' canceled' : ''}" data-status="${escapeHtml(status)}">
+            <span class="${['status-badge', 'order-status-badge', sanitizedStatus ? `status-${sanitizedStatus}` : ''].filter(Boolean).join(' ')}" data-status="${escapeHtml(status)}">
                 <span class="material-symbols-outlined">${isCanceled ? 'block' : 'flag'}</span>
                 <span class="order-status-text">${escapeHtml(order.status_label || capitalize(status))}</span>
             </span>

--- a/styles/awb_generation.css
+++ b/styles/awb_generation.css
@@ -150,11 +150,19 @@
 }
 
 .orders-table tr.has-stock-issue {
-    background-color: #fff6f6;
+    background-color: rgba(220, 53, 69, 0.08);
 }
 
 .orders-table tr.has-stock-issue:hover {
-    background-color: #ffecec;
+    background-color: rgba(220, 53, 69, 0.12);
+}
+
+[data-theme="dark"] .orders-table tr.has-stock-issue {
+    background-color: rgba(220, 53, 69, 0.16);
+}
+
+[data-theme="dark"] .orders-table tr.has-stock-issue:hover {
+    background-color: rgba(220, 53, 69, 0.22);
 }
 
 .stock-status-cell {
@@ -177,20 +185,34 @@
 }
 
 .stock-status.stock-ok {
-    background-color: #e8f5e9;
-    color: #1b5e20;
+    background-color: rgba(25, 135, 84, 0.12);
+    color: var(--success-color);
+}
+
+[data-theme="dark"] .stock-status.stock-ok {
+    background-color: rgba(25, 135, 84, 0.18);
+    color: #72e0a9;
 }
 
 .stock-status.stock-missing {
-    background-color: #fdecea;
-    color: #c62828;
+    background-color: rgba(220, 53, 69, 0.12);
+    color: var(--danger-color);
+}
+
+[data-theme="dark"] .stock-status.stock-missing {
+    background-color: rgba(220, 53, 69, 0.2);
+    color: #ffb3bc;
 }
 
 .stock-status-details {
     margin-top: 0.35rem;
     font-size: 0.75rem;
-    color: #9c1f1f;
+    color: var(--danger-color);
     line-height: 1.35;
+}
+
+[data-theme="dark"] .stock-status-details {
+    color: #ffb3bc;
 }
 
 .stock-status-details div + div {

--- a/styles/orders.css
+++ b/styles/orders.css
@@ -500,6 +500,95 @@
     border: 1px solid rgba(220, 53, 69, 0.2);
 }
 
+.order-status-badge {
+    text-transform: none;
+    letter-spacing: 0.01em;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    border: 1px solid var(--border-color);
+    background-color: rgba(148, 161, 178, 0.14);
+    color: var(--text-secondary);
+}
+
+[data-theme="dark"] .order-status-badge {
+    background-color: rgba(148, 161, 178, 0.2);
+    color: var(--text-primary);
+    border-color: rgba(148, 161, 178, 0.35);
+}
+
+.order-status-badge .material-symbols-outlined {
+    font-size: 1rem;
+}
+
+.order-status-badge .order-status-text {
+    line-height: 1;
+}
+
+.order-status-badge.status-pending,
+.order-status-badge.status-processing,
+.order-status-badge.status-confirmed,
+.order-status-badge.status-ready,
+.order-status-badge.status-ready_to_ship {
+    background-color: rgba(13, 110, 253, 0.12);
+    color: #0d6efd;
+    border-color: rgba(13, 110, 253, 0.25);
+}
+
+[data-theme="dark"] .order-status-badge.status-pending,
+[data-theme="dark"] .order-status-badge.status-processing,
+[data-theme="dark"] .order-status-badge.status-confirmed,
+[data-theme="dark"] .order-status-badge.status-ready,
+[data-theme="dark"] .order-status-badge.status-ready_to_ship {
+    background-color: rgba(13, 110, 253, 0.2);
+    color: #93c5fd;
+    border-color: rgba(147, 197, 253, 0.35);
+}
+
+.order-status-badge.status-picked,
+.order-status-badge.status-shipped,
+.order-status-badge.status-completed,
+.order-status-badge.status-delivered {
+    background-color: rgba(25, 135, 84, 0.12);
+    color: var(--success-color);
+    border-color: rgba(25, 135, 84, 0.25);
+}
+
+[data-theme="dark"] .order-status-badge.status-picked,
+[data-theme="dark"] .order-status-badge.status-shipped,
+[data-theme="dark"] .order-status-badge.status-completed,
+[data-theme="dark"] .order-status-badge.status-delivered {
+    background-color: rgba(25, 135, 84, 0.2);
+    color: #7be9b3;
+    border-color: rgba(123, 233, 179, 0.35);
+}
+
+.order-status-badge.status-canceled,
+.order-status-badge.status-cancelled {
+    background-color: rgba(220, 53, 69, 0.12);
+    color: var(--danger-color);
+    border-color: rgba(220, 53, 69, 0.28);
+}
+
+[data-theme="dark"] .order-status-badge.status-canceled,
+[data-theme="dark"] .order-status-badge.status-cancelled {
+    background-color: rgba(220, 53, 69, 0.2);
+    color: #ffb3bc;
+    border-color: rgba(220, 53, 69, 0.4);
+}
+
+.order-status-badge.status-returned {
+    background-color: rgba(255, 193, 7, 0.14);
+    color: #b58100;
+    border-color: rgba(255, 193, 7, 0.3);
+}
+
+[data-theme="dark"] .order-status-badge.status-returned {
+    background-color: rgba(255, 193, 7, 0.22);
+    color: #ffd166;
+    border-color: rgba(255, 193, 7, 0.45);
+}
+
 /* ===== PRIORITY BADGES ===== */
 .priority-badge {
     display: inline-flex;


### PR DESCRIPTION
## Summary
- avoid referencing missing cancellation columns when updating an order status so status changes and cancellations succeed
- restyle the order status badge to use shared status classes and align with the dashboard theme
- update stock warning styling for dark mode and ensure the frontend keeps badge classes synchronized

## Testing
- php -l models/Order.php
- php -l orders.php

------
https://chatgpt.com/codex/tasks/task_e_68e243def6388320b22bcd77fe04c22f