### PR TITLE
Fix order cancellation status handling

### DIFF
--- a/orders.php
+++ b/orders.php
@@ -471,6 +471,9 @@ if (isset($_GET['export_orders_pdf']) && $_GET['export_orders_pdf'] === '1') {
 
 // Get filters and search
 $statusFilter = $_GET['status'] ?? '';
+if ($statusFilter !== '') {
+    $statusFilter = Order::normalizeStatus($statusFilter);
+}
 $priorityFilter = $_GET['priority'] ?? '';
 $search = trim($_GET['search'] ?? '');
 $requestedView = $_POST['view'] ?? $_GET['view'] ?? 'active';
@@ -480,7 +483,7 @@ if (!in_array($viewMode, $allowedViewModes, true)) {
     $viewMode = 'active';
 }
 
-if ($statusFilter === 'canceled' && $viewMode !== 'canceled') {
+if (Order::isCanceledStatus($statusFilter) && $viewMode !== 'canceled') {
     $viewMode = 'canceled';
 }
 
@@ -495,6 +498,12 @@ $offset = ($page - 1) * $pageSize;
 $totalCount = $orderModel->getTotalCount($statusFilter, $priorityFilter, $search, $viewMode);
 $totalPages = max(1, ceil($totalCount / $pageSize));
 $orders = $orderModel->getOrdersPaginated($pageSize, $offset, $statusFilter, $priorityFilter, $search, $viewMode);
+foreach ($orders as &$orderRow) {
+    if (isset($orderRow['status'])) {
+        $orderRow['status'] = Order::normalizeStatus($orderRow['status']);
+    }
+}
+unset($orderRow);
 $orderIds = array_map(static function ($orderRow) {
     return (int)($orderRow['id'] ?? 0);
 }, $orders);
@@ -953,8 +962,8 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
                                                 $stockStatusTitle = $hasStockIssue
                                                     ? implode(' • ', $stockIssueMessages)
                                                     : 'Stoc disponibil pentru toate produsele din comandă.';
-                                                $statusKey = strtolower((string)$order['status']);
-                                                $isOrderCanceled = $statusKey === 'canceled';
+                                                $statusKey = Order::normalizeStatus($order['status'] ?? '');
+                                                $isOrderCanceled = Order::isCanceledStatus($order['status'] ?? '');
                                                 $statusLabel = $statusDisplayLabels[$statusKey] ?? ($statuses[$statusKey] ?? ucfirst((string)$order['status']));
                                                 $statusClassSuffix = trim(preg_replace('/[^a-z0-9_-]+/', '-', $statusKey), '-');
                                                 $orderStatusBadgeClasses = 'status-badge order-status-badge' . ($statusClassSuffix !== '' ? ' status-' . $statusClassSuffix : '');


### PR DESCRIPTION
## Summary
- normalize cancellation statuses in the Order model so enum values using `cancelled` are written and filtered consistently
- update orders.php to treat cancelled orders as canceled in filters, counts, and row rendering
- align the orders page JavaScript with the new status normalization so UI updates and actions work for cancelled orders

## Testing
- php -l orders.php
- php -l models/Order.php

------
https://chatgpt.com/codex/tasks/task_e_68e248915b648320a5c259b4aae3679e