### PR TITLE
Generate PNG labels for product barcode printing

### DIFF
--- a/api/barcode/print.php
+++ b/api/barcode/print.php
@@ -60,6 +60,11 @@ if (isset($input['product_id'])) {
     }
 }
 
+$requestedPrinter = '';
+if (isset($input['printer']) && is_string($input['printer'])) {
+    $requestedPrinter = trim($input['printer']);
+}
+
 $productUnitIds = array_values(array_unique($productUnitIds));
 $productIds = array_values(array_unique($productIds));
 
@@ -74,12 +79,24 @@ try {
     respond(['status' => 'error', 'message' => 'Database connection failed: ' . $e->getMessage()], 500);
 }
 
-$printer = new GodexPrinter([
-    'host' => getenv('GODEX_PRINTER_HOST') ?: null,
-    'port' => getenv('GODEX_PRINTER_PORT') ?: null,
-    'print_server_url' => $config['print_server_url'] ?? null,
-    'queue' => $config['default_printer'] ?? null,
-]);
+$baseUrl = getBaseUrl();
+$storageDir = BASE_PATH . '/storage/label_pdfs';
+$printServerUrl = $config['print_server_url'] ?? (getenv('PRINT_SERVER_URL') ?: null);
+$printerName = $requestedPrinter !== ''
+    ? $requestedPrinter
+    : resolveProductLabelPrinter($config);
+
+try {
+    $printer = new GodexPrinter([
+        'print_server_url' => $printServerUrl,
+        'printer' => $printerName,
+        'storage_dir' => $storageDir,
+        'storage_url_path' => '/storage/label_pdfs',
+        'base_url' => $baseUrl,
+    ]);
+} catch (Exception $e) {
+    respond(['status' => 'error', 'message' => $e->getMessage()], 500);
+}
 
 try {
     $products = fetchProductsForPrinting($db, $productUnitIds, $productIds);
@@ -143,6 +160,7 @@ $response = [
     'status' => $status,
     'printed' => $result['printed'] ?? 0,
     'errors' => $totalErrors,
+    'printer' => $printerName,
 ];
 
 $httpCode = $status === 'success' ? 200 : 207;
@@ -192,5 +210,36 @@ function fetchProductsForPrinting(PDO $db, array $unitIds, array $productIds): a
     }
 
     return $results;
+}
+
+function resolveProductLabelPrinter(array $config): string
+{
+    $candidates = [
+        $config['product_unit_printer'] ?? null,
+        getenv('PRODUCT_UNIT_PRINTER') ?: null,
+        $config['default_printer'] ?? null,
+        getenv('DEFAULT_PRINTER') ?: null,
+        getenv('GODEX_PRINTER_QUEUE') ?: null,
+        'GODEX+G500',
+    ];
+
+    foreach ($candidates as $candidate) {
+        if (is_string($candidate)) {
+            $candidate = trim($candidate);
+            if ($candidate !== '') {
+                return $candidate;
+            }
+        }
+    }
+
+    return 'GODEX+G500';
+}
+
+function getBaseUrl(): string
+{
+    $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+    $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+
+    return $scheme . '://' . $host;
 }
 

--- a/config/config.php
+++ b/config/config.php
@@ -110,10 +110,10 @@ $connectionFactory = function() use ($dbCfg) {
 return [
     // app environment (development, production, etc.)
     'environment' => $environment,
-    
+
     // Base URL with auto-detected protocol
     'base_url' => $baseUrl,
-    
+
     // raw DB settings, if you need them elsewhere
     'db' => $dbCfg,
 
@@ -123,6 +123,7 @@ return [
     // Print server configuration
     'print_server_url' => getenv('PRINT_SERVER_URL') ?: 'http://86.124.196.102:3000/print_server.php',
     'default_printer'  => getenv('DEFAULT_PRINTER') ?: 'godex_ez6250i',
+    'product_unit_printer' => getenv('PRODUCT_UNIT_PRINTER') ?: 'GODEX+G500',
 
     'label_rotation' => 180,
 

--- a/utils/GodexPrinter.php
+++ b/utils/GodexPrinter.php
@@ -3,75 +3,74 @@ namespace Utils;
 
 use Exception;
 use InvalidArgumentException;
-use PDO;
 
 class GodexPrinter
 {
-    private ?string $host;
-    private int $port;
+    private const DEFAULT_STORAGE_SUBDIR = '/storage/label_pdfs';
+
+    /**
+     * Code 128 patterns (0-106) from specification.
+     * @var array<int,string>
+     */
+    private const CODE128_PATTERNS = [
+        '11011001100','11001101100','11001100110','10010011000','10010001100','10001001100',
+        '10011001000','10011000100','10001100100','11001001000','11001000100','11000100100',
+        '10110011100','10011011100','10011001110','10111001100','10011101100','10011100110',
+        '11001110010','11001011100','11001001110','11011100100','11001110100','11101101110',
+        '11101001100','11100101100','11100100110','11101100100','11100110100','11100110010',
+        '11011011000','11011000110','11000110110','10100011000','10001011000','10001000110',
+        '10110001000','10001101000','10001100010','11010001000','11000101000','11000100010',
+        '10110111000','10110001110','10001101110','10111011000','10111000110','10001110110',
+        '11101110110','11010001110','11000101110','11011101000','11011100010','11011101110',
+        '11101011000','11101000110','11100010110','11101101000','11101100010','11100011010',
+        '11101111010','11001000010','11110001010','10100110000','10100001100','10010110000',
+        '10010000110','10000101100','10000100110','10110010000','10110000100','10011010000',
+        '10011000010','10000110100','10000110010','11000010010','11001010000','11110111010',
+        '11000010100','10001111010','10100111100','10010111100','10010011110','10111100100',
+        '10011110100','10011110010','11110100100','11110010100','11110010010','11011011110',
+        '11011110110','11110110110','10101111000','10100011110','10001011110','10111101000',
+        '10111100010','11110101000','11110100010','10111011110','10111101110','11101011110',
+        '11110101110','11010000100','11010010000','11010011100','11000111010','11010111000',
+        '1100011101011'
+    ];
+
+    private static ?array $code128MapB = null;
+
     private ?string $printServerUrl;
-    private ?string $queueName;
+    private string $printerName;
+    private string $storageDir;
+    private string $storageUrlPath;
+    private string $baseUrl;
+    private string $fontRegular;
+    private string $fontBold;
 
     public function __construct(array $config = [])
     {
-        $this->host = $config['host'] ?? getenv('GODEX_PRINTER_HOST') ?: null;
-        $this->port = (int)($config['port'] ?? getenv('GODEX_PRINTER_PORT') ?: 9100);
+        if (!defined('BASE_PATH')) {
+            define('BASE_PATH', dirname(__DIR__));
+        }
+
         $this->printServerUrl = $config['print_server_url'] ?? getenv('PRINT_SERVER_URL') ?: null;
-        $this->queueName = $config['queue'] ?? getenv('GODEX_PRINTER_QUEUE') ?: null;
-    }
+        $this->printerName = (string)($config['printer'] ?? $config['queue'] ?? getenv('GODEX_PRINTER_QUEUE') ?: 'godex');
 
-    public function generateLabel(array $productData): string
-    {
-        $sku = trim((string)($productData['sku'] ?? ''));
-        if ($sku === '') {
-            throw new InvalidArgumentException('Cannot generate label without SKU value.');
+        $storageDir = $config['storage_dir'] ?? (defined('BASE_PATH') ? BASE_PATH . self::DEFAULT_STORAGE_SUBDIR : __DIR__ . '/../storage/label_pdfs');
+        $this->storageDir = rtrim((string)$storageDir, '/');
+        if ($this->storageDir === '') {
+            $this->storageDir = BASE_PATH . self::DEFAULT_STORAGE_SUBDIR;
         }
 
-        $name = $this->sanitizeText($productData['name'] ?? '', 30);
-        $code = $this->sanitizeText($productData['product_code'] ?? $sku, 30);
-        $weight = isset($productData['weight']) ? (float)$productData['weight'] : null;
-        $unitCode = $this->sanitizeText($productData['unit_code'] ?? '', 10);
+        $storageUrlPath = $config['storage_url_path'] ?? self::DEFAULT_STORAGE_SUBDIR;
+        $storageUrlPath = '/' . ltrim((string)$storageUrlPath, '/');
+        $this->storageUrlPath = rtrim($storageUrlPath, '/');
 
-        $weightText = $weight !== null ? sprintf('Greutate: %.3f %s', $weight, $unitCode ?: 'kg') : '';
-
-        $lines = [
-            'N',
-            'q400',
-            'Q50,30',
-            'S2',
-            'D10',
-            'A10,10,0,3,1,1,N,"WARTUNG WMS"',
-            sprintf('B10,40,0,1,2,2,60,B,"%s"', $sku),
-            sprintf('A10,110,0,2,1,1,N,"%s"', $sku),
-            sprintf('A10,130,0,2,1,1,N,"%s"', $name),
-        ];
-
-        if ($code !== '' && $code !== $sku) {
-            $lines[] = sprintf('A10,150,0,1,1,1,N,"Cod: %s"', $code);
+        $baseUrl = $config['base_url'] ?? $this->detectBaseUrl();
+        $this->baseUrl = rtrim((string)$baseUrl, '/');
+        if ($this->baseUrl === '') {
+            $this->baseUrl = 'http://localhost';
         }
 
-        if ($weightText !== '') {
-            $lines[] = sprintf('A10,170,0,1,1,1,N,"%s"', $weightText);
-        }
-
-        $lines[] = 'P1';
-
-        return implode("\n", $lines) . "\n";
-    }
-
-    public function printLabel(string $labelData): void
-    {
-        if ($this->host) {
-            $this->sendToNetworkPrinter($labelData);
-            return;
-        }
-
-        if ($this->printServerUrl) {
-            $this->sendToPrintServer($labelData);
-            return;
-        }
-
-        throw new Exception('Printer connection is not configured.');
+        $this->ensureStorageDirectory();
+        $this->locateFonts();
     }
 
     public function printBatch(array $products): array
@@ -81,8 +80,11 @@ class GodexPrinter
 
         foreach ($products as $product) {
             try {
-                $label = $this->generateLabel($product);
-                $this->printLabel($label);
+                $label = $this->createLabelDocument($product);
+                $result = $this->sendToPrintServer($label['url'], $this->printerName, $label['format']);
+                if (!$result['success']) {
+                    throw new Exception($result['error'] ?? 'Print server error');
+                }
                 $printed++;
             } catch (Exception $e) {
                 $errors[] = [
@@ -98,66 +100,371 @@ class GodexPrinter
         ];
     }
 
-    private function sanitizeText(string $value, int $maxLength): string
+    private function ensureStorageDirectory(): void
     {
-        $value = trim($value);
+        if (!is_dir($this->storageDir)) {
+            if (!@mkdir($this->storageDir, 0775, true) && !is_dir($this->storageDir)) {
+                throw new Exception('Unable to create storage directory for labels.');
+            }
+        }
+
+        if (!is_writable($this->storageDir)) {
+            throw new Exception('Storage directory for labels is not writable.');
+        }
+    }
+
+    private function detectBaseUrl(): string
+    {
+        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+        $host = $_SERVER['HTTP_HOST'] ?? '';
+
+        if ($host === '') {
+            return 'http://localhost';
+        }
+
+        return $scheme . '://' . $host;
+    }
+
+    private function locateFonts(): void
+    {
+        $defaultRegular = BASE_PATH . '/fonts/Roboto-Regular.ttf';
+        $defaultBold = BASE_PATH . '/fonts/Roboto-Bold.ttf';
+
+        $this->fontRegular = is_readable($defaultRegular) ? $defaultRegular : '';
+        $this->fontBold = is_readable($defaultBold) ? $defaultBold : $this->fontRegular;
+
+        if (($this->fontRegular === '' || $this->fontBold === '') && function_exists('imagettftext')) {
+            $systemFont = getenv('GDFONTPATH');
+            if ($systemFont && is_readable($systemFont)) {
+                $this->fontRegular = $this->fontRegular ?: $systemFont;
+                $this->fontBold = $this->fontBold ?: $systemFont;
+            }
+        }
+
+        $this->fontRegular = $this->fontRegular ?: '';
+        $this->fontBold = $this->fontBold ?: $this->fontRegular;
+    }
+
+    private function createLabelDocument(array $product): array
+    {
+        $sku = trim((string)($product['sku'] ?? ''));
+        if ($sku === '') {
+            throw new InvalidArgumentException('Cannot generate label without SKU value.');
+        }
+
+        $fileName = $this->buildFileName($sku);
+        $filePath = $this->storageDir . '/' . $fileName;
+
+        $document = $this->renderPngLabel($product, $filePath);
+
+        return [
+            'path' => $filePath,
+            'url' => $this->buildFileUrl($fileName),
+            'format' => $document['format'] ?? 'png',
+        ];
+    }
+
+    private function buildFileName(string $sku): string
+    {
+        $safeSku = preg_replace('/[^A-Za-z0-9_-]/', '_', $sku);
+        $safeSku = trim($safeSku, '_');
+        if ($safeSku === '') {
+            $safeSku = 'label';
+        }
+
+        $unique = substr(str_replace('.', '', uniqid('', true)), -6);
+
+        return sprintf('product_label_%s_%s_%s.png', $safeSku, date('Ymd_His'), $unique);
+    }
+
+    private function buildFileUrl(string $fileName): string
+    {
+        return $this->baseUrl . $this->storageUrlPath . '/' . rawurlencode($fileName);
+    }
+
+    private function sanitizeText(?string $value, int $maxLength = 0): string
+    {
+        $value = trim((string)$value);
         if ($value === '') {
             return '';
         }
 
-        $value = preg_replace('/["\r\n]+/', ' ', $value);
-        if (function_exists('mb_strimwidth')) {
-            $value = mb_strimwidth($value, 0, $maxLength, '', 'UTF-8');
-        } else {
-            $value = substr($value, 0, $maxLength);
+        $value = preg_replace('/["\r\n\t]+/', ' ', $value);
+
+        if ($maxLength > 0) {
+            if (function_exists('mb_strimwidth')) {
+                $value = mb_strimwidth($value, 0, $maxLength, '', 'UTF-8');
+            } else {
+                $value = substr($value, 0, $maxLength);
+            }
         }
 
         return $value;
     }
 
-    private function sendToNetworkPrinter(string $payload): void
+    private function encodeCode128(string $value): array
     {
-        $socket = @fsockopen($this->host, $this->port, $errno, $errstr, 5.0);
-        if (!$socket) {
-            throw new Exception(sprintf('Cannot connect to printer %s:%d (%s)', $this->host, $this->port, $errstr ?: $errno));
+        if ($value === '') {
+            throw new InvalidArgumentException('Cannot encode an empty barcode value.');
         }
 
-        stream_set_timeout($socket, 5);
-        $written = fwrite($socket, $payload);
-        fclose($socket);
+        $map = self::$code128MapB;
+        if ($map === null) {
+            $map = [];
+            for ($i = 32; $i <= 126; $i++) {
+                $map[chr($i)] = $i - 32;
+            }
+            $map[chr(127)] = 95;
+            self::$code128MapB = $map;
+        }
 
-        if ($written === false || $written === 0) {
-            throw new Exception('Failed to send label data to printer.');
+        $quietZone = str_repeat('0', 10);
+        $patterns = [$quietZone, self::CODE128_PATTERNS[104]]; // Start Code B
+        $checksum = 104;
+        $length = strlen($value);
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $value[$i];
+            if (!isset($map[$char])) {
+                throw new InvalidArgumentException(sprintf('Unsupported character "%s" for Code 128 barcode.', $char));
+            }
+            $code = $map[$char];
+            $patterns[] = self::CODE128_PATTERNS[$code];
+            $checksum += $code * ($i + 1);
+        }
+
+        $checksumCode = $checksum % 103;
+        $patterns[] = self::CODE128_PATTERNS[$checksumCode];
+        $patterns[] = self::CODE128_PATTERNS[106];
+        $patterns[] = '11'; // Termination bars
+        $patterns[] = $quietZone;
+
+        return $patterns;
+    }
+
+    private function renderPngLabel(array $product, string $filePath): array
+    {
+        if (!extension_loaded('gd')) {
+            throw new Exception('GD extension is required for PNG label rendering.');
+        }
+
+        $width = 600;
+        $height = 400;
+
+        $image = imagecreatetruecolor($width, $height);
+        if ($image === false) {
+            throw new Exception('Unable to initialize image canvas for label.');
+        }
+
+        if (function_exists('imageantialias')) {
+            imageantialias($image, true);
+        }
+
+        $white = imagecolorallocate($image, 255, 255, 255);
+        $black = imagecolorallocate($image, 0, 0, 0);
+        $gray = imagecolorallocate($image, 90, 90, 90);
+
+        imagefill($image, 0, 0, $white);
+
+        $margin = 28;
+        $usableWidth = $width - ($margin * 2);
+
+        $title = 'WARTUNG WMS';
+        $titleSize = 26;
+        $titleY = $margin + $titleSize;
+        $this->drawText($image, $title, $this->fontBold, $titleSize, $margin, $titleY, $black);
+
+        $barcodeTop = $titleY + 20;
+        $barcodeHeight = 160;
+        $patterns = implode('', $this->encodeCode128(trim((string)$product['sku'])));
+        $moduleCount = strlen($patterns);
+        if ($moduleCount === 0) {
+            imagedestroy($image);
+            throw new Exception('Unable to encode barcode pattern.');
+        }
+
+        $moduleWidth = (int)max(1, floor($usableWidth / $moduleCount));
+        $barcodeWidth = $moduleWidth * $moduleCount;
+        $barcodeLeft = (int)($margin + ($usableWidth - $barcodeWidth) / 2);
+
+        for ($i = 0; $i < $moduleCount; $i++) {
+            if ($patterns[$i] === '1') {
+                $x1 = $barcodeLeft + ($i * $moduleWidth);
+                $x2 = $x1 + $moduleWidth - 1;
+                imagefilledrectangle($image, $x1, $barcodeTop, $x2, $barcodeTop + $barcodeHeight, $black);
+            }
+        }
+
+        $skuTextSize = 28;
+        $skuY = $barcodeTop + $barcodeHeight + 42;
+        $this->drawCenteredText($image, $product['sku'], $this->fontRegular, $skuTextSize, $width / 2, $skuY, $black);
+
+        $textTop = $skuY + 24;
+        $lineHeight = 36;
+
+        $name = $this->sanitizeText($product['name'] ?? '', 60);
+        if ($name !== '') {
+            $this->drawWrappedText($image, $name, $this->fontBold ?: $this->fontRegular, 24, $margin, $textTop, $usableWidth, $lineHeight, $black);
+            $textTop += $lineHeight * $this->estimateLineCount($name, $usableWidth, 24, $this->fontBold ?: $this->fontRegular);
+        }
+
+        $code = $this->sanitizeText($product['product_code'] ?? '', 40);
+        if ($code !== '' && $code !== $product['sku']) {
+            $this->drawText($image, 'Cod: ' . $code, $this->fontRegular ?: $this->fontBold, 22, $margin, $textTop, $gray);
+            $textTop += $lineHeight;
+        }
+
+        $weight = isset($product['weight']) ? (float)$product['weight'] : null;
+        $unitCode = $this->sanitizeText($product['unit_code'] ?? '', 10) ?: 'kg';
+        if ($weight !== null && $weight > 0) {
+            $weightText = sprintf('Greutate: %.3f %s', $weight, $unitCode);
+            $this->drawText($image, $weightText, $this->fontRegular ?: $this->fontBold, 22, $margin, $textTop, $gray);
+        }
+
+        $saved = imagepng($image, $filePath, 0);
+        imagedestroy($image);
+
+        if (!$saved) {
+            throw new Exception('Failed to save PNG label to storage.');
+        }
+
+        return ['format' => 'png'];
+    }
+
+    private function drawText($image, string $text, string $font, int $size, int $x, int $y, int $color): void
+    {
+        if ($font !== '' && function_exists('imagettftext')) {
+            imagettftext($image, $size, 0, $x, $y, $color, $font, $text);
+        } else {
+            imagestring($image, 5, $x, $y - 12, $text, $color);
         }
     }
 
-    private function sendToPrintServer(string $payload): void
+    private function drawCenteredText($image, string $text, string $font, int $size, float $centerX, int $baselineY, int $color): void
     {
+        if ($font !== '' && function_exists('imagettfbbox')) {
+            $bbox = imagettfbbox($size, 0, $font, $text);
+            $textWidth = abs($bbox[2] - $bbox[0]);
+            $x = (int)($centerX - ($textWidth / 2));
+            imagettftext($image, $size, 0, $x, $baselineY, $color, $font, $text);
+        } else {
+            $textWidth = imagefontwidth(5) * strlen($text);
+            $x = (int)($centerX - ($textWidth / 2));
+            imagestring($image, 5, $x, $baselineY - 12, $text, $color);
+        }
+    }
+
+    private function drawWrappedText($image, string $text, string $font, int $size, int $x, int $startY, int $maxWidth, int $lineHeight, int $color): void
+    {
+        $words = preg_split('/\s+/', $text);
+        $line = '';
+        $y = $startY;
+
+        foreach ($words as $word) {
+            $testLine = trim($line === '' ? $word : $line . ' ' . $word);
+            if ($testLine === '') {
+                continue;
+            }
+
+            $lineWidth = $this->measureTextWidth($testLine, $font, $size);
+            if ($lineWidth > $maxWidth && $line !== '') {
+                $this->drawText($image, $line, $font, $size, $x, $y, $color);
+                $line = $word;
+                $y += $lineHeight;
+            } else {
+                $line = $testLine;
+            }
+        }
+
+        if ($line !== '') {
+            $this->drawText($image, $line, $font, $size, $x, $y, $color);
+        }
+    }
+
+    private function measureTextWidth(string $text, string $font, int $size): float
+    {
+        if ($font !== '' && function_exists('imagettfbbox')) {
+            $bbox = imagettfbbox($size, 0, $font, $text);
+            return abs($bbox[2] - $bbox[0]);
+        }
+
+        return imagefontwidth(5) * strlen($text);
+    }
+
+    private function estimateLineCount(string $text, int $maxWidth, int $size, string $font): int
+    {
+        $words = preg_split('/\s+/', $text);
+        $lines = 1;
+        $current = '';
+
+        foreach ($words as $word) {
+            $test = trim($current === '' ? $word : $current . ' ' . $word);
+            if ($this->measureTextWidth($test, $font, $size) > $maxWidth && $current !== '') {
+                $lines++;
+                $current = $word;
+            } else {
+                $current = $test;
+            }
+        }
+
+        return max(1, $lines);
+    }
+
+    private function sendToPrintServer(string $fileUrl, string $printer, string $format = 'pdf'): array
+    {
+        if ($this->printServerUrl === null) {
+            return ['success' => false, 'error' => 'Print server URL is not configured'];
+        }
+
+        $query = [
+            'url' => $fileUrl,
+            'printer' => $printer,
+        ];
+
+        if ($format !== '') {
+            $query['format'] = $format;
+        }
+
+        $requestUrl = $this->printServerUrl . '?' . $this->buildPrintQuery($query);
+
         $context = stream_context_create([
             'http' => [
-                'method' => 'POST',
-                'header' => "Content-Type: application/json\r\n",
-                'content' => json_encode([
-                    'queue' => $this->queueName,
-                    'payload' => base64_encode($payload),
-                    'encoding' => 'base64',
-                    'type' => 'epl',
-                ], JSON_THROW_ON_ERROR),
-                'timeout' => 5,
+                'method' => 'GET',
+                'timeout' => 15,
+                'ignore_errors' => true,
+                'user_agent' => 'WMS-PrintClient/1.0',
             ],
         ]);
 
-        $result = @file_get_contents($this->printServerUrl, false, $context);
-        if ($result === false) {
-            $error = error_get_last();
-            throw new Exception('Print server request failed: ' . ($error['message'] ?? 'unknown error'));
+        $response = @file_get_contents($requestUrl, false, $context);
+        if ($response === false) {
+            return ['success' => false, 'error' => 'Failed to connect to print server'];
         }
 
-        $decoded = json_decode($result, true);
-        if (is_array($decoded) && isset($decoded['status']) && $decoded['status'] !== 'success') {
-            $message = $decoded['message'] ?? 'Unknown print server error';
-            throw new Exception('Print server responded with error: ' . $message);
+        foreach (['Trimis la imprimantă', 'sent to printer', 'Print successful'] as $indicator) {
+            if (stripos($response, $indicator) !== false) {
+                return ['success' => true];
+            }
         }
+
+        return ['success' => false, 'error' => 'Print server response: ' . $response];
+    }
+
+    private function buildPrintQuery(array $params): string
+    {
+        $pairs = [];
+
+        foreach ($params as $key => $value) {
+            $encodedKey = rawurlencode((string) $key);
+            $encodedValue = rawurlencode((string) $value);
+
+            if ($key === 'printer') {
+                $encodedValue = str_replace('%2B', '+', $encodedValue);
+            }
+
+            $pairs[] = $encodedKey . '=' . $encodedValue;
+        }
+
+        return implode('&', $pairs);
     }
 }
-


### PR DESCRIPTION
## Summary
- render product unit label content into PNG files using GD and embedded fonts before sending to the print server
- keep the existing print server call flow while allowing the PNG format parameter and preserving printer queue names

## Testing
- php -l utils/GodexPrinter.php
- php -l api/barcode/print.php

------
https://chatgpt.com/codex/tasks/task_e_68e4ca57d8a883209eb0cc6d5c41f54a