### PR TITLE
Add per-item return verification workflow

### DIFF
--- a/api/warehouse/add_return_item.php
+++ b/api/warehouse/add_return_item.php
@@ -1,0 +1,275 @@
+<?php
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Neautorizat.']);
+    exit;
+}
+
+$csrfToken = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+if (function_exists('apache_request_headers')) {
+    $headers = array_change_key_case(apache_request_headers(), CASE_UPPER);
+    $csrfToken = $csrfToken ?: ($headers['X-CSRF-TOKEN'] ?? '');
+}
+
+if (!validateCsrfToken($csrfToken)) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Token CSRF invalid.']);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Metodă nepermisă.']);
+    exit;
+}
+
+try {
+    $config = require BASE_PATH . '/config/config.php';
+    $dbFactory = $config['connection_factory'] ?? null;
+    if (!$dbFactory || !is_callable($dbFactory)) {
+        throw new RuntimeException('Conexiunea la baza de date nu este disponibilă.');
+    }
+
+    $db = $dbFactory();
+
+    $payload = json_decode(file_get_contents('php://input'), true);
+    if (!is_array($payload)) {
+        throw new InvalidArgumentException('Date JSON invalide.');
+    }
+
+    $returnId = isset($payload['return_id']) ? (int)$payload['return_id'] : 0;
+    $orderItemId = isset($payload['order_item_id']) ? (int)$payload['order_item_id'] : 0;
+    $productId = isset($payload['product_id']) ? (int)$payload['product_id'] : 0;
+    $quantityReceived = isset($payload['quantity_received']) ? (int)$payload['quantity_received'] : 0;
+    $condition = isset($payload['condition']) ? strtolower(trim((string)$payload['condition'])) : '';
+    $locationId = isset($payload['location_id']) ? (int)$payload['location_id'] : 0;
+    $notes = isset($payload['notes']) ? trim((string)$payload['notes']) : '';
+
+    if ($returnId <= 0) {
+        throw new InvalidArgumentException('Returul selectat nu este valid.');
+    }
+    if ($orderItemId <= 0) {
+        throw new InvalidArgumentException('Articolul din comandă este obligatoriu.');
+    }
+    if ($productId <= 0) {
+        throw new InvalidArgumentException('Produsul selectat nu este valid.');
+    }
+    if ($quantityReceived < 0) {
+        throw new InvalidArgumentException('Cantitatea primită trebuie să fie un număr pozitiv.');
+    }
+    if ($locationId <= 0) {
+        throw new InvalidArgumentException('Selectați o locație de depozitare pentru produs.');
+    }
+
+    $allowedConditions = ['good', 'damaged', 'defective', 'opened'];
+    if (!in_array($condition, $allowedConditions, true)) {
+        throw new InvalidArgumentException('Selectați o stare validă pentru produs.');
+    }
+
+    $db->beginTransaction();
+
+    // Validate return record
+    $returnStmt = $db->prepare('SELECT id, order_id FROM returns WHERE id = :id LIMIT 1');
+    $returnStmt->execute([':id' => $returnId]);
+    $returnRow = $returnStmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$returnRow) {
+        throw new InvalidArgumentException('Returul selectat nu a fost găsit.');
+    }
+
+    $orderId = (int)($returnRow['order_id'] ?? 0);
+    if ($orderId <= 0) {
+        throw new InvalidArgumentException('Returul nu are o comandă asociată.');
+    }
+
+    // Validate order item and expected quantity
+    $itemStmt = $db->prepare(
+        'SELECT oi.id, oi.order_id, oi.product_id, oi.quantity, COALESCE(oi.picked_quantity, oi.quantity) AS expected_quantity
+         FROM order_items oi
+         WHERE oi.id = :id
+         LIMIT 1'
+    );
+    $itemStmt->execute([':id' => $orderItemId]);
+    $orderItem = $itemStmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$orderItem || (int)$orderItem['order_id'] !== $orderId) {
+        throw new InvalidArgumentException('Articolul nu aparține comenzii acestui retur.');
+    }
+
+    if ((int)$orderItem['product_id'] !== $productId) {
+        throw new InvalidArgumentException('Produsul selectat nu se potrivește cu articolul din comandă.');
+    }
+
+    // Validate location exists and is active
+    $locStmt = $db->prepare("SELECT id, location_code, status FROM locations WHERE id = :id LIMIT 1");
+    $locStmt->execute([':id' => $locationId]);
+    $location = $locStmt->fetch(PDO::FETCH_ASSOC);
+    if (!$location || ($location['status'] ?? '') !== 'active') {
+        throw new InvalidArgumentException('Locația selectată nu este activă.');
+    }
+
+    $expectedQuantity = (int)($orderItem['expected_quantity'] ?? 0);
+
+    // Insert or update return item
+    $existingStmt = $db->prepare(
+        'SELECT id FROM return_items WHERE return_id = :return_id AND order_item_id = :order_item_id LIMIT 1'
+    );
+    $existingStmt->execute([
+        ':return_id' => $returnId,
+        ':order_item_id' => $orderItemId
+    ]);
+    $existing = $existingStmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($existing) {
+        $updateStmt = $db->prepare(
+            'UPDATE return_items
+             SET quantity_returned = :quantity,
+                 item_condition = :condition,
+                 location_id = :location_id,
+                 notes = :notes,
+                 is_extra = 0,
+                 updated_at = NOW()
+             WHERE id = :id'
+        );
+        $updateStmt->execute([
+            ':quantity' => $quantityReceived,
+            ':condition' => $condition,
+            ':location_id' => $locationId,
+            ':notes' => $notes !== '' ? $notes : null,
+            ':id' => (int)$existing['id']
+        ]);
+        $returnItemId = (int)$existing['id'];
+    } else {
+        $insertStmt = $db->prepare(
+            'INSERT INTO return_items
+                 (return_id, order_item_id, product_id, quantity_returned, item_condition, is_extra, notes, location_id, created_at, updated_at)
+             VALUES
+                 (:return_id, :order_item_id, :product_id, :quantity, :condition, 0, :notes, :location_id, NOW(), NOW())'
+        );
+        $insertStmt->execute([
+            ':return_id' => $returnId,
+            ':order_item_id' => $orderItemId,
+            ':product_id' => $productId,
+            ':quantity' => $quantityReceived,
+            ':condition' => $condition,
+            ':notes' => $notes !== '' ? $notes : null,
+            ':location_id' => $locationId
+        ]);
+        $returnItemId = (int)$db->lastInsertId();
+    }
+
+    // Handle discrepancies
+    $notesForDiscrepancy = $notes !== '' ? $notes : null;
+
+    $discrepancyStmt = $db->prepare(
+        'INSERT INTO return_discrepancies
+            (return_id, order_item_id, product_id, discrepancy_type, expected_quantity, actual_quantity, item_condition, notes, updated_at)
+         VALUES
+            (:return_id, :order_item_id, :product_id, :type, :expected, :actual, :condition, :notes, NOW())
+         ON DUPLICATE KEY UPDATE
+            expected_quantity = VALUES(expected_quantity),
+            actual_quantity = VALUES(actual_quantity),
+            item_condition = VALUES(item_condition),
+            notes = VALUES(notes),
+            updated_at = VALUES(updated_at)'
+    );
+
+    $deleteDiscrepancyStmt = $db->prepare(
+        'DELETE FROM return_discrepancies WHERE return_id = :return_id AND order_item_id = :order_item_id AND product_id = :product_id AND discrepancy_type = :type'
+    );
+
+    // Quantity short
+    if ($quantityReceived < $expectedQuantity) {
+        $discrepancyStmt->execute([
+            ':return_id' => $returnId,
+            ':order_item_id' => $orderItemId,
+            ':product_id' => $productId,
+            ':type' => 'quantity_short',
+            ':expected' => $expectedQuantity,
+            ':actual' => $quantityReceived,
+            ':condition' => $condition,
+            ':notes' => $notesForDiscrepancy
+        ]);
+    } else {
+        $deleteDiscrepancyStmt->execute([
+            ':return_id' => $returnId,
+            ':order_item_id' => $orderItemId,
+            ':product_id' => $productId,
+            ':type' => 'quantity_short'
+        ]);
+    }
+
+    // Quantity over
+    if ($quantityReceived > $expectedQuantity) {
+        $discrepancyStmt->execute([
+            ':return_id' => $returnId,
+            ':order_item_id' => $orderItemId,
+            ':product_id' => $productId,
+            ':type' => 'quantity_over',
+            ':expected' => $expectedQuantity,
+            ':actual' => $quantityReceived,
+            ':condition' => $condition,
+            ':notes' => $notesForDiscrepancy
+        ]);
+    } else {
+        $deleteDiscrepancyStmt->execute([
+            ':return_id' => $returnId,
+            ':order_item_id' => $orderItemId,
+            ':product_id' => $productId,
+            ':type' => 'quantity_over'
+        ]);
+    }
+
+    // Condition issue
+    if ($condition !== 'good') {
+        $discrepancyStmt->execute([
+            ':return_id' => $returnId,
+            ':order_item_id' => $orderItemId,
+            ':product_id' => $productId,
+            ':type' => 'condition_issue',
+            ':expected' => $expectedQuantity,
+            ':actual' => $quantityReceived,
+            ':condition' => $condition,
+            ':notes' => $notesForDiscrepancy
+        ]);
+    } else {
+        $deleteDiscrepancyStmt->execute([
+            ':return_id' => $returnId,
+            ':order_item_id' => $orderItemId,
+            ':product_id' => $productId,
+            ':type' => 'condition_issue'
+        ]);
+    }
+
+    $db->commit();
+
+    echo json_encode([
+        'success' => true,
+        'message' => 'Produsul a fost înregistrat pentru retur.',
+        'return_item_id' => $returnItemId,
+        'quantity_received' => $quantityReceived,
+        'condition' => $condition,
+        'location_id' => $locationId
+    ]);
+} catch (InvalidArgumentException $e) {
+    if (isset($db) && $db->inTransaction()) {
+        $db->rollBack();
+    }
+    http_response_code(422);
+    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+} catch (Throwable $e) {
+    if (isset($db) && $db->inTransaction()) {
+        $db->rollBack();
+    }
+    error_log('add_return_item error: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'A apărut o eroare la înregistrarea produsului.']);
+}

--- a/api/warehouse/return_order_details.php
+++ b/api/warehouse/return_order_details.php
@@ -23,24 +23,125 @@ try {
     $db = $dbFactory();
 
     $orderId = isset($_GET['order_id']) ? (int)$_GET['order_id'] : 0;
+    $returnId = isset($_GET['return_id']) ? (int)$_GET['return_id'] : 0;
+
+    if ($returnId <= 0 && $orderId <= 0) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'message' => 'Parametri invalidi']);
+        exit;
+    }
+
+    $order = null;
+    $returnInfo = null;
+
+    if ($returnId > 0) {
+        $returnStmt = $db->prepare(
+            'SELECT
+                r.id AS return_id,
+                r.status AS return_status,
+                r.notes AS return_notes,
+                r.return_awb,
+                r.return_date,
+                r.created_at AS return_created_at,
+                r.updated_at AS return_updated_at,
+                o.id AS order_id,
+                o.order_number,
+                o.customer_name,
+                o.status AS order_status,
+                o.order_date,
+                o.updated_at AS order_updated_at,
+                o.total_value
+             FROM returns r
+             JOIN orders o ON o.id = r.order_id
+             WHERE r.id = :return_id
+             LIMIT 1'
+        );
+        $returnStmt->execute([':return_id' => $returnId]);
+        $row = $returnStmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$row) {
+            http_response_code(404);
+            echo json_encode(['success' => false, 'message' => 'Returul nu a fost găsit.']);
+            exit;
+        }
+
+        $orderId = (int)$row['order_id'];
+
+        $order = [
+            'id' => $orderId,
+            'order_number' => $row['order_number'],
+            'customer_name' => $row['customer_name'],
+            'status' => $row['order_status'],
+            'order_date' => $row['order_date'],
+            'updated_at' => $row['order_updated_at'],
+            'total_value' => $row['total_value']
+        ];
+
+        $returnInfo = [
+            'id' => (int)$row['return_id'],
+            'status' => $row['return_status'],
+            'return_date' => $row['return_date'],
+            'return_awb' => $row['return_awb'],
+            'notes' => $row['return_notes'],
+            'created_at' => $row['return_created_at'],
+            'updated_at' => $row['return_updated_at']
+        ];
+    }
+
     if ($orderId <= 0) {
         http_response_code(400);
         echo json_encode(['success' => false, 'message' => 'Order ID invalid']);
         exit;
     }
 
-    $orderStmt = $db->prepare(
-        'SELECT id, order_number, customer_name, status, order_date, updated_at, total_value
-         FROM orders
-         WHERE id = :id'
-    );
-    $orderStmt->execute([':id' => $orderId]);
-    $order = $orderStmt->fetch(PDO::FETCH_ASSOC);
+    if ($order === null) {
+        $orderStmt = $db->prepare(
+            'SELECT id, order_number, customer_name, status, order_date, updated_at, total_value
+             FROM orders
+             WHERE id = :id'
+        );
+        $orderStmt->execute([':id' => $orderId]);
+        $orderRow = $orderStmt->fetch(PDO::FETCH_ASSOC);
 
-    if (!$order) {
-        http_response_code(404);
-        echo json_encode(['success' => false, 'message' => 'Comanda nu a fost găsită.']);
-        exit;
+        if (!$orderRow) {
+            http_response_code(404);
+            echo json_encode(['success' => false, 'message' => 'Comanda nu a fost găsită.']);
+            exit;
+        }
+
+        $order = [
+            'id' => (int)$orderRow['id'],
+            'order_number' => $orderRow['order_number'],
+            'customer_name' => $orderRow['customer_name'],
+            'status' => $orderRow['status'],
+            'order_date' => $orderRow['order_date'],
+            'updated_at' => $orderRow['updated_at'],
+            'total_value' => $orderRow['total_value']
+        ];
+
+        if ($returnId <= 0) {
+            $activeReturnStmt = $db->prepare(
+                'SELECT id, status, return_date, return_awb, notes, created_at, updated_at
+                 FROM returns
+                 WHERE order_id = :order_id AND status IN ("pending", "in_progress")
+                 ORDER BY updated_at DESC
+                 LIMIT 1'
+            );
+            $activeReturnStmt->execute([':order_id' => $orderId]);
+            $activeReturn = $activeReturnStmt->fetch(PDO::FETCH_ASSOC);
+            if ($activeReturn) {
+                $returnInfo = [
+                    'id' => (int)$activeReturn['id'],
+                    'status' => $activeReturn['status'],
+                    'return_date' => $activeReturn['return_date'],
+                    'return_awb' => $activeReturn['return_awb'],
+                    'notes' => $activeReturn['notes'],
+                    'created_at' => $activeReturn['created_at'],
+                    'updated_at' => $activeReturn['updated_at']
+                ];
+                $returnId = (int)$activeReturn['id'];
+            }
+        }
     }
 
     $status = strtolower((string)($order['status'] ?? ''));
@@ -62,36 +163,65 @@ try {
             COALESCE(oi.picked_quantity, oi.quantity) AS picked_quantity,
             p.name AS product_name,
             p.sku,
-            p.barcode
+            p.barcode,
+            ri.id AS return_item_id,
+            ri.quantity_returned,
+            ri.item_condition,
+            ri.notes AS return_notes,
+            ri.location_id AS processed_location_id,
+            ri.updated_at AS processed_updated_at,
+            ri.created_at AS processed_created_at,
+            l.location_code AS processed_location_code
          FROM order_items oi
          JOIN products p ON oi.product_id = p.product_id
+         LEFT JOIN return_items ri
+            ON ri.order_item_id = oi.id AND ri.return_id = :return_id
+         LEFT JOIN locations l ON l.id = ri.location_id
          WHERE oi.order_id = :order_id
          ORDER BY oi.id'
     );
-    $itemsStmt->execute([':order_id' => $orderId]);
+    $itemsStmt->execute([
+        ':order_id' => $orderId,
+        ':return_id' => $returnId > 0 ? $returnId : 0
+    ]);
     $items = $itemsStmt->fetchAll(PDO::FETCH_ASSOC);
 
     $responseItems = [];
     $missingLocations = [];
-    $totalRestockQty = 0;
+    $totalExpectedQty = 0;
+    $processedCount = 0;
+    $processedUnits = 0;
 
     foreach ($items as $item) {
         $productId = (int)$item['product_id'];
         $pickedQty = (int)($item['picked_quantity'] ?? 0);
         $orderedQty = (int)($item['quantity_ordered'] ?? 0);
-        $restockQty = $pickedQty > 0 ? $pickedQty : $orderedQty;
-        if ($restockQty < 0) {
-            $restockQty = 0;
+        $expectedQty = $pickedQty > 0 ? $pickedQty : $orderedQty;
+        if ($expectedQty < 0) {
+            $expectedQty = 0;
         }
 
-        $locationInfo = findProductReturnLocation($db, $productId);
-        if (!$locationInfo) {
+        $defaultLocation = findProductReturnLocation($db, $productId);
+        if (!$defaultLocation) {
             $missingLocations[] = [
                 'product_id' => $productId,
                 'product_name' => $item['product_name'],
                 'sku' => $item['sku']
             ];
         }
+
+        $isProcessed = !empty($item['return_item_id']);
+        if ($isProcessed) {
+            $processedCount++;
+            $processedUnits += (int)($item['quantity_returned'] ?? 0);
+        }
+
+        $selectedLocationId = $isProcessed
+            ? (int)$item['processed_location_id']
+            : ($defaultLocation['location_id'] ?? null);
+        $selectedLocationCode = $isProcessed
+            ? $item['processed_location_code']
+            : ($defaultLocation['location_code'] ?? null);
 
         $responseItems[] = [
             'order_item_id' => (int)$item['order_item_id'],
@@ -100,18 +230,30 @@ try {
             'sku' => $item['sku'],
             'quantity_ordered' => $orderedQty,
             'picked_quantity' => $pickedQty,
-            'restock_quantity' => $restockQty,
-            'location_id' => $locationInfo['location_id'] ?? null,
-            'location_code' => $locationInfo['location_code'] ?? null,
-            'inventory_id' => $locationInfo['inventory_id'] ?? null,
-            'shelf_level' => $locationInfo['shelf_level'] ?? null,
-            'subdivision_number' => $locationInfo['subdivision_number'] ?? null
+            'expected_quantity' => $expectedQty,
+            'restock_quantity' => $expectedQty,
+            'default_location_id' => $defaultLocation['location_id'] ?? null,
+            'default_location_code' => $defaultLocation['location_code'] ?? null,
+            'inventory_id' => $defaultLocation['inventory_id'] ?? null,
+            'shelf_level' => $defaultLocation['shelf_level'] ?? null,
+            'subdivision_number' => $defaultLocation['subdivision_number'] ?? null,
+            'location_id' => $selectedLocationId,
+            'location_code' => $selectedLocationCode,
+            'is_processed' => $isProcessed,
+            'processed_quantity' => $isProcessed ? (int)$item['quantity_returned'] : null,
+            'processed_condition' => $isProcessed ? ($item['item_condition'] ?? null) : null,
+            'processed_notes' => $isProcessed ? ($item['return_notes'] ?? null) : null,
+            'processed_location_id' => $isProcessed ? (int)$item['processed_location_id'] : null,
+            'processed_location_code' => $isProcessed ? $item['processed_location_code'] : null,
+            'processed_at' => $isProcessed ? ($item['processed_updated_at'] ?? $item['processed_created_at']) : null,
+            'return_item_id' => $isProcessed ? (int)$item['return_item_id'] : null
         ];
 
-        $totalRestockQty += $restockQty;
+        $totalExpectedQty += $expectedQty;
     }
 
     $latestActivity = $order['updated_at'] ?: $order['order_date'];
+    $totalItems = count($responseItems);
 
     echo json_encode([
         'success' => true,
@@ -122,15 +264,23 @@ try {
             'status' => $order['status'],
             'status_label' => translateOrderStatus($order['status']),
             'latest_activity' => $latestActivity,
-            'total_items' => count($responseItems),
+            'total_items' => $totalItems,
             'total_value' => isset($order['total_value']) ? (float)$order['total_value'] : null
         ],
+        'return' => $returnInfo,
         'items' => $responseItems,
         'missing_locations' => $missingLocations,
         'totals' => [
-            'items' => count($responseItems),
-            'restock_quantity' => $totalRestockQty,
+            'items' => $totalItems,
+            'expected_quantity' => $totalExpectedQty,
+            'processed_items' => $processedCount,
+            'processed_quantity' => $processedUnits,
             'missing_locations' => count($missingLocations)
+        ],
+        'processing' => [
+            'all_processed' => $totalItems > 0 && $processedCount === $totalItems,
+            'processed_items' => $processedCount,
+            'total_items' => $totalItems
         ]
     ]);
 } catch (Throwable $e) {

--- a/styles/warehouse-css/warehouse_receiving.css
+++ b/styles/warehouse-css/warehouse_receiving.css
@@ -337,6 +337,39 @@ body {
   color: var(--white);
 }
 
+.return-processing-instructions {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.25rem;
+  border-radius: 12px;
+  background: rgba(30, 136, 229, 0.12);
+  border: 1px solid rgba(30, 136, 229, 0.35);
+  color: var(--white);
+}
+
+.return-processing-instructions .material-symbols-outlined {
+  font-size: 1.8rem;
+  color: #64b5f6;
+}
+
+.return-processing-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.return-processing-title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.return-processing-subtitle {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
 .return-order-summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -365,31 +398,70 @@ body {
   color: var(--white);
 }
 
+.return-processing-progress {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 1.25rem 0;
+  padding: 0.85rem 1.25rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  color: var(--white);
+  font-weight: 600;
+}
+
+.return-processing-progress span.material-symbols-outlined {
+  font-size: 1.1rem;
+  color: #90caf9;
+}
+
+.return-processing-progress-count,
+.return-processing-progress-quantities {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .return-items-list {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.return-item {
+.return-item-card {
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 10px;
-  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  padding: 1.1rem 1.35rem;
   display: flex;
   flex-direction: column;
+  gap: 0.85rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.return-item-card.processed {
+  border-color: rgba(76, 175, 80, 0.45);
+  box-shadow: 0 0 0 1px rgba(76, 175, 80, 0.3) inset;
+}
+
+.return-item-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   gap: 0.75rem;
 }
 
-.return-item-header {
+.return-item-card-info {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
+  flex-direction: column;
+  gap: 0.3rem;
 }
 
 .return-item-name {
   font-weight: 600;
+  font-size: 1rem;
   color: var(--white);
 }
 
@@ -398,22 +470,103 @@ body {
   color: var(--light-gray);
 }
 
-.return-item-meta {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+.return-item-card-status {
+  display: flex;
+  align-items: center;
   gap: 0.75rem;
-  color: var(--light-gray);
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.9rem;
 }
 
-.return-item-meta span {
+.return-item-badge {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(76, 175, 80, 0.2);
+  color: #a5d6a7;
+  font-weight: 600;
+  font-size: 0.8rem;
 }
 
-.return-item-location-missing {
-  color: #ffbaba;
+.return-item-badge .material-symbols-outlined {
+  font-size: 1rem;
+}
+
+.return-item-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.return-item-form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.return-item-form-row.full-width {
+  flex-direction: column;
+}
+
+.return-item-form-group {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.return-item-form-group.full-width {
+  width: 100%;
+}
+
+.return-item-form-group label {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.75);
+  font-weight: 500;
+}
+
+.return-item-form-group input,
+.return-item-form-group select,
+.return-item-form-group textarea {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(8, 13, 23, 0.65);
+  padding: 0.55rem 0.65rem;
+  color: var(--white);
+  font-size: 0.95rem;
+}
+
+.return-item-form-group input[readonly],
+.return-item-form-group textarea[readonly],
+.return-item-form-group select:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.return-item-processed-quantity {
+  max-width: 200px;
+  min-width: 180px;
+}
+
+.return-item-processed-value {
+  padding: 0.55rem 0.75rem;
+  background: rgba(76, 175, 80, 0.18);
+  border-radius: 8px;
+  color: #c8e6c9;
   font-weight: 600;
+  text-align: center;
+}
+
+.return-item-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.return-item-submit.loading {
+  pointer-events: none;
 }
 
 .return-restock-hint {

--- a/warehouse_receiving.php
+++ b/warehouse_receiving.php
@@ -373,6 +373,13 @@ $currentPage = 'warehouse_receiving';
                                 <p class="returns-hint">Rezultatele afișează retururile active, cele mai recente apar primele.</p>
                             </div>
                             <div class="returns-panel-content">
+                                <div class="return-processing-instructions">
+                                    <span class="material-symbols-outlined">info</span>
+                                    <div class="return-processing-text">
+                                        <p class="return-processing-title">Verificați fiecare produs returnat și înregistrați cantitatea primită și starea acestuia.</p>
+                                        <p class="return-processing-subtitle">Înregistrați toate produsele înainte de a adăuga în stoc.</p>
+                                    </div>
+                                </div>
                                 <div class="return-orders-column">
                                     <div id="return-orders-results" class="return-orders-results">
                                         <div class="empty-state">


### PR DESCRIPTION
## Summary
- add an API endpoint to register returned items with selected locations and auto-create discrepancies
- extend return order details and restock processing to respect per-item recorded locations and statuses
- rebuild the Romanian return processing UI with per-product forms, progress tracking, and updated styling

## Testing
- php -l api/warehouse/add_return_item.php
- php -l api/warehouse/return_order_details.php
- php -l api/warehouse/process_return_restock.php

------
https://chatgpt.com/codex/tasks/task_e_68e4066a15f88320b0456ed078a65d4b