### PR TITLE
Add PDF export for detailed stock view

### DIFF
--- a/styles/inventory.css
+++ b/styles/inventory.css
@@ -711,6 +711,20 @@
             font-size: 0.85rem;
         }
 
+        .filter-form .form-actions {
+            display: flex;
+            gap: 0.75rem;
+            align-items: center;
+            flex-wrap: wrap;
+            margin-top: 0.5rem;
+        }
+
+        .filter-form .form-actions .btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
         .checkbox-label {
             display: flex;
             align-items: center;


### PR DESCRIPTION
## Summary
- generate a PDF report for the detailed stock view using the existing filters and FPDF
- add an Exportă PDF action to the Detaliat filter bar and adjust styles so the buttons stay aligned

## Testing
- php -l inventory.php

------
https://chatgpt.com/codex/tasks/task_e_68e61778362083208020f9ef06dddbc8