### PR TITLE
Add pending returns search endpoint

### DIFF
--- a/api/warehouse/search_pending_returns.php
+++ b/api/warehouse/search_pending_returns.php
@@ -1,0 +1,98 @@
+<?php
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Unauthorized']);
+    exit;
+}
+
+$config = require BASE_PATH . '/config/config.php';
+$dbFactory = $config['connection_factory'];
+$db = $dbFactory();
+
+$company = trim($_GET['company'] ?? '');
+$length = function_exists('mb_strlen') ? mb_strlen($company) : strlen($company);
+
+if ($company === '' || $length < 2) {
+    echo json_encode([
+        'success' => true,
+        'returns' => [],
+        'message' => $company === '' ? 'No search term provided' : 'Search term too short'
+    ]);
+    exit;
+}
+
+try {
+    $normalizedSearch = function_exists('mb_strtolower') ? mb_strtolower($company) : strtolower($company);
+
+    $stmt = $db->prepare(
+        "SELECT 
+            r.id AS return_id,
+            r.order_id,
+            o.order_number,
+            o.customer_name,
+            r.status AS return_status,
+            r.return_awb,
+            r.return_date,
+            r.notes,
+            r.created_at,
+            COUNT(oi.id) AS total_items
+        FROM returns r
+        JOIN orders o ON r.order_id = o.id
+        LEFT JOIN order_items oi ON oi.order_id = o.id
+        WHERE r.status IN ('pending', 'in_progress')
+          AND LOWER(o.customer_name) LIKE :search
+        GROUP BY r.id, r.order_id, o.order_number, o.customer_name, r.status, r.return_awb, r.return_date, r.notes, r.created_at
+        ORDER BY r.return_date DESC, r.created_at DESC
+        LIMIT 50"
+    );
+
+    $stmt->execute([':search' => '%' . $normalizedSearch . '%']);
+    $returns = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $statusMap = [
+        'pending' => 'În așteptare',
+        'in_progress' => 'În curs',
+        'completed' => 'Finalizat',
+        'cancelled' => 'Anulat'
+    ];
+
+    $formatted = array_map(function ($return) use ($statusMap) {
+        $status = strtolower($return['return_status'] ?? '');
+
+        return [
+            'return_id' => (int)($return['return_id'] ?? 0),
+            'order_id' => isset($return['order_id']) ? (int)$return['order_id'] : null,
+            'id' => isset($return['order_id']) ? (int)$return['order_id'] : null,
+            'order_number' => $return['order_number'] ?? null,
+            'customer_name' => $return['customer_name'] ?? 'Client necunoscut',
+            'return_status' => $status,
+            'status_label' => $statusMap[$status] ?? ($return['return_status'] ?? 'Necunoscut'),
+            'return_awb' => $return['return_awb'] ?? null,
+            'return_date' => $return['return_date'] ?? null,
+            'notes' => $return['notes'] ?? null,
+            'created_at' => $return['created_at'] ?? null,
+            'total_items' => (int)($return['total_items'] ?? 0)
+        ];
+    }, $returns);
+
+    echo json_encode([
+        'success' => true,
+        'returns' => $formatted,
+        'count' => count($formatted)
+    ]);
+} catch (Exception $e) {
+    error_log('search_pending_returns error: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Server error'
+    ]);
+}

--- a/scripts/warehouse-js/warehouse_receiving.js
+++ b/scripts/warehouse-js/warehouse_receiving.js
@@ -397,7 +397,7 @@ class WarehouseReceiving {
             container.innerHTML = `
                 <div class="empty-state">
                     <span class="material-symbols-outlined">travel_explore</span>
-                    <p>Introduceți numele unei companii pentru a vedea comenzile pregătite pentru retur.</p>
+                    <p>Introduceți numele unei companii pentru a vedea retururile active.</p>
                 </div>
             `;
             return;
@@ -431,17 +431,17 @@ class WarehouseReceiving {
         this.returnSearchAbortController = new AbortController();
 
         try {
-            const response = await fetch(`${this.config.apiBase}/warehouse/search_picked_orders.php?company=${encodeURIComponent(trimmedQuery)}`, {
+            const response = await fetch(`${this.config.apiBase}/warehouse/search_pending_returns.php?company=${encodeURIComponent(trimmedQuery)}`, {
                 signal: this.returnSearchAbortController.signal
             });
             const result = await response.json();
 
             if (!response.ok) {
-                throw new Error(result.message || 'Nu am putut căuta comenzile pregătite.');
+                throw new Error(result.message || 'Nu am putut căuta retururile active.');
             }
 
-            const orders = Array.isArray(result.orders) ? result.orders : [];
-            this.renderReturnOrders(orders, trimmedQuery);
+            const returns = Array.isArray(result.returns) ? result.returns : [];
+            this.renderReturnOrders(returns, trimmedQuery);
         } catch (error) {
             if (error.name === 'AbortError') {
                 return;
@@ -450,7 +450,7 @@ class WarehouseReceiving {
             console.error('Return search error:', error);
             container.innerHTML = `
                 <div class="return-orders-error">
-                    ${this.escapeHtml(error.message || 'A apărut o eroare la încărcarea comenzilor de retur.')}
+                    ${this.escapeHtml(error.message || 'A apărut o eroare la încărcarea retururilor active.')}
                 </div>
             `;
             this.toggleReturnRestockHint();
@@ -469,7 +469,7 @@ class WarehouseReceiving {
         container.innerHTML = `
             <div class="returns-loading">
                 <span class="material-symbols-outlined">autorenew</span>
-                <span>Căutăm comenzile pregătite...</span>
+                <span>Căutăm retururile active...</span>
             </div>
         `;
 
@@ -489,7 +489,7 @@ class WarehouseReceiving {
             container.innerHTML = `
                 <div class="empty-state">
                     <span class="material-symbols-outlined">inventory_2</span>
-                    <p>Nu am găsit comenzi pregătite pentru compania <strong>${this.escapeHtml(query)}</strong>.</p>
+                    <p>Nu am găsit retururi active pentru compania <strong>${this.escapeHtml(query)}</strong>.</p>
                 </div>
             `;
             this.clearReturnSelection();

--- a/warehouse_receiving.php
+++ b/warehouse_receiving.php
@@ -362,7 +362,7 @@ $currentPage = 'warehouse_receiving';
                                     <span class="material-symbols-outlined">assignment_return</span>
                                     Recepție Retururi
                                 </h2>
-                                <p class="returns-panel-subtitle">Caută comenzile pregătite (status „picked”) după numele companiei</p>
+                                <p class="returns-panel-subtitle">Caută retururile active după numele companiei</p>
                             </div>
                             <div class="returns-search">
                                 <label for="return-company-search" class="form-label">Companie</label>
@@ -370,14 +370,14 @@ $currentPage = 'warehouse_receiving';
                                     <span class="material-symbols-outlined">search</span>
                                     <input type="text" id="return-company-search" class="form-input" placeholder="Introdu numele companiei">
                                 </div>
-                                <p class="returns-hint">Rezultatele afișează comenzile deja ridicate, cele mai recente apar primele.</p>
+                                <p class="returns-hint">Rezultatele afișează retururile active, cele mai recente apar primele.</p>
                             </div>
                             <div class="returns-panel-content">
                                 <div class="return-orders-column">
                                     <div id="return-orders-results" class="return-orders-results">
                                         <div class="empty-state">
                                             <span class="material-symbols-outlined">travel_explore</span>
-                                            <p>Introduceți numele unei companii pentru a vedea comenzile pregătite pentru retur.</p>
+                                            <p>Introduceți numele unei companii pentru a vedea retururile active.</p>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- add a warehouse API endpoint to search pending and in-progress returns
- return enriched metadata including order, customer, and item counts
- update the receiving UI to call the pending returns search and adjust copy for active returns
- expose an `id` alias for the order identifier in return search results for UI compatibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3fe4e32c88320a9a230e786306ad1