### PR TITLE
Add autocomplete editing for recipient address metadata

### DIFF
--- a/api/warehouse/manage_order_item.php
+++ b/api/warehouse/manage_order_item.php
@@ -1,0 +1,475 @@
+<?php
+// File: api/warehouse/manage_order_item.php - CRUD operations for order items
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+$config = require BASE_PATH . '/config/config.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$allowedRoles = ['admin', 'warehouse', 'warehouse_worker'];
+if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'] ?? '', $allowedRoles, true)) {
+    http_response_code(403);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Autentificare necesară.'
+    ]);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Metodă HTTP neacceptată. Folosește POST.'
+    ]);
+    exit;
+}
+
+if (!isset($config['connection_factory']) || !is_callable($config['connection_factory'])) {
+    http_response_code(500);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Configurația bazei de date lipsește.'
+    ]);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input)) {
+    $input = $_POST;
+}
+
+$action = strtolower(trim((string)($input['action'] ?? '')));
+$orderId = filter_var($input['order_id'] ?? null, FILTER_VALIDATE_INT);
+
+if (!$orderId || !in_array($action, ['create', 'update', 'delete'], true)) {
+    http_response_code(400);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Date invalide pentru procesare.'
+    ]);
+    exit;
+}
+
+try {
+    $dbFactory = $config['connection_factory'];
+    $db = $dbFactory();
+    $db->beginTransaction();
+
+    require_once BASE_PATH . '/models/Order.php';
+    $orderModel = new Order($db);
+    $order = $orderModel->getOrderById($orderId);
+
+    if (!$order) {
+        $db->rollBack();
+        http_response_code(404);
+        echo json_encode([
+            'status' => 'error',
+            'message' => 'Comanda nu a fost găsită.'
+        ]);
+        exit;
+    }
+
+    $itemId = null;
+    if (isset($input['order_item_id'])) {
+        $itemId = filter_var($input['order_item_id'], FILTER_VALIDATE_INT);
+    }
+
+    switch ($action) {
+        case 'delete':
+            if (!$itemId) {
+                throw new InvalidArgumentException('ID-ul produsului este necesar pentru ștergere.');
+            }
+
+            $item = fetchOrderItem($db, $orderId, $itemId);
+            if (!$item) {
+                throw new RuntimeException('Produsul specificat nu a fost găsit în această comandă.');
+            }
+
+            $deleteStmt = $db->prepare('DELETE FROM order_items WHERE id = :id AND order_id = :order_id LIMIT 1');
+            $deleteStmt->execute([
+                ':id' => $itemId,
+                ':order_id' => $orderId
+            ]);
+
+            logActivity(
+                $_SESSION['user_id'] ?? 0,
+                'delete',
+                'order_item',
+                $itemId,
+                'Produs eliminat din comandă',
+                [
+                    'order_id' => $orderId,
+                    'product_id' => $item['product_id'] ?? null,
+                    'quantity' => $item['quantity'] ?? $item['quantity_ordered'] ?? null
+                ],
+                null,
+                'order',
+                $orderId
+            );
+            break;
+
+        case 'create':
+            $productId = filter_var($input['product_id'] ?? null, FILTER_VALIDATE_INT);
+            $quantity = (int)($input['quantity'] ?? 0);
+            $unitPrice = normalizeNumericValue($input['unit_price'] ?? null);
+
+            if (!$productId || $quantity <= 0) {
+                throw new InvalidArgumentException('Produsul și cantitatea sunt obligatorii.');
+            }
+
+            $product = fetchProduct($db, $productId);
+            if (!$product) {
+                throw new RuntimeException('Produsul selectat nu există.');
+            }
+
+            if ($unitPrice === null || $unitPrice < 0) {
+                $unitPrice = isset($product['price']) ? (float)$product['price'] : 0.0;
+            }
+
+            $unitMeasure = $product['unit_of_measure'] ?? 'buc';
+            $columns = ['order_id', 'product_id'];
+            $placeholders = [':order_id', ':product_id'];
+            $params = [
+                ':order_id' => $orderId,
+                ':product_id' => $productId
+            ];
+
+            $quantityColumns = buildQuantityColumns($db, $quantity, $params, $columns, $placeholders);
+            $columns = $quantityColumns['columns'];
+            $placeholders = $quantityColumns['placeholders'];
+            $params = $quantityColumns['params'];
+
+            if (tableColumnExists($db, 'order_items', 'unit_price')) {
+                $columns[] = 'unit_price';
+                $placeholders[] = ':unit_price';
+                $params[':unit_price'] = $unitPrice;
+            }
+
+            if (tableColumnExists($db, 'order_items', 'total_price')) {
+                $columns[] = 'total_price';
+                $placeholders[] = ':total_price';
+                $params[':total_price'] = $unitPrice * $quantity;
+            }
+
+            if (tableColumnExists($db, 'order_items', 'unit_measure')) {
+                $columns[] = 'unit_measure';
+                $placeholders[] = ':unit_measure';
+                $params[':unit_measure'] = $unitMeasure;
+            }
+
+            if (tableColumnExists($db, 'order_items', 'picked_quantity')) {
+                $columns[] = 'picked_quantity';
+                $placeholders[] = ':picked_quantity';
+                $params[':picked_quantity'] = 0;
+            }
+
+            if (tableColumnExists($db, 'order_items', 'notes')) {
+                $columns[] = 'notes';
+                $placeholders[] = ':notes';
+                $params[':notes'] = '';
+            }
+
+            $insertQuery = sprintf(
+                'INSERT INTO order_items (%s) VALUES (%s)',
+                implode(', ', $columns),
+                implode(', ', $placeholders)
+            );
+
+            $insertStmt = $db->prepare($insertQuery);
+            $insertStmt->execute($params);
+            $itemId = (int)$db->lastInsertId();
+
+            logActivity(
+                $_SESSION['user_id'] ?? 0,
+                'create',
+                'order_item',
+                $itemId,
+                'Produs adăugat în comandă',
+                null,
+                [
+                    'order_id' => $orderId,
+                    'product_id' => $productId,
+                    'quantity' => $quantity,
+                    'unit_price' => $unitPrice
+                ],
+                'order',
+                $orderId
+            );
+            break;
+
+        case 'update':
+            if (!$itemId) {
+                throw new InvalidArgumentException('ID-ul produsului este necesar pentru modificare.');
+            }
+
+            $item = fetchOrderItem($db, $orderId, $itemId);
+            if (!$item) {
+                throw new RuntimeException('Produsul specificat nu a fost găsit în această comandă.');
+            }
+
+            $productId = filter_var($input['product_id'] ?? null, FILTER_VALIDATE_INT) ?: (int)$item['product_id'];
+            $quantity = (int)($input['quantity'] ?? ($item['quantity'] ?? $item['quantity_ordered'] ?? 0));
+            $unitPriceInput = normalizeNumericValue($input['unit_price'] ?? null);
+            $unitPrice = $unitPriceInput !== null ? $unitPriceInput : (isset($item['unit_price']) ? (float)$item['unit_price'] : 0.0);
+
+            if ($quantity <= 0) {
+                throw new InvalidArgumentException('Cantitatea trebuie să fie mai mare decât zero.');
+            }
+
+            if ($item['picked_quantity'] ?? 0 > $quantity) {
+                throw new RuntimeException('Cantitatea nu poate fi mai mică decât cantitatea deja ridicată.');
+            }
+
+            $product = fetchProduct($db, $productId);
+            if (!$product) {
+                throw new RuntimeException('Produsul selectat nu există.');
+            }
+
+            if ($unitPrice < 0) {
+                $unitPrice = isset($product['price']) ? (float)$product['price'] : 0.0;
+            }
+
+            $unitMeasure = $product['unit_of_measure'] ?? ($item['unit_measure'] ?? 'buc');
+
+            $updateParts = ['product_id = :product_id'];
+            $params = [
+                ':order_id' => $orderId,
+                ':id' => $itemId,
+                ':product_id' => $productId
+            ];
+
+            $quantityColumns = buildQuantityColumns($db, $quantity, $params);
+            $updateParts = array_merge($updateParts, $quantityColumns['setParts']);
+            $params = $quantityColumns['params'];
+
+            if (tableColumnExists($db, 'order_items', 'unit_price')) {
+                $updateParts[] = 'unit_price = :unit_price';
+                $params[':unit_price'] = $unitPrice;
+            }
+
+            if (tableColumnExists($db, 'order_items', 'total_price')) {
+                $updateParts[] = 'total_price = :total_price';
+                $params[':total_price'] = $unitPrice * $quantity;
+            }
+
+            if (tableColumnExists($db, 'order_items', 'unit_measure')) {
+                $updateParts[] = 'unit_measure = :unit_measure';
+                $params[':unit_measure'] = $unitMeasure;
+            }
+
+            $updateQuery = 'UPDATE order_items SET ' . implode(', ', $updateParts) . ' WHERE id = :id AND order_id = :order_id';
+            $updateStmt = $db->prepare($updateQuery);
+            $updateStmt->execute($params);
+
+            logActivity(
+                $_SESSION['user_id'] ?? 0,
+                'update',
+                'order_item',
+                $itemId,
+                'Produs actualizat în comandă',
+                [
+                    'order_id' => $orderId,
+                    'product_id' => $item['product_id'] ?? null,
+                    'quantity' => $item['quantity'] ?? $item['quantity_ordered'] ?? null,
+                    'unit_price' => $item['unit_price'] ?? null
+                ],
+                [
+                    'order_id' => $orderId,
+                    'product_id' => $productId,
+                    'quantity' => $quantity,
+                    'unit_price' => $unitPrice
+                ],
+                'order',
+                $orderId
+            );
+            break;
+    }
+
+    recalculateOrderSummary($db, $orderModel, $orderId);
+
+    $db->commit();
+
+    echo json_encode([
+        'status' => 'success',
+        'message' => $action === 'delete'
+            ? 'Produsul a fost eliminat din comandă.'
+            : 'Comanda a fost actualizată.'
+    ]);
+} catch (Throwable $e) {
+    if (isset($db) && $db->inTransaction()) {
+        $db->rollBack();
+    }
+
+    $message = $e->getMessage();
+    $statusCode = $e instanceof InvalidArgumentException ? 422 : ($e instanceof RuntimeException ? 400 : 500);
+
+    if ($statusCode === 500) {
+        error_log('manage_order_item error: ' . $e->getMessage());
+        $message = 'A apărut o eroare la actualizarea produselor comenzii.';
+    }
+
+    http_response_code($statusCode);
+    echo json_encode([
+        'status' => 'error',
+        'message' => $message
+    ]);
+}
+
+function normalizeNumericValue($value): ?float
+{
+    if ($value === null || $value === '') {
+        return null;
+    }
+
+    if (is_string($value)) {
+        $value = str_replace([' ', ','], ['', '.'], $value);
+    }
+
+    return is_numeric($value) ? (float)$value : null;
+}
+
+function fetchOrderItem(PDO $db, int $orderId, int $itemId): ?array
+{
+    $stmt = $db->prepare('SELECT * FROM order_items WHERE id = :id AND order_id = :order_id');
+    $stmt->execute([
+        ':id' => $itemId,
+        ':order_id' => $orderId
+    ]);
+    $item = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    return $item ?: null;
+}
+
+function fetchProduct(PDO $db, int $productId): ?array
+{
+    $stmt = $db->prepare('SELECT product_id, price, unit_of_measure, name FROM products WHERE product_id = :id');
+    $stmt->execute([':id' => $productId]);
+    $product = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    return $product ?: null;
+}
+
+function tableColumnExists(PDO $db, string $table, string $column): bool
+{
+    static $cache = [];
+    $key = $table . '.' . $column;
+
+    if (array_key_exists($key, $cache)) {
+        return $cache[$key];
+    }
+
+    $stmt = $db->prepare(
+        'SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :table AND COLUMN_NAME = :column'
+    );
+    $stmt->execute([
+        ':table' => $table,
+        ':column' => $column
+    ]);
+
+    $cache[$key] = (int)$stmt->fetchColumn() > 0;
+    return $cache[$key];
+}
+
+function buildQuantityColumns(PDO $db, int $quantity, array $params, array $columns = [], array $placeholders = []): array
+{
+    if (empty($columns)) {
+        $columns = [];
+    }
+    if (empty($placeholders)) {
+        $placeholders = [];
+    }
+
+    if (tableColumnExists($db, 'order_items', 'quantity')) {
+        $columns[] = 'quantity';
+        $placeholders[] = ':quantity';
+        $params[':quantity'] = $quantity;
+    }
+
+    if (tableColumnExists($db, 'order_items', 'quantity_ordered')) {
+        $columns[] = 'quantity_ordered';
+        $placeholders[] = ':quantity_ordered';
+        $params[':quantity_ordered'] = $quantity;
+    }
+
+    return [
+        'columns' => $columns,
+        'placeholders' => $placeholders,
+        'params' => $params,
+        'setParts' => array_filter([
+            tableColumnExists($db, 'order_items', 'quantity') ? 'quantity = :quantity' : null,
+            tableColumnExists($db, 'order_items', 'quantity_ordered') ? 'quantity_ordered = :quantity_ordered' : null
+        ])
+    ];
+}
+
+function recalculateOrderSummary(PDO $db, Order $orderModel, int $orderId): void
+{
+    $quantityColumn = tableColumnExists($db, 'order_items', 'quantity') ? 'quantity' : (tableColumnExists($db, 'order_items', 'quantity_ordered') ? 'quantity_ordered' : null);
+    $unitPriceColumnExists = tableColumnExists($db, 'order_items', 'unit_price');
+    $pickedQuantityExists = tableColumnExists($db, 'order_items', 'picked_quantity');
+
+    $totalsQueryParts = [];
+    if ($quantityColumn !== null) {
+        $totalsQueryParts[] = 'SUM(COALESCE(' . $quantityColumn . ', 0)) AS total_quantity';
+    }
+    if ($unitPriceColumnExists && $quantityColumn !== null) {
+        $totalsQueryParts[] = 'SUM(COALESCE(' . $quantityColumn . ', 0) * COALESCE(unit_price, 0)) AS total_value';
+    }
+    if ($pickedQuantityExists) {
+        $totalsQueryParts[] = 'SUM(COALESCE(picked_quantity, 0)) AS total_picked';
+    }
+
+    $totals = [
+        'total_quantity' => 0,
+        'total_value' => 0,
+        'total_picked' => 0
+    ];
+
+    if (!empty($totalsQueryParts)) {
+        $totalsQuery = 'SELECT ' . implode(', ', $totalsQueryParts) . ' FROM order_items WHERE order_id = :order_id';
+        $totalsStmt = $db->prepare($totalsQuery);
+        $totalsStmt->execute([':order_id' => $orderId]);
+        $totals = array_merge($totals, array_filter((array)$totalsStmt->fetch(PDO::FETCH_ASSOC)));
+    }
+
+    $ordersUpdateParts = [];
+    $ordersParams = [':order_id' => $orderId];
+
+    if (tableColumnExists($db, 'orders', 'total_value') && isset($totals['total_value'])) {
+        $ordersUpdateParts[] = 'total_value = :total_value';
+        $ordersParams[':total_value'] = (float)$totals['total_value'];
+    }
+
+    if (tableColumnExists($db, 'orders', 'updated_at')) {
+        $ordersUpdateParts[] = 'updated_at = NOW()';
+    }
+
+    if (tableColumnExists($db, 'orders', 'items_count')) {
+        $countStmt = $db->prepare('SELECT COUNT(*) FROM order_items WHERE order_id = :order_id');
+        $countStmt->execute([':order_id' => $orderId]);
+        $ordersUpdateParts[] = 'items_count = :items_count';
+        $ordersParams[':items_count'] = (int)$countStmt->fetchColumn();
+    }
+
+    if (!empty($ordersUpdateParts)) {
+        $ordersUpdate = 'UPDATE orders SET ' . implode(', ', $ordersUpdateParts) . ' WHERE id = :order_id';
+        $ordersStmt = $db->prepare($ordersUpdate);
+        $ordersStmt->execute($ordersParams);
+    }
+
+    try {
+        if (method_exists($orderModel, 'recalculateShipping')) {
+            $orderModel->recalculateShipping($orderId);
+        }
+    } catch (Throwable $e) {
+        error_log('manage_order_item recalculation warning: ' . $e->getMessage());
+    }
+}

--- a/api/warehouse/order_details.php
+++ b/api/warehouse/order_details.php
@@ -110,12 +110,17 @@ try {
             'customer_name' => $order['customer_name'],
             'customer_email' => $order['customer_email'],
             'shipping_address' => $order['shipping_address'],
+            'address_text' => $order['address_text'],
             'order_date' => $order['order_date'],
             'status' => $order['status'],
             'status_label' => $statusTranslations[$order['status']] ?? $order['status'],
             'tracking_number' => $order['tracking_number'],
             'total_value' => number_format((float)$order['total_value'], 2),
             'notes' => $order['notes'],
+            'recipient_county_id' => $order['recipient_county_id'],
+            'recipient_county_name' => $order['recipient_county_name'],
+            'recipient_locality_id' => $order['recipient_locality_id'],
+            'recipient_locality_name' => $order['recipient_locality_name'],
             
             // Progress information
             'progress' => [

--- a/api/warehouse/search_location_mappings.php
+++ b/api/warehouse/search_location_mappings.php
@@ -1,0 +1,145 @@
+<?php
+// File: api/warehouse/search_location_mappings.php - Lightweight lookup for recipient address mappings
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$allowedRoles = ['admin', 'warehouse', 'warehouse_worker'];
+if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'] ?? '', $allowedRoles, true)) {
+    http_response_code(403);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Acces interzis.'
+    ]);
+    exit;
+}
+
+try {
+    $config = require BASE_PATH . '/config/config.php';
+    if (!isset($config['connection_factory']) || !is_callable($config['connection_factory'])) {
+        throw new RuntimeException('Configurația bazei de date lipsește.');
+    }
+    $db = $config['connection_factory']();
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Nu se poate stabili conexiunea la baza de date.'
+    ]);
+    exit;
+}
+
+$type = strtolower(trim((string)($_GET['type'] ?? 'locality')));
+if (!in_array($type, ['county', 'locality'], true)) {
+    $type = 'locality';
+}
+
+$query = trim((string)($_GET['query'] ?? $_GET['q'] ?? ''));
+if ($query === '') {
+    echo json_encode([
+        'status' => 'success',
+        'data' => []
+    ]);
+    exit;
+}
+
+$limit = (int)($_GET['limit'] ?? 15);
+$limit = max(5, min(30, $limit));
+
+$params = [':search' => '%' . $query . '%'];
+
+if ($type === 'county') {
+    $sql = "
+        SELECT
+            cargus_county_id,
+            MAX(cargus_county_name) AS cargus_county_name,
+            MAX(county_name) AS county_name
+        FROM address_location_mappings
+        WHERE (county_name LIKE :search OR cargus_county_name LIKE :search)
+          AND cargus_county_id IS NOT NULL AND cargus_county_id <> 0
+        GROUP BY cargus_county_id
+        ORDER BY MAX(cargus_county_name) ASC
+        LIMIT :limit
+    ";
+} else {
+    $countyId = $_GET['county_id'] ?? $_GET['cargus_county_id'] ?? null;
+    $countyId = filter_var($countyId, FILTER_VALIDATE_INT, ['options' => ['default' => null]]);
+
+    $whereCounty = '';
+    if ($countyId !== null && $countyId > 0) {
+        $whereCounty = ' AND cargus_county_id = :county_id';
+        $params[':county_id'] = $countyId;
+    }
+
+    $sql = "
+        SELECT
+            cargus_locality_id,
+            MAX(cargus_locality_name) AS cargus_locality_name,
+            MAX(locality_name) AS locality_name,
+            MAX(cargus_county_id) AS cargus_county_id,
+            MAX(cargus_county_name) AS cargus_county_name,
+            MAX(county_name) AS county_name
+        FROM address_location_mappings
+        WHERE (locality_name LIKE :search OR cargus_locality_name LIKE :search)
+          AND cargus_locality_id IS NOT NULL AND cargus_locality_id <> 0
+          {$whereCounty}
+        GROUP BY cargus_locality_id
+        ORDER BY MAX(cargus_locality_name) ASC
+        LIMIT :limit
+    ";
+}
+
+try {
+    $stmt = $db->prepare($sql);
+    foreach ($params as $key => $value) {
+        if ($value === null) {
+            $stmt->bindValue($key, null, PDO::PARAM_NULL);
+        } elseif (is_int($value)) {
+            $stmt->bindValue($key, $value, PDO::PARAM_INT);
+        } else {
+            $stmt->bindValue($key, $value, PDO::PARAM_STR);
+        }
+    }
+    $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+    $stmt->execute();
+
+    $results = [];
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        if ($type === 'county') {
+            $results[] = [
+                'cargus_county_id' => (int)$row['cargus_county_id'],
+                'cargus_county_name' => $row['cargus_county_name'],
+                'county_name' => $row['county_name']
+            ];
+        } else {
+            $results[] = [
+                'cargus_locality_id' => (int)$row['cargus_locality_id'],
+                'cargus_locality_name' => $row['cargus_locality_name'],
+                'locality_name' => $row['locality_name'],
+                'cargus_county_id' => $row['cargus_county_id'] !== null ? (int)$row['cargus_county_id'] : null,
+                'cargus_county_name' => $row['cargus_county_name'],
+                'county_name' => $row['county_name']
+            ];
+        }
+    }
+
+    echo json_encode([
+        'status' => 'success',
+        'data' => $results
+    ]);
+} catch (Throwable $e) {
+    error_log('search_location_mappings error: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Căutarea nu a reușit.'
+    ]);
+}

--- a/api/warehouse/update_order_details.php
+++ b/api/warehouse/update_order_details.php
@@ -1,0 +1,208 @@
+<?php
+// File: api/warehouse/update_order_details.php - Update contact information for an order
+header('Content-Type: application/json');
+
+if (!defined('BASE_PATH')) {
+    define('BASE_PATH', dirname(__DIR__, 2));
+}
+
+require_once BASE_PATH . '/bootstrap.php';
+$config = require BASE_PATH . '/config/config.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$allowedRoles = ['admin', 'warehouse', 'warehouse_worker'];
+if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'] ?? '', $allowedRoles, true)) {
+    http_response_code(403);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Autentificare necesară.'
+    ]);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Metodă HTTP neacceptată. Folosește POST.'
+    ]);
+    exit;
+}
+
+if (!isset($config['connection_factory']) || !is_callable($config['connection_factory'])) {
+    http_response_code(500);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Configurația bazei de date lipsește.'
+    ]);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input)) {
+    $input = $_POST;
+}
+
+$orderId = filter_var($input['order_id'] ?? null, FILTER_VALIDATE_INT);
+if (!$orderId) {
+    http_response_code(400);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'ID comandă invalid.'
+    ]);
+    exit;
+}
+
+$customerEmail = trim((string)($input['customer_email'] ?? ''));
+$shippingAddress = trim((string)($input['shipping_address'] ?? ''));
+$addressText = trim((string)($input['address_text'] ?? ''));
+$recipientCountyName = trim((string)($input['recipient_county_name'] ?? ''));
+$recipientCountyId = $input['recipient_county_id'] ?? null;
+$recipientLocalityName = trim((string)($input['recipient_locality_name'] ?? ''));
+$recipientLocalityId = $input['recipient_locality_id'] ?? null;
+
+$recipientCountyId = filter_var($recipientCountyId, FILTER_VALIDATE_INT, ['options' => ['default' => null]]);
+if ($recipientCountyId !== null && $recipientCountyId <= 0) {
+    $recipientCountyId = null;
+}
+
+$recipientLocalityId = filter_var($recipientLocalityId, FILTER_VALIDATE_INT, ['options' => ['default' => null]]);
+if ($recipientLocalityId !== null && $recipientLocalityId <= 0) {
+    $recipientLocalityId = null;
+}
+
+if ($customerEmail !== '' && !filter_var($customerEmail, FILTER_VALIDATE_EMAIL)) {
+    http_response_code(422);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'Adresa de email introdusă nu este validă.'
+    ]);
+    exit;
+}
+
+try {
+    $dbFactory = $config['connection_factory'];
+    $db = $dbFactory();
+
+    require_once BASE_PATH . '/models/Order.php';
+    $orderModel = new Order($db);
+    $existingOrder = $orderModel->getOrderById($orderId);
+
+    if (!$existingOrder) {
+        http_response_code(404);
+        echo json_encode([
+            'status' => 'error',
+            'message' => 'Comanda nu a fost găsită.'
+        ]);
+        exit;
+    }
+
+    $updateParts = [];
+    $params = [':id' => $orderId];
+
+    if ($customerEmail === '') {
+        $updateParts[] = 'customer_email = NULL';
+    } else {
+        $updateParts[] = 'customer_email = :customer_email';
+        $params[':customer_email'] = $customerEmail;
+    }
+
+    if ($shippingAddress === '') {
+        $updateParts[] = 'shipping_address = NULL';
+    } else {
+        $updateParts[] = 'shipping_address = :shipping_address';
+        $params[':shipping_address'] = $shippingAddress;
+    }
+
+    if ($addressText === '') {
+        $updateParts[] = 'address_text = NULL';
+    } else {
+        $updateParts[] = 'address_text = :address_text';
+        $params[':address_text'] = $addressText;
+    }
+
+    if ($recipientCountyId === null) {
+        $updateParts[] = 'recipient_county_id = NULL';
+    } else {
+        $updateParts[] = 'recipient_county_id = :recipient_county_id';
+        $params[':recipient_county_id'] = $recipientCountyId;
+    }
+
+    if ($recipientCountyName === '') {
+        $updateParts[] = 'recipient_county_name = NULL';
+    } else {
+        $updateParts[] = 'recipient_county_name = :recipient_county_name';
+        $params[':recipient_county_name'] = $recipientCountyName;
+    }
+
+    if ($recipientLocalityId === null) {
+        $updateParts[] = 'recipient_locality_id = NULL';
+    } else {
+        $updateParts[] = 'recipient_locality_id = :recipient_locality_id';
+        $params[':recipient_locality_id'] = $recipientLocalityId;
+    }
+
+    if ($recipientLocalityName === '') {
+        $updateParts[] = 'recipient_locality_name = NULL';
+    } else {
+        $updateParts[] = 'recipient_locality_name = :recipient_locality_name';
+        $params[':recipient_locality_name'] = $recipientLocalityName;
+    }
+
+    $updateParts[] = 'updated_at = NOW()';
+
+    $query = 'UPDATE orders SET ' . implode(', ', $updateParts) . ' WHERE id = :id LIMIT 1';
+
+    $stmt = $db->prepare($query);
+    foreach ($params as $key => $value) {
+        if ($value === null) {
+            $stmt->bindValue($key, null, PDO::PARAM_NULL);
+        } elseif (is_int($value)) {
+            $stmt->bindValue($key, $value, PDO::PARAM_INT);
+        } else {
+            $stmt->bindValue($key, $value);
+        }
+    }
+    $stmt->execute();
+
+    logActivity(
+        $_SESSION['user_id'] ?? 0,
+        'update',
+        'order',
+        $orderId,
+        'Actualizare detalii client pentru comandă',
+        [
+            'customer_email' => $existingOrder['customer_email'] ?? null,
+            'shipping_address' => $existingOrder['shipping_address'] ?? null,
+            'address_text' => $existingOrder['address_text'] ?? null,
+            'recipient_county_id' => $existingOrder['recipient_county_id'] ?? null,
+            'recipient_county_name' => $existingOrder['recipient_county_name'] ?? null,
+            'recipient_locality_id' => $existingOrder['recipient_locality_id'] ?? null,
+            'recipient_locality_name' => $existingOrder['recipient_locality_name'] ?? null
+        ],
+        [
+            'customer_email' => $customerEmail !== '' ? $customerEmail : null,
+            'shipping_address' => $shippingAddress !== '' ? $shippingAddress : null,
+            'address_text' => $addressText !== '' ? $addressText : null,
+            'recipient_county_id' => $recipientCountyId,
+            'recipient_county_name' => $recipientCountyName !== '' ? $recipientCountyName : null,
+            'recipient_locality_id' => $recipientLocalityId,
+            'recipient_locality_name' => $recipientLocalityName !== '' ? $recipientLocalityName : null
+        ]
+    );
+
+    echo json_encode([
+        'status' => 'success',
+        'message' => 'Detaliile comenzii au fost actualizate.'
+    ]);
+} catch (Throwable $e) {
+    error_log('update_order_details error: ' . $e->getMessage());
+    http_response_code(500);
+    echo json_encode([
+        'status' => 'error',
+        'message' => 'A apărut o eroare la actualizarea comenzii.'
+    ]);
+}

--- a/orders.php
+++ b/orders.php
@@ -1454,4 +1454,15 @@ $currentPage = basename($_SERVER['SCRIPT_NAME'], '.php');
         </div>
     </div>
     
+    <script>
+        window.orderProductsList = <?= json_encode(array_map(static function ($product) {
+            return [
+                'product_id' => (int)($product['product_id'] ?? 0),
+                'name' => $product['name'] ?? '',
+                'sku' => $product['sku'] ?? '',
+                'price' => isset($product['price']) ? (float)$product['price'] : 0,
+                'unit_of_measure' => $product['unit_of_measure'] ?? ''
+            ];
+        }, $allProducts ?? []), JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>;
+    </script>
     <?php require_once __DIR__ . '/includes/footer.php'; ?>

--- a/scripts/orders.js
+++ b/scripts/orders.js
@@ -18,6 +18,17 @@ const ORDERS_REALTIME_INTERVAL_MS = 5000;
 let ordersRealtimeTimer = null;
 let ordersRealtimeController = null;
 let ordersLatestTimestamp = null;
+let currentOrderDetails = null;
+let currentOrderId = null;
+
+const RECIPIENT_AUTOCOMPLETE_MIN_CHARS = 2;
+const RECIPIENT_AUTOCOMPLETE_DELAY_MS = 250;
+const recipientAutocompleteStates = [];
+let recipientAutocompleteDocumentListenerAttached = false;
+const recipientAutocompleteRegistry = {
+    county: null,
+    locality: null
+};
 
 function normalizeOrderStatus(status) {
     const value = (status ?? '').toString().trim().toLowerCase();
@@ -786,6 +797,8 @@ function closeCancelModal() {
  * @param {number} orderId The ID of the order to display.
  */
 function viewOrderDetails(orderId) {
+    currentOrderId = orderId;
+    currentOrderDetails = null;
     // Create modal if it doesn't exist
     let modal = document.getElementById('orderDetailsModal');
     if (!modal) {
@@ -857,19 +870,185 @@ function createOrderDetailsModal() {
 }
 
 function displayOrderDetails(order) {
-    // Debug: log the order data to see what we're getting
     console.log('Order data for display:', order);
-    
-    // Ensure items is always an array
-    const items = order.items || [];
-    
-    // Generate items table HTML
-    let itemsTableHtml = '';
-    if (items.length > 0) {
-        itemsTableHtml = `
-            <div class="items-section" style="margin-top: 2rem;">
-                <h4>Produse comandate</h4>
-                <table class="order-items-table" style="width: 100%; border-collapse: collapse;">
+
+    currentOrderDetails = order || null;
+    if (order && order.id) {
+        currentOrderId = order.id;
+    }
+
+    const safeOrder = order || {};
+    const items = Array.isArray(safeOrder.items) ? safeOrder.items : [];
+    const countyIdValue = safeOrder.recipient_county_id && Number(safeOrder.recipient_county_id) > 0
+        ? String(safeOrder.recipient_county_id)
+        : '';
+    const localityIdValue = safeOrder.recipient_locality_id && Number(safeOrder.recipient_locality_id) > 0
+        ? String(safeOrder.recipient_locality_id)
+        : '';
+    const countyIdDisplay = countyIdValue !== '' ? escapeHtml(countyIdValue) : '—';
+    const localityIdDisplay = localityIdValue !== '' ? escapeHtml(localityIdValue) : '—';
+
+    let formattedDate = safeOrder.order_date || 'N/A';
+    if (safeOrder.order_date && safeOrder.order_date !== 'N/A') {
+        try {
+            const date = new Date(safeOrder.order_date);
+            formattedDate = `${date.toLocaleDateString('ro-RO')} ${date.toLocaleTimeString('ro-RO', { hour: '2-digit', minute: '2-digit' })}`;
+        } catch (error) {
+            formattedDate = safeOrder.order_date;
+        }
+    }
+
+    const trackingLink = safeOrder.tracking_number
+        ? `https://www.cargus.ro/personal/urmareste-coletul/?tracking_number=${encodeURIComponent(safeOrder.tracking_number)}&Urm%C4%83re%C8%99te=Urm%C4%83re%C8%99te`
+        : null;
+
+    const itemsSectionHtml = renderOrderItemsSection(safeOrder, items);
+    const progressSectionHtml = safeOrder.progress ? `
+        <div class="progress-section" style="margin-top: 2rem;">
+            <h4>Progres comandă</h4>
+            <p><strong>Total articole:</strong> <span id="progress-total-items">${safeOrder.progress.total_items || 0}</span></p>
+            <p><strong>Cantitate comandată:</strong> <span id="progress-total-ordered">${safeOrder.progress.total_quantity_ordered || 0}</span></p>
+            <p><strong>Cantitate ridicată:</strong> <span id="progress-total-picked">${safeOrder.progress.total_quantity_picked || 0}</span></p>
+            <p><strong>Rămas de ridicat:</strong> <span id="progress-total-remaining">${safeOrder.progress.total_remaining || 0}</span></p>
+            <p><strong>Progres:</strong> <span id="progress-percent">${safeOrder.progress.progress_percent || 0}</span>%</p>
+        </div>
+    ` : '';
+
+    const notesSectionHtml = safeOrder.notes ? `
+        <div class="notes-section" style="margin-top: 2rem;">
+            <h4>Observații</h4>
+            <p>${safeOrder.notes}</p>
+        </div>
+    ` : '';
+
+    const content = `
+        <div class="order-details">
+            <div class="details-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 2rem;">
+                <div class="detail-section">
+                    <h4>Informații Comandă</h4>
+                    <p><strong>Număr:</strong> ${escapeHtml(safeOrder.order_number || 'N/A')}</p>
+                    <p><strong>Data:</strong> ${escapeHtml(formattedDate)}</p>
+                    <p><strong>Status:</strong> ${escapeHtml(safeOrder.status_label || safeOrder.status || 'N/A')}</p>
+                    <p><strong>Valoare:</strong> ${formatCurrency(safeOrder.total_value || 0)} RON</p>
+                    ${trackingLink ? `<p><strong>AWB:</strong> <a href="${trackingLink}" target="_blank" rel="noopener noreferrer" class="order-awb-link">${escapeHtml(safeOrder.tracking_number)}</a></p>` : ''}
+                </div>
+                <div class="detail-section">
+                    <h4>Informații Client</h4>
+                    <p><strong>Nume:</strong> ${escapeHtml(safeOrder.customer_name || 'N/A')}</p>
+                    <form id="orderContactForm" class="order-contact-form" style="margin-top: 1rem; display: grid; gap: 0.75rem;">
+                        <div class="form-group" style="display: flex; flex-direction: column; gap: 0.35rem;">
+                            <label for="orderContactEmail" class="form-label">Email</label>
+                            <input type="email" id="orderContactEmail" name="customer_email" class="form-control" value="${escapeHtml(safeOrder.customer_email || '')}" placeholder="client@example.com">
+                        </div>
+                        <div class="form-group" style="display: flex; flex-direction: column; gap: 0.35rem;">
+                            <label for="orderContactAddress" class="form-label">Adresă livrare</label>
+                            <textarea id="orderContactAddress" name="shipping_address" class="form-control" rows="2" placeholder="Introduce adresa completă">${escapeHtml(safeOrder.shipping_address || '')}</textarea>
+                        </div>
+                        <div class="form-group" style="display: flex; flex-direction: column; gap: 0.35rem;">
+                            <label for="orderContactAddressText" class="form-label">Adresă completă (text)</label>
+                            <textarea id="orderContactAddressText" name="address_text" class="form-control" rows="3" placeholder="Textul complet trimis către Cargus">${escapeHtml(safeOrder.address_text || '')}</textarea>
+                        </div>
+                        <div class="form-group" style="display: flex; flex-direction: column; gap: 0.35rem;">
+                            <label for="orderRecipientCountyName" class="form-label">Recipient County Name</label>
+                            <div class="recipient-autocomplete" data-autocomplete-wrapper style="position: relative;">
+                                <input type="text" id="orderRecipientCountyName" name="recipient_county_name" class="form-control" value="${escapeHtml(safeOrder.recipient_county_name || '')}" placeholder="Introduce județul" autocomplete="off" data-autocomplete-type="county">
+                                <input type="hidden" id="orderRecipientCountyId" name="recipient_county_id" value="${escapeHtml(countyIdValue)}">
+                                <div class="autocomplete-results" data-autocomplete-results="orderRecipientCountyName" style="position: absolute; top: calc(100% + 2px); left: 0; right: 0; background: #fff; border: 1px solid #ced4da; border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.08); z-index: 1050; display: none; max-height: 240px; overflow-y: auto;"></div>
+                            </div>
+                            <small style="color: #6c757d;">Cargus County ID: <span id="orderRecipientCountyIdDisplay">${countyIdDisplay}</span></small>
+                        </div>
+                        <div class="form-group" style="display: flex; flex-direction: column; gap: 0.35rem;">
+                            <label for="orderRecipientLocalityName" class="form-label">Recipient Locality Name</label>
+                            <div class="recipient-autocomplete" data-autocomplete-wrapper style="position: relative;">
+                                <input type="text" id="orderRecipientLocalityName" name="recipient_locality_name" class="form-control" value="${escapeHtml(safeOrder.recipient_locality_name || '')}" placeholder="Introduce localitatea" autocomplete="off" data-autocomplete-type="locality" data-associated-county-input="orderRecipientCountyId">
+                                <input type="hidden" id="orderRecipientLocalityId" name="recipient_locality_id" value="${escapeHtml(localityIdValue)}">
+                                <div class="autocomplete-results" data-autocomplete-results="orderRecipientLocalityName" style="position: absolute; top: calc(100% + 2px); left: 0; right: 0; background: #fff; border: 1px solid #ced4da; border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.08); z-index: 1050; display: none; max-height: 240px; overflow-y: auto;"></div>
+                            </div>
+                            <small style="color: #6c757d;">Cargus Locality ID: <span id="orderRecipientLocalityIdDisplay">${localityIdDisplay}</span></small>
+                        </div>
+                        <div class="form-actions" style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                            <button type="submit" class="btn btn-primary">Salvează detalii</button>
+                            <button type="button" class="btn btn-light" onclick="refreshOrderDetails(${safeOrder.id || 0}, { silent: true, showLoading: true })">Reîncarcă</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            ${progressSectionHtml}
+            ${itemsSectionHtml}
+            ${notesSectionHtml}
+        </div>
+    `;
+
+    const container = document.getElementById('orderDetailsContent');
+    if (container) {
+        container.innerHTML = content;
+    }
+
+    bindOrderDetailsEvents(safeOrder);
+    applyOrderItemsState(items);
+    if (safeOrder.id) {
+        startOrderPolling(safeOrder.id);
+    }
+}
+
+function renderOrderItemsSection(order, items) {
+    const productOptions = buildProductOptions();
+    let rowsHtml = '';
+
+    if (Array.isArray(items) && items.length) {
+        rowsHtml = items.map(item => {
+            const quantityOrdered = Number(item.quantity_ordered != null ? item.quantity_ordered : item.quantity) || 0;
+            const pickedQuantity = Number(item.picked_quantity) || 0;
+            const unitPrice = Number(item.unit_price) || 0;
+            const totalValue = quantityOrdered * unitPrice;
+            const productName = escapeHtml(item.product_name || 'Produs necunoscut');
+            const sku = escapeHtml(item.sku || '-');
+            const location = item.location_code
+                ? `<div class="order-item-location" style="color: #6c757d; font-size: 0.85rem; margin-top: 0.25rem;">Locație: ${escapeHtml(item.location_code)}</div>`
+                : '';
+
+            return `
+                <tr class="order-item-row${item.is_complete ? ' item-complete' : ''}" data-order-item-id="${item.order_item_id}" data-quantity-ordered="${quantityOrdered}">
+                    <td style="padding: 8px; border: 1px solid #ddd;">${productName}${location}</td>
+                    <td style="padding: 8px; border: 1px solid #ddd;">${sku}</td>
+                    <td style="padding: 8px; border: 1px solid #ddd;">${quantityOrdered}</td>
+                    <td class="picked-quantity-cell" style="padding: 8px; border: 1px solid #ddd;">
+                        <span class="picked-quantity-value">${pickedQuantity}</span>
+                    </td>
+                    <td style="padding: 8px; border: 1px solid #ddd;">${formatCurrency(unitPrice)} RON</td>
+                    <td style="padding: 8px; border: 1px solid #ddd;">${formatCurrency(totalValue)} RON</td>
+                    <td style="padding: 8px; border: 1px solid #ddd; width: 140px;">
+                        <div class="btn-group btn-group-sm">
+                            <button type="button" class="btn btn-sm btn-outline-secondary" data-action="edit-item" data-item-id="${item.order_item_id}" title="Modifică produs">
+                                <span class="material-symbols-outlined">edit</span>
+                            </button>
+                            <button type="button" class="btn btn-sm btn-outline-danger" data-action="delete-item" data-item-id="${item.order_item_id}" title="Șterge produs">
+                                <span class="material-symbols-outlined">delete</span>
+                            </button>
+                        </div>
+                    </td>
+                </tr>
+            `;
+        }).join('');
+    } else {
+        rowsHtml = `
+            <tr class="order-items-empty">
+                <td colspan="7" style="text-align: center; padding: 1rem; color: #666;">Nu există produse în această comandă.</td>
+            </tr>
+        `;
+    }
+
+    return `
+        <div class="items-section" style="margin-top: 2rem;">
+            <div class="items-header" style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem;">
+                <h4 style="margin: 0;">Produse comandate</h4>
+                <button type="button" class="btn btn-sm btn-outline-primary" onclick="resetOrderItemForm()" title="Adaugă produs nou">
+                    <span class="material-symbols-outlined">add</span> Produs nou
+                </button>
+            </div>
+            <div class="table-responsive" style="margin-top: 1rem; overflow-x: auto;">
+                <table class="order-items-table" style="width: 100%; border-collapse: collapse; min-width: 760px;">
                     <thead>
                         <tr style="background-color: #f5f5f5;">
                             <th style="padding: 8px; border: 1px solid #ddd;">Produs</th>
@@ -878,96 +1057,924 @@ function displayOrderDetails(order) {
                             <th style="padding: 8px; border: 1px solid #ddd;">Cantitate ridicată</th>
                             <th style="padding: 8px; border: 1px solid #ddd;">Preț unitar</th>
                             <th style="padding: 8px; border: 1px solid #ddd;">Total</th>
+                            <th style="padding: 8px; border: 1px solid #ddd; width: 140px;">Acțiuni</th>
                         </tr>
                     </thead>
                     <tbody>
-                        ${items.map(item => `
-                            <tr class="order-item-row${item.is_complete ? ' item-complete' : ''}" data-order-item-id="${item.order_item_id}" data-quantity-ordered="${item.quantity_ordered || item.quantity || 0}">
-                                <td style="padding: 8px; border: 1px solid #ddd;">${item.product_name || 'Produs necunoscut'}</td>
-                                <td style="padding: 8px; border: 1px solid #ddd;">${item.sku || '-'}</td>
-                                <td style="padding: 8px; border: 1px solid #ddd;">${item.quantity_ordered || item.quantity || '0'}</td>
-                                <td class="picked-quantity-cell" style="padding: 8px; border: 1px solid #ddd;">
-                                    <span class="picked-quantity-value">${item.picked_quantity || '0'}</span>
-                                </td>
-                                <td style="padding: 8px; border: 1px solid #ddd;">${parseFloat(item.unit_price || 0).toFixed(2)} RON</td>
-                                <td style="padding: 8px; border: 1px solid #ddd;">${(parseFloat(item.quantity_ordered || item.quantity || 0) * parseFloat(item.unit_price || 0)).toFixed(2)} RON</td>
-                            </tr>
-                        `).join('')}
+                        ${rowsHtml}
                     </tbody>
                 </table>
             </div>
-        `;
-    } else {
-        itemsTableHtml = `
-            <div class="items-section" style="margin-top: 2rem;">
-                <h4>Produse comandate</h4>
-                <p style="color: #666; font-style: italic;">Nu au fost găsite produse pentru această comandă.</p>
+            <div class="order-item-form-wrapper" style="margin-top: 1.5rem; border: 1px solid #eee; border-radius: 8px; padding: 1rem;">
+                <h5 id="orderItemFormTitle" data-default-title="Adaugă produs" style="margin: 0 0 1rem;">Adaugă produs</h5>
+                <form id="orderItemForm" data-mode="add">
+                    <input type="hidden" name="order_item_id" value="">
+                    <div class="row" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem;">
+                        <div class="form-group" style="display: flex; flex-direction: column; gap: 0.35rem;">
+                            <label class="form-label" for="orderItemProduct">Produs</label>
+                            <select id="orderItemProduct" name="product_id" class="form-control" required>
+                                ${productOptions}
+                            </select>
+                        </div>
+                        <div class="form-group" style="display: flex; flex-direction: column; gap: 0.35rem;">
+                            <label class="form-label" for="orderItemQuantity">Cantitate</label>
+                            <input type="number" id="orderItemQuantity" name="quantity" class="form-control" min="1" step="1" value="1" required>
+                        </div>
+                        <div class="form-group" style="display: flex; flex-direction: column; gap: 0.35rem;">
+                            <label class="form-label" for="orderItemPrice">Preț unitar (RON)</label>
+                            <input type="number" id="orderItemPrice" name="unit_price" class="form-control" min="0" step="0.01" placeholder="Auto">
+                        </div>
+                    </div>
+                    <div class="form-actions" style="margin-top: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                        <button type="submit" class="btn btn-primary" id="orderItemFormSubmit" data-default-label="Adaugă produs">Adaugă produs</button>
+                        <button type="button" class="btn btn-secondary" id="orderItemFormReset" onclick="resetOrderItemForm()">Resetează</button>
+                    </div>
+                </form>
             </div>
-        `;
-    }
-    
-    // Format the date nicely
-    let formattedDate = order.order_date || 'N/A';
-    if (order.order_date && order.order_date !== 'N/A') {
-        try {
-            const date = new Date(order.order_date);
-            formattedDate = date.toLocaleDateString('ro-RO') + ' ' + date.toLocaleTimeString('ro-RO', {hour: '2-digit', minute: '2-digit'});
-        } catch (e) {
-            formattedDate = order.order_date;
-        }
-    }
-    
-    const trackingLink = order.tracking_number
-        ? `https://www.cargus.ro/personal/urmareste-coletul/?tracking_number=${encodeURIComponent(order.tracking_number)}&Urm%C4%83re%C8%99te=Urm%C4%83re%C8%99te`
-        : null;
-
-    const content = `
-        <div class="order-details">
-            <div class="details-grid" style="display: grid; grid-template-columns: 1fr 1fr; gap: 2rem;">
-                <div class="detail-section">
-                    <h4>Informații Comandă</h4>
-                    <p><strong>Număr:</strong> ${order.order_number || 'N/A'}</p>
-                    <p><strong>Data:</strong> ${formattedDate}</p>
-                    <p><strong>Status:</strong> ${order.status_label || order.status || 'N/A'}</p>
-                    <p><strong>Valoare:</strong> ${parseFloat(order.total_value || 0).toFixed(2)} RON</p>
-                    ${order.tracking_number ? `<p><strong>AWB:</strong> <a href="${trackingLink}" target="_blank" rel="noopener noreferrer" class="order-awb-link">${order.tracking_number}</a></p>` : ''}
-                </div>
-                <div class="detail-section">
-                    <h4>Informații Client</h4>
-                    <p><strong>Nume:</strong> ${order.customer_name || 'N/A'}</p>
-                    <p><strong>Email:</strong> ${order.customer_email || 'N/A'}</p>
-                    <p><strong>Adresă:</strong> ${order.shipping_address || 'Nu este specificată'}</p>
-                </div>
-            </div>
-
-            ${order.progress ? `
-                <div class="progress-section" style="margin-top: 2rem;">
-                    <h4>Progres comandă</h4>
-                    <p><strong>Total articole:</strong> <span id="progress-total-items">${order.progress.total_items || 0}</span></p>
-                    <p><strong>Cantitate comandată:</strong> <span id="progress-total-ordered">${order.progress.total_quantity_ordered || 0}</span></p>
-                    <p><strong>Cantitate ridicată:</strong> <span id="progress-total-picked">${order.progress.total_quantity_picked || 0}</span></p>
-                    <p><strong>Rămas de ridicat:</strong> <span id="progress-total-remaining">${order.progress.total_remaining || 0}</span></p>
-                    <p><strong>Progres:</strong> <span id="progress-percent">${order.progress.progress_percent || 0}</span>%</p>
-                </div>
-            ` : ''}
-
-            ${itemsTableHtml}
-
-            ${order.notes ? `
-                <div class="notes-section" style="margin-top: 2rem;">
-                    <h4>Observații</h4>
-                    <p>${order.notes}</p>
-                </div>
-            ` : ''}
         </div>
     `;
+}
 
-    document.getElementById('orderDetailsContent').innerHTML = content;
+function buildProductOptions(selectedId) {
+    const products = Array.isArray(window.orderProductsList) ? window.orderProductsList : [];
+    const selectedValue = Number(selectedId);
+    const options = ['<option value="">Selectează produs</option>'];
 
-    applyOrderItemsState(items);
-    if (order.id) {
-        startOrderPolling(order.id);
+    products.forEach(product => {
+        const productId = Number(product.product_id);
+        if (!productId) {
+            return;
+        }
+
+        const isSelected = productId === selectedValue ? ' selected' : '';
+        const numericPrice = Number(product.price);
+        const priceAttr = Number.isFinite(numericPrice) ? ` data-price="${numericPrice}"` : '';
+        const unit = product.unit_of_measure ? ` data-unit="${escapeHtml(product.unit_of_measure)}"` : '';
+        const sku = product.sku ? ` (${product.sku})` : '';
+        const label = `${product.name || `Produs #${productId}`}${sku}`;
+
+        options.push(`<option value="${productId}"${isSelected}${priceAttr}${unit}>${escapeHtml(label)}</option>`);
+    });
+
+    return options.join('');
+}
+
+function bindOrderDetailsEvents(order) {
+    const contactForm = document.getElementById('orderContactForm');
+    if (contactForm) {
+        contactForm.addEventListener('submit', submitOrderContactForm);
     }
+
+    initRecipientAutocomplete(order || {});
+
+    const orderItemForm = document.getElementById('orderItemForm');
+    if (orderItemForm) {
+        orderItemForm.addEventListener('submit', submitOrderItemForm);
+
+        const productSelect = orderItemForm.querySelector('select[name="product_id"]');
+        const priceInput = orderItemForm.querySelector('input[name="unit_price"]');
+        if (productSelect && priceInput) {
+            productSelect.addEventListener('change', () => {
+                const isEditMode = (orderItemForm.dataset.mode || 'add') === 'edit';
+                updateOrderItemPriceFromProduct(productSelect, priceInput, isEditMode);
+            });
+        }
+
+        if (priceInput) {
+            priceInput.addEventListener('input', () => {
+                priceInput.dataset.userEdited = '1';
+            });
+        }
+    }
+
+    const itemsTable = document.querySelector('#orderDetailsContent table.order-items-table');
+    if (itemsTable) {
+        itemsTable.addEventListener('click', event => {
+            const editButton = event.target.closest('[data-action="edit-item"]');
+            if (editButton) {
+                event.preventDefault();
+                const itemId = parseInt(editButton.getAttribute('data-item-id'), 10);
+                prefillOrderItemForm(itemId);
+                return;
+            }
+
+            const deleteButton = event.target.closest('[data-action="delete-item"]');
+            if (deleteButton) {
+                event.preventDefault();
+                const itemId = parseInt(deleteButton.getAttribute('data-item-id'), 10);
+                deleteOrderItem(deleteButton, itemId);
+            }
+        });
+    }
+
+    resetOrderItemForm(true);
+}
+
+function initRecipientAutocomplete(order) {
+    recipientAutocompleteStates.length = 0;
+    recipientAutocompleteRegistry.county = null;
+    recipientAutocompleteRegistry.locality = null;
+
+    const countyState = createRecipientAutocompleteState({
+        type: 'county',
+        inputId: 'orderRecipientCountyName',
+        idInputId: 'orderRecipientCountyId',
+        idDisplayId: 'orderRecipientCountyIdDisplay'
+    });
+
+    if (countyState) {
+        recipientAutocompleteRegistry.county = countyState;
+        recipientAutocompleteStates.push(countyState);
+    }
+
+    const localityState = createRecipientAutocompleteState({
+        type: 'locality',
+        inputId: 'orderRecipientLocalityName',
+        idInputId: 'orderRecipientLocalityId',
+        idDisplayId: 'orderRecipientLocalityIdDisplay'
+    });
+
+    if (localityState) {
+        recipientAutocompleteRegistry.locality = localityState;
+        recipientAutocompleteStates.push(localityState);
+
+        const initialCountyId = order && order.recipient_county_id ? String(order.recipient_county_id) : '';
+        localityState.input.dataset.selectedCountyId = initialCountyId;
+        localityState.idInput.dataset.countyId = initialCountyId;
+        localityState.idInput.dataset.previousCountyId = initialCountyId;
+
+        if (order && order.recipient_locality_id) {
+            localityState.lastSelectedLabel = localityState.input.value.trim();
+        }
+    }
+
+    if (countyState && order && order.recipient_county_id) {
+        countyState.lastSelectedLabel = countyState.input.value.trim();
+    }
+
+    if (!recipientAutocompleteDocumentListenerAttached) {
+        document.addEventListener('click', event => {
+            recipientAutocompleteStates.forEach(state => {
+                if (!state.wrapper || state.wrapper.contains(event.target)) {
+                    return;
+                }
+                hideRecipientSuggestions(state);
+            });
+        });
+        recipientAutocompleteDocumentListenerAttached = true;
+    }
+}
+
+function createRecipientAutocompleteState(config) {
+    const input = document.getElementById(config.inputId);
+    const idInput = document.getElementById(config.idInputId);
+    const idDisplay = document.getElementById(config.idDisplayId);
+    const suggestionsEl = document.querySelector(`.autocomplete-results[data-autocomplete-results="${config.inputId}"]`);
+
+    if (!input || !idInput || !idDisplay || !suggestionsEl) {
+        return null;
+    }
+
+    const wrapper = input.closest('[data-autocomplete-wrapper]') || input.parentElement;
+
+    const state = {
+        type: config.type,
+        input,
+        idInput,
+        idDisplay,
+        suggestionsEl,
+        wrapper,
+        timer: null,
+        controller: null,
+        lastSelectedLabel: input.value.trim(),
+        isApplyingSelection: false,
+        pendingQuery: null
+    };
+
+    input.addEventListener('input', () => handleRecipientAutocompleteInput(state));
+    input.addEventListener('focus', () => {
+        if (state.input.value.trim().length >= RECIPIENT_AUTOCOMPLETE_MIN_CHARS) {
+            handleRecipientAutocompleteInput(state, { immediate: true });
+        }
+    });
+    input.addEventListener('keydown', event => {
+        if (event.key === 'Escape') {
+            hideRecipientSuggestions(state);
+        }
+    });
+
+    suggestionsEl.addEventListener('mousedown', event => {
+        event.preventDefault();
+    });
+
+    suggestionsEl.addEventListener('click', event => {
+        const option = event.target.closest('.autocomplete-option');
+        if (!option) {
+            return;
+        }
+        applyRecipientSelection(state, option.dataset);
+    });
+
+    return state;
+}
+
+function handleRecipientAutocompleteInput(state, options) {
+    if (!state || !state.input) {
+        return;
+    }
+
+    const immediate = Boolean(options && options.immediate);
+    const value = state.input.value.trim();
+
+    if (!state.isApplyingSelection && value !== state.lastSelectedLabel) {
+        setRecipientFieldId(state, '');
+        state.lastSelectedLabel = '';
+
+        if (state.type === 'county') {
+            handleCountyChanged('', '', { skipClear: false });
+        } else if (state.type === 'locality') {
+            state.idInput.dataset.countyId = state.idInput.dataset.countyId || '';
+        }
+    }
+
+    if (state.timer) {
+        clearTimeout(state.timer);
+        state.timer = null;
+    }
+
+    if (!immediate && value.length < RECIPIENT_AUTOCOMPLETE_MIN_CHARS) {
+        hideRecipientSuggestions(state);
+        state.pendingQuery = null;
+        return;
+    }
+
+    if (immediate && value.length < RECIPIENT_AUTOCOMPLETE_MIN_CHARS) {
+        hideRecipientSuggestions(state);
+        state.pendingQuery = null;
+        return;
+    }
+
+    const fetchSuggestions = () => {
+        state.pendingQuery = value;
+        fetchRecipientSuggestions(state, value);
+    };
+
+    if (immediate) {
+        fetchSuggestions();
+    } else {
+        state.timer = setTimeout(fetchSuggestions, RECIPIENT_AUTOCOMPLETE_DELAY_MS);
+    }
+}
+
+function fetchRecipientSuggestions(state, query) {
+    if (!state || !query) {
+        return;
+    }
+
+    if (state.controller) {
+        state.controller.abort();
+    }
+
+    const params = new URLSearchParams();
+    params.set('type', state.type);
+    params.set('query', query);
+
+    if (state.type === 'locality') {
+        const associated = state.input.dataset.selectedCountyId || state.idInput.dataset.countyId || '';
+        let countyId = associated;
+        if (!countyId && recipientAutocompleteRegistry.county && recipientAutocompleteRegistry.county.idInput.value) {
+            countyId = recipientAutocompleteRegistry.county.idInput.value;
+        }
+        if (countyId) {
+            params.set('county_id', countyId);
+        }
+    }
+
+    state.controller = new AbortController();
+
+    fetch(`api/warehouse/search_location_mappings.php?${params.toString()}`, {
+        signal: state.controller.signal,
+        credentials: 'same-origin'
+    })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(data => {
+            if (!data || data.status !== 'success' || !Array.isArray(data.data)) {
+                throw new Error('Răspuns invalid de la server.');
+            }
+
+            if (state.pendingQuery !== query) {
+                return;
+            }
+
+            renderRecipientSuggestions(state, data.data);
+        })
+        .catch(error => {
+            if (error.name === 'AbortError') {
+                return;
+            }
+            console.error('Autocomplete recipient search failed:', error);
+        })
+        .finally(() => {
+            state.controller = null;
+        });
+}
+
+function renderRecipientSuggestions(state, results) {
+    if (!state || !state.suggestionsEl) {
+        return;
+    }
+
+    if (!Array.isArray(results) || !results.length) {
+        hideRecipientSuggestions(state);
+        return;
+    }
+
+    const optionsHtml = results
+        .map(result => {
+            if (state.type === 'county') {
+                return buildCountySuggestionOption(result);
+            }
+            return buildLocalitySuggestionOption(result);
+        })
+        .filter(Boolean)
+        .join('');
+
+    if (!optionsHtml) {
+        hideRecipientSuggestions(state);
+        return;
+    }
+
+    state.suggestionsEl.innerHTML = optionsHtml;
+    state.suggestionsEl.style.display = 'block';
+    const options = state.suggestionsEl.querySelectorAll('.autocomplete-option');
+    if (options.length) {
+        options[options.length - 1].style.borderBottom = 'none';
+    }
+}
+
+function hideRecipientSuggestions(state) {
+    if (!state || !state.suggestionsEl) {
+        return;
+    }
+    state.suggestionsEl.innerHTML = '';
+    state.suggestionsEl.style.display = 'none';
+    state.pendingQuery = null;
+}
+
+function setRecipientFieldId(state, value) {
+    if (!state || !state.idInput || !state.idDisplay) {
+        return;
+    }
+    const normalized = value != null && value !== '' ? String(value) : '';
+    state.idInput.value = normalized;
+    state.idDisplay.textContent = normalized !== '' ? normalized : '—';
+}
+
+function applyRecipientSelection(state, dataset) {
+    if (!state || !dataset) {
+        return;
+    }
+
+    const label = (dataset.value || '').trim();
+    state.isApplyingSelection = true;
+    state.input.value = label;
+    state.lastSelectedLabel = label;
+
+    if (state.type === 'county') {
+        const countyId = dataset.id || dataset.countyId || '';
+        setRecipientFieldId(state, countyId);
+        handleCountyChanged(countyId, dataset.countyName || label, { skipClear: false });
+    } else {
+        const localityId = dataset.id || dataset.localityId || '';
+        const countyId = dataset.countyId || '';
+        setRecipientFieldId(state, localityId);
+        state.idInput.dataset.countyId = countyId;
+        state.input.dataset.selectedCountyId = countyId;
+        handleCountyChanged(countyId, dataset.countyName || '', { skipClear: true });
+        applyCountyFromLocality(dataset);
+    }
+
+    hideRecipientSuggestions(state);
+    state.isApplyingSelection = false;
+}
+
+function handleCountyChanged(newCountyId, newCountyName, options) {
+    const localityState = recipientAutocompleteRegistry.locality;
+    if (!localityState) {
+        return;
+    }
+
+    const normalizedId = newCountyId != null && newCountyId !== '' ? String(newCountyId) : '';
+    const previousCountyId = localityState.idInput.dataset.previousCountyId || '';
+    localityState.input.dataset.selectedCountyId = normalizedId;
+    localityState.idInput.dataset.countyId = normalizedId;
+
+    if (options && options.skipClear) {
+        localityState.idInput.dataset.previousCountyId = normalizedId;
+        return;
+    }
+
+    if (normalizedId === '') {
+        if (localityState.input.value || localityState.idInput.value) {
+            clearRecipientLocalitySelection(localityState);
+        }
+        localityState.idInput.dataset.previousCountyId = '';
+        return;
+    }
+
+    if (previousCountyId && previousCountyId !== normalizedId) {
+        clearRecipientLocalitySelection(localityState);
+    }
+
+    localityState.idInput.dataset.previousCountyId = normalizedId;
+    if (newCountyName && recipientAutocompleteRegistry.county && recipientAutocompleteRegistry.county.input) {
+        recipientAutocompleteRegistry.county.input.dataset.lastKnownCountyName = newCountyName;
+    }
+}
+
+function clearRecipientLocalitySelection(state) {
+    if (!state) {
+        return;
+    }
+    state.input.value = '';
+    state.lastSelectedLabel = '';
+    setRecipientFieldId(state, '');
+    state.idInput.dataset.countyId = '';
+    state.idInput.dataset.previousCountyId = '';
+    state.input.dataset.selectedCountyId = '';
+}
+
+function applyCountyFromLocality(dataset) {
+    const countyState = recipientAutocompleteRegistry.county;
+    if (!countyState) {
+        return;
+    }
+
+    const countyId = dataset.countyId || '';
+    if (!countyId) {
+        return;
+    }
+
+    const currentCountyId = countyState.idInput.value;
+    if (currentCountyId === String(countyId)) {
+        handleCountyChanged(countyId, dataset.countyName || countyState.input.value || '', { skipClear: true });
+        return;
+    }
+
+    countyState.isApplyingSelection = true;
+    const countyName = dataset.countyName || countyState.input.dataset.lastKnownCountyName || countyState.input.value || '';
+    if (countyName) {
+        countyState.input.value = countyName;
+        countyState.lastSelectedLabel = countyName.trim();
+    }
+    setRecipientFieldId(countyState, countyId);
+    hideRecipientSuggestions(countyState);
+    countyState.isApplyingSelection = false;
+    handleCountyChanged(countyId, countyName, { skipClear: true });
+}
+
+function buildCountySuggestionOption(result) {
+    if (!result) {
+        return '';
+    }
+    const countyId = Number(result.cargus_county_id);
+    const displayName = (result.cargus_county_name || result.county_name || '').trim();
+    if (!countyId || !displayName) {
+        return '';
+    }
+
+    const secondaryName = result.county_name && result.county_name !== displayName
+        ? `<div style="font-size: 0.78rem; color: #6c757d;">Mapare: ${escapeHtml(result.county_name)}</div>`
+        : '';
+
+    return `
+        <div class="autocomplete-option" role="button" tabindex="-1"
+            data-type="county"
+            data-id="${escapeHtml(String(countyId))}"
+            data-value="${escapeHtml(displayName)}"
+            data-county-id="${escapeHtml(String(countyId))}"
+            data-county-name="${escapeHtml(displayName)}"
+            style="padding: 0.45rem 0.75rem; cursor: pointer; border-bottom: 1px solid #f1f3f5;">
+            <div style="display: flex; justify-content: space-between; align-items: center; gap: 0.5rem;">
+                <span>${escapeHtml(displayName)}</span>
+                <span style="color: #0d6efd; font-weight: 600;">${escapeHtml(String(countyId))}</span>
+            </div>
+            ${secondaryName}
+        </div>
+    `;
+}
+
+function buildLocalitySuggestionOption(result) {
+    if (!result) {
+        return '';
+    }
+    const localityId = Number(result.cargus_locality_id);
+    const localityName = (result.cargus_locality_name || result.locality_name || '').trim();
+    if (!localityId || !localityName) {
+        return '';
+    }
+
+    const countyId = result.cargus_county_id ? String(result.cargus_county_id) : '';
+    const countyName = (result.cargus_county_name || result.county_name || '').trim();
+
+    const countyInfo = countyName
+        ? `<div style="font-size: 0.78rem; color: #6c757d;">Județ: ${escapeHtml(countyName)}</div>`
+        : '';
+
+    return `
+        <div class="autocomplete-option" role="button" tabindex="-1"
+            data-type="locality"
+            data-id="${escapeHtml(String(localityId))}"
+            data-value="${escapeHtml(localityName)}"
+            data-county-id="${escapeHtml(countyId)}"
+            data-county-name="${escapeHtml(countyName)}"
+            style="padding: 0.45rem 0.75rem; cursor: pointer; border-bottom: 1px solid #f1f3f5;">
+            <div style="display: flex; justify-content: space-between; align-items: center; gap: 0.5rem;">
+                <span>${escapeHtml(localityName)}</span>
+                <span style="color: #0d6efd; font-weight: 600;">${escapeHtml(String(localityId))}</span>
+            </div>
+            ${countyInfo}
+        </div>
+    `;
+}
+
+function refreshOrderDetails(orderId, options) {
+    const opts = options || {};
+    const resolvedId = Number(orderId || currentOrderId || 0);
+
+    if (!resolvedId) {
+        return Promise.resolve();
+    }
+
+    if (opts.showLoading) {
+        const container = document.getElementById('orderDetailsContent');
+        if (container) {
+            container.innerHTML = '<div class="loading" style="text-align: center; padding: 2rem; color: #666;">Se reîncarcă detaliile comenzii...</div>';
+        }
+    }
+
+    return fetch(`api/warehouse/order_details.php?id=${resolvedId}`)
+        .then(parseJsonResponse)
+        .then(data => {
+            if (data && data.data) {
+                displayOrderDetails(data.data);
+                if (opts.toast && opts.toast.message) {
+                    showOrdersToast(opts.toast.type || 'success', opts.toast.message);
+                }
+            }
+            return data;
+        })
+        .catch(error => {
+            console.error('refreshOrderDetails error:', error);
+            if (!opts.silent) {
+                showOrdersToast('warning', error.message || 'Nu s-au putut reîncărca detaliile comenzii.');
+            }
+            throw error;
+        });
+}
+
+function submitOrderContactForm(event) {
+    event.preventDefault();
+
+    if (!currentOrderDetails || !currentOrderDetails.id) {
+        return;
+    }
+
+    const form = event.target;
+    const submitButton = form.querySelector('button[type="submit"]');
+    if (submitButton) {
+        submitButton.disabled = true;
+    }
+
+    const parseIdField = value => {
+        const trimmed = String(value ?? '').trim();
+        if (!trimmed) {
+            return null;
+        }
+        const numeric = Number(trimmed);
+        return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+    };
+
+    const payload = {
+        order_id: currentOrderDetails.id,
+        customer_email: form.customer_email ? form.customer_email.value.trim() : '',
+        shipping_address: form.shipping_address ? form.shipping_address.value.trim() : '',
+        address_text: form.address_text ? form.address_text.value.trim() : '',
+        recipient_county_name: form.recipient_county_name ? form.recipient_county_name.value.trim() : '',
+        recipient_county_id: parseIdField(form.recipient_county_id ? form.recipient_county_id.value : null),
+        recipient_locality_name: form.recipient_locality_name ? form.recipient_locality_name.value.trim() : '',
+        recipient_locality_id: parseIdField(form.recipient_locality_id ? form.recipient_locality_id.value : null)
+    };
+
+    fetch('api/warehouse/update_order_details.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify(payload)
+    })
+        .then(parseJsonResponse)
+        .then(response => {
+            const message = response.message || 'Detaliile comenzii au fost actualizate.';
+            return refreshOrderDetails(currentOrderDetails.id, {
+                toast: {
+                    type: 'success',
+                    message
+                }
+            });
+        })
+        .catch(error => {
+            console.error('submitOrderContactForm error:', error);
+            showOrdersToast('warning', error.message || 'Actualizarea detaliilor a eșuat.');
+        })
+        .finally(() => {
+            if (submitButton) {
+                submitButton.disabled = false;
+            }
+        });
+}
+
+function submitOrderItemForm(event) {
+    event.preventDefault();
+
+    if (!currentOrderDetails || !currentOrderDetails.id) {
+        return;
+    }
+
+    const form = event.target;
+    const mode = (form.dataset.mode || 'add') === 'edit' ? 'update' : 'create';
+    const productSelect = form.querySelector('select[name="product_id"]');
+    const quantityInput = form.querySelector('input[name="quantity"]');
+    const priceInput = form.querySelector('input[name="unit_price"]');
+    const submitButton = form.querySelector('button[type="submit"]');
+
+    const productId = productSelect ? parseInt(productSelect.value, 10) : 0;
+    const quantity = quantityInput ? parseInt(quantityInput.value, 10) : 0;
+    const unitPriceRaw = priceInput ? priceInput.value.trim() : '';
+
+    if (!productId) {
+        showOrdersToast('warning', 'Selectează un produs înainte de a salva.');
+        return;
+    }
+
+    if (!quantity || quantity <= 0) {
+        showOrdersToast('warning', 'Cantitatea trebuie să fie mai mare decât zero.');
+        return;
+    }
+
+    if (submitButton) {
+        submitButton.disabled = true;
+    }
+
+    const payload = {
+        action: mode,
+        order_id: currentOrderDetails.id,
+        product_id: productId,
+        quantity: quantity
+    };
+
+    if (mode === 'update') {
+        const itemId = form.dataset.itemId ? parseInt(form.dataset.itemId, 10) : 0;
+        if (itemId) {
+            payload.order_item_id = itemId;
+        }
+    }
+
+    if (unitPriceRaw !== '') {
+        payload.unit_price = unitPriceRaw;
+    }
+
+    fetch('api/warehouse/manage_order_item.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify(payload)
+    })
+        .then(parseJsonResponse)
+        .then(response => {
+            const message = response.message || 'Comanda a fost actualizată.';
+            resetOrderItemForm(true);
+            return refreshOrderDetails(currentOrderDetails.id, {
+                toast: {
+                    type: 'success',
+                    message
+                }
+            });
+        })
+        .catch(error => {
+            console.error('submitOrderItemForm error:', error);
+            showOrdersToast('warning', error.message || 'Actualizarea produsului a eșuat.');
+        })
+        .finally(() => {
+            if (submitButton) {
+                submitButton.disabled = false;
+            }
+        });
+}
+
+function resetOrderItemForm(skipFocus) {
+    const form = document.getElementById('orderItemForm');
+    if (!form) {
+        return;
+    }
+
+    form.dataset.mode = 'add';
+    form.dataset.itemId = '';
+
+    const hiddenInput = form.querySelector('input[name="order_item_id"]');
+    if (hiddenInput) {
+        hiddenInput.value = '';
+    }
+
+    const productSelect = form.querySelector('select[name="product_id"]');
+    if (productSelect) {
+        productSelect.value = '';
+    }
+
+    const quantityInput = form.querySelector('input[name="quantity"]');
+    if (quantityInput) {
+        quantityInput.value = 1;
+    }
+
+    const priceInput = form.querySelector('input[name="unit_price"]');
+    if (priceInput) {
+        priceInput.value = '';
+        priceInput.dataset.userEdited = '0';
+    }
+
+    const title = document.getElementById('orderItemFormTitle');
+    if (title) {
+        title.textContent = title.dataset.defaultTitle || 'Adaugă produs';
+    }
+
+    const submitButton = document.getElementById('orderItemFormSubmit');
+    if (submitButton) {
+        submitButton.textContent = submitButton.dataset.defaultLabel || 'Adaugă produs';
+    }
+
+    const resetButton = document.getElementById('orderItemFormReset');
+    if (resetButton) {
+        resetButton.textContent = 'Resetează';
+    }
+
+    if (!skipFocus && productSelect) {
+        productSelect.focus();
+    }
+}
+
+function prefillOrderItemForm(itemId) {
+    const form = document.getElementById('orderItemForm');
+    if (!form) {
+        return;
+    }
+
+    const item = getOrderItemById(itemId);
+    if (!item) {
+        showOrdersToast('warning', 'Produsul selectat nu a fost găsit în această comandă.');
+        return;
+    }
+
+    form.dataset.mode = 'edit';
+    form.dataset.itemId = String(itemId);
+
+    const hiddenInput = form.querySelector('input[name="order_item_id"]');
+    if (hiddenInput) {
+        hiddenInput.value = itemId;
+    }
+
+    const productSelect = form.querySelector('select[name="product_id"]');
+    if (productSelect) {
+        productSelect.value = item.product_id;
+    }
+
+    const quantityInput = form.querySelector('input[name="quantity"]');
+    if (quantityInput) {
+        const quantityValue = Number(item.quantity_ordered != null ? item.quantity_ordered : item.quantity) || 1;
+        quantityInput.value = quantityValue;
+    }
+
+    const priceInput = form.querySelector('input[name="unit_price"]');
+    if (priceInput) {
+        const priceValue = Number(item.unit_price);
+        if (!Number.isNaN(priceValue)) {
+            priceInput.value = priceValue.toFixed(2);
+        } else {
+            priceInput.value = '';
+        }
+        priceInput.dataset.userEdited = '0';
+    }
+
+    const title = document.getElementById('orderItemFormTitle');
+    if (title) {
+        title.textContent = 'Modifică produs';
+    }
+
+    const submitButton = document.getElementById('orderItemFormSubmit');
+    if (submitButton) {
+        submitButton.textContent = 'Actualizează produs';
+    }
+
+    const resetButton = document.getElementById('orderItemFormReset');
+    if (resetButton) {
+        resetButton.textContent = 'Renunță';
+    }
+
+    form.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function deleteOrderItem(triggerElement, itemId) {
+    const orderId = currentOrderDetails && currentOrderDetails.id ? currentOrderDetails.id : 0;
+    if (!orderId || !itemId) {
+        return;
+    }
+
+    if (!window.confirm('Ești sigur că vrei să elimini acest produs din comandă?')) {
+        return;
+    }
+
+    if (triggerElement) {
+        triggerElement.disabled = true;
+    }
+
+    fetch('api/warehouse/manage_order_item.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+            action: 'delete',
+            order_id: orderId,
+            order_item_id: itemId
+        })
+    })
+        .then(parseJsonResponse)
+        .then(response => {
+            const message = response.message || 'Produsul a fost eliminat din comandă.';
+            return refreshOrderDetails(orderId, {
+                toast: {
+                    type: 'success',
+                    message
+                }
+            });
+        })
+        .catch(error => {
+            console.error('deleteOrderItem error:', error);
+            showOrdersToast('warning', error.message || 'Ștergerea produsului a eșuat.');
+        })
+        .finally(() => {
+            if (triggerElement) {
+                triggerElement.disabled = false;
+            }
+        });
+}
+
+function updateOrderItemPriceFromProduct(selectEl, priceInput, isEditMode) {
+    if (!selectEl || !priceInput) {
+        return;
+    }
+
+    const selectedOption = selectEl.options[selectEl.selectedIndex];
+    if (!selectedOption) {
+        if (!isEditMode) {
+            priceInput.value = '';
+            priceInput.dataset.userEdited = '0';
+        }
+        return;
+    }
+
+    const priceAttr = selectedOption.getAttribute('data-price');
+    if (priceAttr !== null && priceAttr !== '' && priceInput.dataset.userEdited !== '1') {
+        const numericPrice = Number(priceAttr);
+        if (!Number.isNaN(numericPrice)) {
+            priceInput.value = numericPrice.toFixed(2);
+            priceInput.dataset.userEdited = '0';
+        }
+    } else if (!isEditMode && priceInput.dataset.userEdited !== '1') {
+        priceInput.value = '';
+    }
+}
+
+function getOrderItemById(itemId) {
+    if (!currentOrderDetails || !Array.isArray(currentOrderDetails.items)) {
+        return null;
+    }
+
+    const numericId = Number(itemId);
+    return currentOrderDetails.items.find(item => Number(item.order_item_id) === numericId) || null;
+}
+
+function parseJsonResponse(response) {
+    return response.json().catch(() => ({})).then(data => {
+        const status = data && typeof data.status === 'string' ? data.status : (response.ok ? 'success' : 'error');
+        if (!response.ok || status !== 'success') {
+            const message = data && data.message ? data.message : `HTTP ${response.status}`;
+            throw new Error(message);
+        }
+        return data;
+    });
 }
 
 function closeOrderDetailsModal() {
@@ -975,6 +1982,8 @@ function closeOrderDetailsModal() {
     if (modal) {
         modal.style.display = 'none';
     }
+    currentOrderDetails = null;
+    currentOrderId = null;
     stopOrderPolling();
 }
 


### PR DESCRIPTION
## Summary
- expose full recipient address fields in the order details API so the modal can display and edit address text and Cargus IDs
- extend the warehouse update endpoint to persist address text plus recipient county and locality names/IDs with audit logging
- add a lightweight lookup API and client-side autocomplete to search address_location_mappings and fill the recipient county/locality selectors

## Testing
- php -l api/warehouse/order_details.php
- php -l api/warehouse/update_order_details.php
- php -l api/warehouse/search_location_mappings.php

------
https://chatgpt.com/codex/tasks/task_e_68e6298716448320a11842092d403f80