### PR TITLE
Adjust print server defaults and improve error handling

### DIFF
--- a/api/receiving/record_production_receipt.php
+++ b/api/receiving/record_production_receipt.php
@@ -813,7 +813,7 @@ function extractProductCodeTemplate(string $productName, string $templateDir): ?
 
 function sendToPrintServer(string $labelUrl, ?string $printer, array $config): void {
     $printerName    = $printer ?: ($config['default_printer'] ?? 'godex');
-    $printServerUrl = $config['print_server_url'] ?? 'http://86.124.196.102:3000/print_server.php';
+    $printServerUrl = resolvePrintServerUrl($config);
 
     $path         = strtolower(parse_url($labelUrl, PHP_URL_PATH) ?? '');
     $isPdf        = substr($path, -4) === '.pdf';
@@ -830,11 +830,23 @@ function sendToPrintServer(string $labelUrl, ?string $printer, array $config): v
 }
 
 function sendPngToServer(string $url, string $pngUrl, string $printer): array {
-    $requestUrl = $url . '?' . http_build_query([
+    return sendPrintRequest($url, [
         'url' => $pngUrl,
         'printer' => $printer,
         'format' => 'png'
     ]);
+}
+
+function sendPdfToServer(string $url, string $pdfUrl, string $printer): array {
+    return sendPrintRequest($url, [
+        'url' => $pdfUrl,
+        'printer' => $printer
+    ]);
+}
+
+function sendPrintRequest(string $url, array $params): array {
+    $separator = (strpos($url, '?') === false) ? '?' : '&';
+    $requestUrl = $url . $separator . http_build_query($params);
 
     $context = stream_context_create([
         'http' => [
@@ -846,8 +858,21 @@ function sendPngToServer(string $url, string $pngUrl, string $printer): array {
     ]);
 
     $response = @file_get_contents($requestUrl, false, $context);
+    $statusCode = extractHttpStatusCode($http_response_header ?? []);
+
     if ($response === false) {
-        return ['success' => false, 'error' => 'Failed to connect to print server'];
+        $message = 'Failed to connect to print server';
+        if ($statusCode !== null) {
+            $message .= sprintf(' (HTTP %d)', $statusCode);
+        }
+        return ['success' => false, 'error' => $message];
+    }
+
+    if ($statusCode !== null && $statusCode >= 400) {
+        return [
+            'success' => false,
+            'error' => sprintf('Print server returned HTTP %d: %s', $statusCode, trim($response))
+        ];
     }
 
     foreach (['Trimis la imprimantă', 'sent to printer', 'Print successful'] as $indicator) {
@@ -859,33 +884,15 @@ function sendPngToServer(string $url, string $pngUrl, string $printer): array {
     return ['success' => false, 'error' => 'Print server response: ' . $response];
 }
 
-function sendPdfToServer(string $url, string $pdfUrl, string $printer): array {
-    $requestUrl = $url . '?' . http_build_query([
-        'url' => $pdfUrl,
-        'printer' => $printer
-    ]);
-
-    $context = stream_context_create([
-        'http' => [
-            'method' => 'GET',
-            'timeout' => 15,
-            'ignore_errors' => true,
-            'user_agent' => 'WMS-PrintClient/1.0'
-        ]
-    ]);
-
-    $response = @file_get_contents($requestUrl, false, $context);
-    if ($response === false) {
-        return ['success' => false, 'error' => 'Failed to connect to print server'];
+function resolvePrintServerUrl(array $config): string {
+    if (!empty($config['print_server_url'])) {
+        return $config['print_server_url'];
     }
 
-    foreach (['Trimis la imprimantă', 'sent to printer', 'Print successful'] as $indicator) {
-        if (stripos($response, $indicator) !== false) {
-            return ['success' => true];
-        }
-    }
+    $host = rtrim($_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? 'localhost', '/');
+    $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
 
-    return ['success' => false, 'error' => 'Print server response: ' . $response];
+    return sprintf('%s://%s/print_server.php', $scheme, $host);
 }
 
 function getBaseUrl(): string {
@@ -893,4 +900,15 @@ function getBaseUrl(): string {
     $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
     return $scheme . '://' . $host;
 }
+
+function extractHttpStatusCode(array $headers): ?int {
+    foreach ($headers as $header) {
+        if (stripos($header, 'HTTP/') === 0 && preg_match('/HTTP\/\d+\.\d+\s+(\d+)/', $header, $matches)) {
+            return (int)$matches[1];
+        }
+    }
+
+    return null;
+}
+
 ?>

--- a/config/config.php
+++ b/config/config.php
@@ -121,7 +121,21 @@ return [
     'connection_factory' => $connectionFactory,
 
     // Print server configuration
-    'print_server_url' => getenv('PRINT_SERVER_URL') ?: 'http://86.124.196.102:3000/print_server.php',
+    'print_server_url' => (function () use ($baseUrl) {
+        $configuredUrl = getenv('PRINT_SERVER_URL');
+        if ($configuredUrl) {
+            return $configuredUrl;
+        }
+
+        $host = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? '';
+        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+
+        if ($host !== '') {
+            return sprintf('%s://%s/print_server.php', $scheme, rtrim($host, '/'));
+        }
+
+        return rtrim($baseUrl, '/') . '/print_server.php';
+    })(),
     'default_printer'  => getenv('DEFAULT_PRINTER') ?: 'godex_ez6250i',
 
     'label_rotation' => 180,

--- a/direct_png_test.php
+++ b/direct_png_test.php
@@ -3,6 +3,8 @@
  * Fix for Both Printer Name and Template Size Issues
  */
 
+$config = require __DIR__ . '/config/config.php';
+
 // ===== ISSUE 1: CORRECT PRINTER NAME =====
 
 /**
@@ -10,10 +12,10 @@
  */
 function testPrinterNames($testUrl) {
     echo "=== TESTING PRINTER NAMES ===\n";
-    
+
     $printerNames = [
         'Godex EZ6250i',
-        'EZ6250i', 
+        'EZ6250i',
         'godex_ez6250i',
         'godex-ez6250i',
         'GODEX_EZ6250i',
@@ -23,13 +25,15 @@ function testPrinterNames($testUrl) {
         'godex6250',
         'default'
     ];
-    
-    $printServerUrl = 'http://86.124.196.102:3000/print_server.php';
+
+    global $config;
+    $printServerUrl = $config['print_server_url'] ?? 'http://localhost/print_server.php';
+    $separator = (strpos($printServerUrl, '?') === false) ? '?' : '&';
     
     foreach ($printerNames as $printerName) {
         echo "\n🖨️  Testing printer name: '$printerName'\n";
         
-        $testRequestUrl = $printServerUrl . '?' . http_build_query([
+        $testRequestUrl = $printServerUrl . $separator . http_build_query([
             'url' => $testUrl,
             'printer' => $printerName,
             'format' => 'png',
@@ -230,7 +234,10 @@ function testUpgradedTemplate($upgradedTemplatePath, $correctPrinterName) {
     echo "Test URL: $testUrl\n";
     
     // Print with correct printer name
-    $printUrl = 'http://86.124.196.102:3000/print_server.php?' . http_build_query([
+    global $config;
+    $printServerUrl = $config['print_server_url'] ?? 'http://localhost/print_server.php';
+    $separator = (strpos($printServerUrl, '?') === false) ? '?' : '&';
+    $printUrl = $printServerUrl . $separator . http_build_query([
         'url' => $testUrl,
         'printer' => $correctPrinterName,
         'format' => 'png',
@@ -252,11 +259,12 @@ function testUpgradedTemplate($upgradedTemplatePath, $correctPrinterName) {
  */
 function generateUpdatedConfig() {
     echo "\n=== UPDATED CONFIGURATION ===\n";
-    
+
     echo "📝 1. Update your config/config.php:\n";
     echo "```php\n";
     echo "'default_printer' => 'EZ6250i',  // or whatever name works\n";
-    echo "'print_server_url' => 'http://86.124.196.102:3000/print_server.php',\n";
+    global $config;
+    echo "'print_server_url' => '" . ($config['print_server_url'] ?? 'http://localhost/print_server.php') . "',\n";
     echo "'label_dpi' => 203,\n";
     echo "'label_width_mm' => 148,\n";
     echo "'label_height_mm' => 210,\n";


### PR DESCRIPTION
## Summary
- update the print server default configuration to prefer the current host when no explicit URL is provided
- improve label and production receipt printing helpers to reuse the resolved URL and report HTTP status errors from the print server
- align the direct PNG test utility with the configuration-driven print server URL so diagnostics match production behavior

## Testing
- php -l config/config.php
- php -l api/labels/print.php
- php -l api/receiving/record_production_receipt.php
- php -l "api/receiving/record_production_receipt copy.php"
- php -l direct_png_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e4c6cf1bf883209dcb9d189b2261e5