### PR TITLE
Replace AWB timeline with custom horizontal layout

### DIFF
--- a/styles/orders_awb_tracking.css
+++ b/styles/orders_awb_tracking.css
@@ -204,82 +204,76 @@
 }
 
 
+
 .awb-timeline-container {
-    min-height: 140px;
     position: relative;
+    min-height: 150px;
+    padding: 0.5rem 0.75rem 1rem;
+    overflow-x: auto;
+    scrollbar-width: thin;
 }
 
 .awb-timeline-container[hidden] {
     display: none;
 }
 
-.awb-timeline-container .vis-timeline {
-    border: none;
-    background: transparent;
-}
-
-.awb-timeline-container .vis-panel.vis-center,
-.awb-timeline-container .vis-panel.vis-left,
-.awb-timeline-container .vis-panel.vis-right {
-    border: none !important;
-}
-
-.awb-timeline-container .vis-panel.vis-bottom {
-    display: none !important;
-}
-
-.awb-timeline-container .vis-time-axis {
-    display: none !important;
-}
-
-.awb-timeline-container .vis-item.awb-timeline-node {
-    border: none;
-    background: transparent;
-    color: inherit;
-    box-shadow: none;
-    overflow: visible;
-}
-
-.awb-timeline-container .vis-item .vis-item-content {
+.awb-timeline-track {
     display: flex;
-    justify-content: center;
-    align-items: stretch;
-    padding: 0;
-    background: transparent;
-    border: none;
-    white-space: normal;
-    overflow: visible;
+    align-items: flex-start;
+    gap: 3rem;
+    min-height: 150px;
+    width: max-content;
+    padding: 0.5rem 0;
 }
 
-.awb-timeline-node__inner {
-    position: relative;
+.awb-timeline-event {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.55rem;
     text-align: center;
-    min-width: 160px;
+    gap: 0.5rem;
+    min-width: 140px;
     max-width: 220px;
-    padding: 0.75rem 1rem;
-    box-sizing: border-box;
 }
 
-.awb-timeline-node__date {
-    font-weight: 700;
-    font-size: 0.95rem;
+.awb-timeline-event-date {
+    font-size: 0.75rem;
+    font-weight: 600;
     color: var(--text-primary, #1d2939);
-    line-height: 1.25;
+    line-height: 1.3;
 }
 
-.awb-timeline-node__details {
-    font-size: 0.85rem;
+.awb-timeline-event-marker-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    min-height: 24px;
+}
+
+.awb-timeline-event-line {
+    flex: 1 1 auto;
+    height: 2px;
+    background: rgba(249, 115, 22, 0.4);
+}
+
+.awb-timeline-event-marker {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #f97316;
+    box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.2);
+}
+
+.awb-timeline-event-description {
+    font-size: 0.65rem;
     color: var(--text-secondary, #475467);
     line-height: 1.4;
     word-break: break-word;
 }
 
-.awb-timeline-node__location {
-    font-size: 0.82rem;
+.awb-timeline-event-location {
+    font-size: 0.6875rem;
     font-weight: 600;
     letter-spacing: 0.02em;
     color: #f97316;
@@ -288,68 +282,37 @@
     word-break: break-word;
 }
 
-.awb-timeline-node__marker {
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    background: #f97316;
-    border: 3px solid #f97316;
-    position: relative;
-    box-shadow: 0 0 0 6px rgba(249, 115, 22, 0.2);
+.awb-timeline-event--first .awb-timeline-event-line--left,
+.awb-timeline-event--last .awb-timeline-event-line--right {
+    visibility: hidden;
 }
 
-.awb-timeline-node__marker::before,
-.awb-timeline-node__marker::after {
-    content: '';
-    position: absolute;
-    top: 50%;
-    width: 68px;
-    height: 2px;
-    background: rgba(249, 115, 22, 0.35);
-    transform: translateY(-50%);
-}
-
-.awb-timeline-node__marker::before {
-    left: calc(-68px - 3px);
-}
-
-.awb-timeline-node__marker::after {
-    right: calc(-68px - 3px);
-}
-
-.awb-timeline-node--first .awb-timeline-node__marker::before {
-    display: none;
-}
-
-.awb-timeline-node--last .awb-timeline-node__marker::after {
-    display: none;
-}
-
-.awb-timeline-node--return .awb-timeline-node__marker {
+.awb-timeline-event--return .awb-timeline-event-marker {
     background: #dc3545;
-    border-color: #dc3545;
-    box-shadow: 0 0 0 6px rgba(220, 53, 69, 0.2);
+    box-shadow: 0 0 0 4px rgba(220, 53, 69, 0.2);
 }
 
-.awb-timeline-node--return .awb-timeline-node__marker::before,
-.awb-timeline-node--return .awb-timeline-node__marker::after {
+.awb-timeline-event--return .awb-timeline-event-line {
     background: rgba(220, 53, 69, 0.35);
 }
 
-[data-theme="dark"] .awb-timeline-node__date {
+[data-theme="dark"] .awb-timeline-container {
+    scrollbar-color: rgba(250, 174, 97, 0.4) transparent;
+}
+
+[data-theme="dark"] .awb-timeline-event-date {
     color: #e2e8f0;
 }
 
-[data-theme="dark"] .awb-timeline-node__details {
+[data-theme="dark"] .awb-timeline-event-description {
     color: #cbd5f5;
 }
 
-[data-theme="dark"] .awb-timeline-node__location {
+[data-theme="dark"] .awb-timeline-event-location {
     color: #faae61;
 }
 
-[data-theme="dark"] .awb-timeline-node__marker::before,
-[data-theme="dark"] .awb-timeline-node__marker::after {
+[data-theme="dark"] .awb-timeline-event-line {
     background: rgba(250, 174, 97, 0.35);
 }
 
@@ -376,8 +339,8 @@
         padding: 0.9rem;
     }
 
-    .awb-timeline-node__inner {
-        min-width: 140px;
+    .awb-timeline-event {
+        min-width: 130px;
         max-width: 200px;
     }
 }
@@ -396,10 +359,9 @@
         justify-content: space-between;
     }
 
-    .awb-timeline-node__inner {
+    .awb-timeline-event {
         min-width: 120px;
-        max-width: 180px;
-        padding: 0.65rem 0.75rem;
+        max-width: 170px;
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the vis-timeline dependency with a DOM-built AWB history timeline that keeps caching and expand/collapse behaviour
- normalise tracking events with improved date parsing and build accessible timeline markup with markers, descriptions, and locations
- restyle the AWB timeline container and nodes with flexbox for a horizontal, scrollable presentation that matches the requested design specs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e29dd788448320b84b25cf1f7697e4