### PR TITLE
Ensure auto-orders share duplicate guard with transactional locking

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -163,6 +163,10 @@ return [
         'imap_sent_folders' => ['INBOX.Sent', 'Sent', 'INBOX/Sent', 'Sent Items', 'Sent Messages']
     ],
 
+    'autoorders' => [
+        'min_interval_minutes' => max(1, (int)(getenv('AUTOORDERS_MIN_INTERVAL_MINUTES') ?: 30)),
+    ],
+
     'automation' => [
         'auto_return_user_id' => (int)(getenv('AUTO_RETURN_USER_ID') ?: 0),
         'delta_event_hours' => (int)(getenv('AUTO_RETURN_DELTA_HOURS') ?: 6),

--- a/models/AutoOrderDuplicateGuard.php
+++ b/models/AutoOrderDuplicateGuard.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+class AutoOrderDuplicateGuard
+{
+    private PDO $conn;
+    private string $productsTable;
+    private ?int $configuredIntervalCache = null;
+
+    public function __construct(PDO $conn, string $productsTable = 'products')
+    {
+        $this->conn = $conn;
+        $this->productsTable = $productsTable;
+    }
+
+    /**
+     * @return array{permisa: bool, mesaj: string}
+     */
+    public function canPlaceAutoOrder(int $productId, int $minIntervalMinutes = 30, bool $forUpdate = false): array
+    {
+        $intervalMinutes = $this->resolveIntervalMinutes($minIntervalMinutes);
+
+        try {
+            $sql = "SELECT last_auto_order_date FROM {$this->productsTable} WHERE product_id = :id";
+            if ($forUpdate && $this->supportsRowLocking()) {
+                $sql .= ' FOR UPDATE';
+            }
+
+            $stmt = $this->conn->prepare($sql);
+            $stmt->bindValue(':id', $productId, PDO::PARAM_INT);
+            $stmt->execute();
+            $ultimaData = $stmt->fetchColumn();
+        } catch (PDOException $e) {
+            error_log('[AutoOrder] Nu s-a putut verifica ultima autocomandă pentru produs #' . $productId . ': ' . $e->getMessage());
+            return [
+                'permisa' => false,
+                'mesaj' => 'Verificarea intervalului minim pentru autocomandă a eșuat.'
+            ];
+        }
+
+        if ($ultimaData === false) {
+            $mesaj = 'Produsul nu a fost găsit pentru verificarea autocomenzii.';
+            error_log('[AutoOrder] ' . $mesaj . ' ID: ' . $productId);
+            return [
+                'permisa' => false,
+                'mesaj' => $mesaj
+            ];
+        }
+
+        if ($ultimaData === null || $ultimaData === '' || $ultimaData === '0000-00-00 00:00:00') {
+            return [
+                'permisa' => true,
+                'mesaj' => 'Nu există autocomenzi recente pentru acest produs.'
+            ];
+        }
+
+        try {
+            $ultimaAutocomanda = new DateTimeImmutable($ultimaData);
+        } catch (Exception $e) {
+            error_log(sprintf('[AutoOrder] Data invalidă "%s" pentru produs #%d: %s', $ultimaData, $productId, $e->getMessage()));
+            return [
+                'permisa' => true,
+                'mesaj' => 'Nu există autocomenzi recente pentru acest produs.'
+            ];
+        }
+
+        $acum = new DateTimeImmutable('now', $ultimaAutocomanda->getTimezone());
+        $difSecunde = $acum->getTimestamp() - $ultimaAutocomanda->getTimestamp();
+        $difMinute = (int)floor($difSecunde / 60);
+        if ($difMinute < $intervalMinutes) {
+            $ramase = max(0, $intervalMinutes - $difMinute);
+            $mesaj = sprintf(
+                'Ultima autocomandă a fost trimisă la %s (acum %d minute). Intervalul minim este de %d minute. Mai așteptați aproximativ %d minute.',
+                $ultimaAutocomanda->format('d.m.Y H:i:s'),
+                max(0, $difMinute),
+                $intervalMinutes,
+                $ramase
+            );
+
+            error_log(sprintf(
+                '[AutoOrder] Blocked duplicate for product #%d: last=%s, diff=%d min, interval=%d min',
+                $productId,
+                $ultimaAutocomanda->format(DATE_ATOM),
+                max(0, $difMinute),
+                $intervalMinutes
+            ));
+
+            return [
+                'permisa' => false,
+                'mesaj' => $mesaj
+            ];
+        }
+
+        return [
+            'permisa' => true,
+            'mesaj' => 'Nu există autocomenzi recente pentru acest produs.'
+        ];
+    }
+
+    public function getConfiguredMinIntervalMinutes(): int
+    {
+        if ($this->configuredIntervalCache !== null) {
+            return $this->configuredIntervalCache;
+        }
+
+        $valoare = null;
+
+        if (isset($GLOBALS['config']['autoorders']['min_interval_minutes'])) {
+            $valoare = (int)$GLOBALS['config']['autoorders']['min_interval_minutes'];
+        } else {
+            $caleConfig = $this->resolveConfigPath();
+            if ($caleConfig && file_exists($caleConfig)) {
+                $config = require $caleConfig;
+                if (is_array($config) && isset($config['min_interval_minutes'])) {
+                    $valoare = (int)$config['min_interval_minutes'];
+                }
+            }
+        }
+
+        if ($valoare === null) {
+            $env = getenv('AUTOORDERS_MIN_INTERVAL_MINUTES');
+            if ($env !== false && $env !== '') {
+                $valoare = (int)$env;
+            }
+        }
+
+        if ($valoare === null || $valoare <= 0) {
+            $valoare = 30;
+        }
+
+        $this->configuredIntervalCache = max(1, (int)$valoare);
+        return $this->configuredIntervalCache;
+    }
+
+    private function resolveIntervalMinutes(int $minIntervalMinutes): int
+    {
+        $configurat = $this->getConfiguredMinIntervalMinutes();
+        $explicit = max(1, $minIntervalMinutes);
+        return max($configurat, $explicit);
+    }
+
+    private function resolveConfigPath(): ?string
+    {
+        if (defined('BASE_PATH')) {
+            return rtrim(BASE_PATH, '/') . '/config/autoorders.php';
+        }
+
+        return dirname(__DIR__) . '/config/autoorders.php';
+    }
+
+    private function supportsRowLocking(): bool
+    {
+        try {
+            $driver = strtolower((string)$this->conn->getAttribute(PDO::ATTR_DRIVER_NAME));
+        } catch (Throwable $e) {
+            return false;
+        }
+
+        return in_array($driver, ['mysql', 'pgsql', 'sqlsrv'], true);
+    }
+}

--- a/tests/autoorder_duplicate_guard_test.php
+++ b/tests/autoorder_duplicate_guard_test.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../models/AutoOrderDuplicateGuard.php';
+
+function setupTestDatabase(PDO $pdo): void
+{
+    $pdo->exec('CREATE TABLE products (
+        product_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT,
+        last_auto_order_date DATETIME NULL
+    )');
+
+    $pdo->exec('CREATE TABLE purchase_orders (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        order_number TEXT,
+        seller_id INTEGER,
+        total_amount REAL,
+        currency TEXT,
+        custom_message TEXT,
+        email_subject TEXT,
+        status TEXT,
+        expected_delivery_date DATETIME NULL,
+        email_recipient TEXT,
+        notes TEXT,
+        pdf_path TEXT,
+        tax_rate INTEGER,
+        created_by INTEGER,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )');
+
+    $pdo->prepare('INSERT INTO products (name, last_auto_order_date) VALUES (:name, NULL)')
+        ->execute([':name' => 'Produs Test']);
+}
+
+function simulateAutoOrder(
+    PDO $pdo,
+    AutoOrderDuplicateGuard $guard,
+    int $productId,
+    int $intervalMinutes,
+    string $source
+): array {
+    $pdo->beginTransaction();
+    $check = $guard->canPlaceAutoOrder($productId, $intervalMinutes, true);
+    if (!$check['permisa']) {
+        $pdo->rollBack();
+        return [
+            'created' => false,
+            'source' => $source,
+            'reason' => $check['mesaj']
+        ];
+    }
+
+    $orderNumber = sprintf('PO-%s-%s', strtoupper(substr($source, 0, 1)), substr(uniqid('', true), -6));
+    $stmt = $pdo->prepare('INSERT INTO purchase_orders (
+        order_number, seller_id, total_amount, currency, custom_message,
+        email_subject, status, expected_delivery_date, email_recipient,
+        notes, pdf_path, tax_rate, created_by
+    ) VALUES (
+        :order_number, 1, 0, "RON", NULL,
+        NULL, "sent", NULL, NULL,
+        :notes, NULL, 0, 1
+    )');
+    $stmt->execute([
+        ':order_number' => $orderNumber,
+        ':notes' => $source
+    ]);
+
+    $pdo->prepare('UPDATE products SET last_auto_order_date = CURRENT_TIMESTAMP WHERE product_id = :id')
+        ->execute([':id' => $productId]);
+
+    $pdo->commit();
+
+    return [
+        'created' => true,
+        'source' => $source,
+        'order_number' => $orderNumber,
+        'last_auto_order_date' => $pdo->query('SELECT last_auto_order_date FROM products WHERE product_id = ' . (int)$productId)->fetchColumn()
+    ];
+}
+
+function printResult(array $result): void
+{
+    if ($result['created']) {
+        printf(
+            "%s ➜ creat (%s) la %s\n",
+            str_pad($result['source'], 12, ' ', STR_PAD_RIGHT),
+            $result['order_number'],
+            $result['last_auto_order_date']
+        );
+    } else {
+        printf(
+            "%s ➜ blocat: %s\n",
+            str_pad($result['source'], 12, ' ', STR_PAD_RIGHT),
+            $result['reason']
+        );
+    }
+}
+
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+setupTestDatabase($pdo);
+
+$guard = new AutoOrderDuplicateGuard($pdo, 'products');
+$interval = max(1, $guard->getConfiguredMinIntervalMinutes());
+
+printf("Interval minim configurat: %d minute\n", $interval);
+
+$initial = simulateAutoOrder($pdo, $guard, 1, $interval, 'scheduled');
+printResult($initial);
+
+$immediateReactive = simulateAutoOrder($pdo, $guard, 1, $interval, 'reactive');
+printResult($immediateReactive);
+
+$pdo->prepare('UPDATE products SET last_auto_order_date = datetime(?, ? ) WHERE product_id = 1')
+    ->execute([date('Y-m-d H:i:s'), sprintf('-%d minutes', $interval + 1)]);
+
+$afterInterval = simulateAutoOrder($pdo, $guard, 1, $interval, 'after-wait');
+printResult($afterInterval);
+
+$pdo->prepare('UPDATE products SET last_auto_order_date = datetime(?, ? ) WHERE product_id = 1')
+    ->execute([date('Y-m-d H:i:s'), sprintf('-%d minutes', $interval + 1)]);
+
+$concurrentFirst = simulateAutoOrder($pdo, $guard, 1, $interval, 'concurrent-A');
+printResult($concurrentFirst);
+
+$concurrentSecond = simulateAutoOrder($pdo, $guard, 1, $interval, 'concurrent-B');
+printResult($concurrentSecond);
+
+$ordersCount = (int)$pdo->query('SELECT COUNT(*) FROM purchase_orders')->fetchColumn();
+$lastDate = $pdo->query('SELECT last_auto_order_date FROM products WHERE product_id = 1')->fetchColumn();
+
+printf("Comenzi create: %d\n", $ordersCount);
+printf("Ultima autocomandă salvată: %s\n", $lastDate);


### PR DESCRIPTION
## Summary
- add a reusable `AutoOrderDuplicateGuard` that reads the configured interval and logs duplicate blocks
- update AutoOrderManager and Inventory flows to lock the product row, reuse the guard, and update `last_auto_order_date` only after the order is created
- allow PurchaseOrder::createPurchaseOrder to participate in external transactions and add a CLI regression test covering duplicate suppression scenarios

## Testing
- php -l models/AutoOrderDuplicateGuard.php
- php -l models/AutoOrderManager.php
- php -l models/Inventory.php
- php -l models/PurchaseOrder.php
- php -l tests/autoorder_duplicate_guard_test.php
- php tests/autoorder_duplicate_guard_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e409be2cd48320af7c21e5a91ac2f0